### PR TITLE
[🔧 기술작업] common-domain 핵심 컴포넌트 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,14 +58,11 @@ kover {
 				format = "<entity> coverage: <value>%"
 				coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
 			}
-			
-			// 커버리지 검증 규칙 - main 브랜치에서 점진적 적용
+
 			verify {
-				if (System.getenv("GITHUB_REF") == "refs/heads/main") {
-					rule {
-						minBound(40) // 점진적으로 80%까지 향상 목표
-					}
-				}
+                rule {
+                    minBound(80)
+                }
 			}
 			
 			// 제외 설정

--- a/libs/common-domain/build.gradle.kts
+++ b/libs/common-domain/build.gradle.kts
@@ -6,7 +6,8 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     
     // Test dependencies
-    testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation("io.kotest:kotest-runner-junit5:5.8.0")
+    testImplementation("io.kotest:kotest-assertions-core:5.8.0")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/libs/common-domain/src/main/kotlin/cloud/luigi99/blog/common/domain/AggregateRoot.kt
+++ b/libs/common-domain/src/main/kotlin/cloud/luigi99/blog/common/domain/AggregateRoot.kt
@@ -1,14 +1,108 @@
 package cloud.luigi99.blog.common.domain
 
+/**
+ * 애그리게이트 루트(Aggregate Root)의 기반이 되는 추상 클래스
+ *
+ * 개인 기술 블로그 프로젝트에서 사용되는 모든 애그리게이트 루트는 이 클래스를 상속받아
+ * 도메인 이벤트 관리 기능과 트랜잭션 경계를 제공받습니다.
+ *
+ * 애그리게이트 루트는 다음 책임을 가집니다:
+ * - 도메인 이벤트 수집 및 발행
+ * - 비즈니스 불변 조건 보장
+ * - 트랜잭션 경계 정의
+ */
 abstract class AggregateRoot : BaseEntity() {
-    private val _domainEvents = mutableListOf<DomainEvent>()
-    val domainEvents: List<DomainEvent> get() = _domainEvents.toList()
 
+    /**
+     * 발생한 도메인 이벤트들을 저장하는 내부 컬렉션
+     */
+    private val _domainEvents = mutableListOf<DomainEvent>()
+
+    /**
+     * 현재 애그리게이트에서 발생한 도메인 이벤트들을 읽기 전용으로 반환합니다.
+     *
+     * @return 도메인 이벤트 리스트 (읽기 전용)
+     */
+    val domainEvents: List<DomainEvent>
+        get() = _domainEvents.toList()
+
+    /**
+     * 도메인 이벤트가 존재하는지 확인합니다.
+     *
+     * @return 도메인 이벤트가 하나 이상 있으면 true, 없으면 false
+     */
+    fun hasDomainEvents(): Boolean {
+        return _domainEvents.isNotEmpty()
+    }
+
+    /**
+     * 특정 타입의 도메인 이벤트가 존재하는지 확인합니다.
+     *
+     * @param eventType 확인할 이벤트 타입
+     * @return 해당 타입의 이벤트가 존재하면 true, 없으면 false
+     */
+    fun hasDomainEvent(eventType: String): Boolean {
+        return _domainEvents.any { it.eventType == eventType }
+    }
+
+    /**
+     * 도메인 이벤트를 애그리게이트에 추가합니다.
+     *
+     * 비즈니스 로직 수행 중 발생한 중요한 도메인 이벤트를 기록하여
+     * 나중에 이벤트 발행기를 통해 다른 바운디드 컨텍스트로 전파할 수 있습니다.
+     *
+     * @param event 추가할 도메인 이벤트
+     */
     protected fun addDomainEvent(event: DomainEvent) {
         _domainEvents.add(event)
     }
 
+    /**
+     * 여러 도메인 이벤트를 한 번에 추가합니다.
+     *
+     * @param events 추가할 도메인 이벤트들
+     */
+    protected fun addDomainEvents(vararg events: DomainEvent) {
+        _domainEvents.addAll(events)
+    }
+
+    /**
+     * 여러 도메인 이벤트를 한 번에 추가합니다.
+     *
+     * @param events 추가할 도메인 이벤트 컬렉션
+     */
+    protected fun addDomainEvents(events: Collection<DomainEvent>) {
+        _domainEvents.addAll(events)
+    }
+
+    /**
+     * 저장된 모든 도메인 이벤트를 제거합니다.
+     *
+     * 일반적으로 이벤트 발행이 완료된 후 호출되어 메모리 누수를 방지합니다.
+     * 이벤트 발행기에서 자동으로 호출되므로 직접 호출할 필요는 없습니다.
+     */
     fun clearDomainEvents() {
         _domainEvents.clear()
+    }
+
+    /**
+     * 특정 타입의 도메인 이벤트들만 제거합니다.
+     *
+     * @param eventType 제거할 이벤트 타입
+     * @return 제거된 이벤트의 개수
+     */
+    fun clearDomainEvents(eventType: String): Int {
+        val sizeBefore = _domainEvents.size
+        _domainEvents.removeAll { it.eventType == eventType }
+        return sizeBefore - _domainEvents.size
+    }
+
+    /**
+     * 도메인 이벤트의 개수를 반환합니다.
+     *
+     * @return 현재 저장된 도메인 이벤트의 개수
+     */
+    fun domainEventCount(): Int {
+        return _domainEvents.size
     }
 }

--- a/libs/common-domain/src/main/kotlin/cloud/luigi99/blog/common/domain/BaseDomainEvent.kt
+++ b/libs/common-domain/src/main/kotlin/cloud/luigi99/blog/common/domain/BaseDomainEvent.kt
@@ -1,0 +1,171 @@
+package cloud.luigi99.blog.common.domain
+
+import java.time.LocalDateTime
+import java.util.*
+
+/**
+ * 도메인 이벤트의 기본 추상 구현체
+ *
+ * 개인 기술 블로그 프로젝트에서 발생하는 모든 도메인 이벤트의 공통 기능을 제공하는 추상 클래스입니다.
+ * DomainEvent 인터페이스의 모든 필수 프로퍼티에 대한 기본 구현을 포함하며,
+ * 구체적인 도메인 이벤트 클래스들이 상속받아 사용할 수 있는 공통 기반을 제공합니다.
+ *
+ * 주요 특징:
+ * - 불변성: 생성 후 변경할 수 없는 이벤트 속성들
+ * - 자동 생성: eventId와 occurredAt은 생성 시점에 자동 설정
+ * - 타입 안전성: Kotlin의 타입 시스템을 활용한 컴파일 타임 검증
+ * - 추적 가능성: equals/hashCode를 통한 이벤트 식별 및 추적
+ *
+ * @property aggregateId 이벤트를 발생시킨 애그리게이트의 고유 식별자
+ * @property eventType 이벤트의 종류를 나타내는 문자열
+ * @property eventId 이벤트의 고유 식별자 (자동 생성)
+ * @property occurredAt 이벤트 발생 시각 (자동 생성)
+ */
+abstract class BaseDomainEvent(
+    override val aggregateId: UUID,
+    override val eventType: String
+) : DomainEvent {
+
+    /**
+     * 이벤트 고유 식별자
+     * 생성 시점에 자동으로 UUID가 생성됩니다.
+     */
+    override val eventId: UUID = UUID.randomUUID()
+
+    /**
+     * 이벤트 발생 시각
+     * 생성 시점의 현재 시각으로 자동 설정됩니다.
+     */
+    override val occurredAt: LocalDateTime = LocalDateTime.now()
+
+    /**
+     * 이벤트 버전
+     * 기본값은 1이며, 하위 클래스에서 필요시 오버라이드 가능합니다.
+     */
+    override val eventVersion: Int = 1
+
+    /**
+     * 애그리게이트 타입
+     * 클래스명에서 "Event" 접미사를 제거하여 자동 추출합니다.
+     * 예: UserRegisteredEvent → "UserRegistered"
+     */
+    override val aggregateType: String
+        get() = this::class.simpleName?.replace("Event", "") ?: "Unknown"
+
+    /**
+     * 객체 동등성 비교
+     * eventId를 기준으로 두 이벤트가 같은지 판단합니다.
+     *
+     * @param other 비교할 객체
+     * @return eventId가 같으면 true, 다르면 false
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is BaseDomainEvent) return false
+        return eventId == other.eventId
+    }
+
+    /**
+     * 해시코드 생성
+     * eventId를 기준으로 해시코드를 생성합니다.
+     *
+     * @return eventId 기반의 해시코드
+     */
+    override fun hashCode(): Int {
+        return eventId.hashCode()
+    }
+
+    /**
+     * 문자열 표현
+     * 디버깅과 로깅을 위한 이벤트의 문자열 표현을 제공합니다.
+     *
+     * @return 이벤트의 주요 정보를 포함한 문자열
+     */
+    override fun toString(): String {
+        return "${this::class.simpleName}(" +
+                "eventId=$eventId, " +
+                "aggregateId=$aggregateId, " +
+                "eventType='$eventType', " +
+                "aggregateType='$aggregateType', " +
+                "occurredAt=$occurredAt, " +
+                "eventVersion=$eventVersion" +
+                ")"
+    }
+
+    companion object {
+        /**
+         * 이벤트 타입 생성 헬퍼 메서드
+         * 클래스명에서 이벤트 타입을 자동 생성합니다.
+         *
+         * @param eventClass 이벤트 클래스
+         * @return 이벤트 타입 문자열
+         */
+        fun generateEventType(eventClass: Class<*>): String {
+            return eventClass.simpleName
+        }
+
+        /**
+         * 이벤트 빌더 생성 헬퍼 메서드
+         * 공통 이벤트 생성 로직을 위한 빌더 패턴 지원
+         *
+         * @param aggregateId 애그리게이트 ID
+         * @param eventType 이벤트 타입
+         * @return 이벤트 빌더 인스턴스
+         */
+        fun builder(aggregateId: UUID, eventType: String): EventBuilder {
+            return EventBuilder(aggregateId, eventType)
+        }
+    }
+
+    /**
+     * 이벤트 빌더 클래스
+     * 복잡한 이벤트 생성을 위한 빌더 패턴을 제공합니다.
+     */
+    class EventBuilder internal constructor(
+        private val aggregateId: UUID,
+        private val eventType: String
+    ) {
+        private var customEventId: UUID? = null
+        private var customOccurredAt: LocalDateTime? = null
+        private var customEventVersion: Int = 1
+
+        /**
+         * 커스텀 이벤트 ID 설정
+         * 기본 자동 생성 대신 특정 UUID를 사용하고 싶을 때 사용합니다.
+         */
+        fun withEventId(eventId: UUID): EventBuilder {
+            this.customEventId = eventId
+            return this
+        }
+
+        /**
+         * 커스텀 발생 시각 설정
+         * 현재 시각 대신 특정 시각을 설정하고 싶을 때 사용합니다.
+         */
+        fun withOccurredAt(occurredAt: LocalDateTime): EventBuilder {
+            this.customOccurredAt = occurredAt
+            return this
+        }
+
+        /**
+         * 이벤트 버전 설정
+         * 기본값 1 대신 다른 버전을 사용하고 싶을 때 사용합니다.
+         */
+        fun withEventVersion(version: Int): EventBuilder {
+            this.customEventVersion = version
+            return this
+        }
+
+        /**
+         * 설정된 값들로 간단한 도메인 이벤트를 빌드합니다.
+         * 테스트나 간단한 용도로 사용할 수 있는 기본 구현체를 반환합니다.
+         */
+        fun buildSimple(): BaseDomainEvent {
+            return object : BaseDomainEvent(aggregateId, eventType) {
+                override val eventId: UUID = customEventId ?: super.eventId
+                override val occurredAt: LocalDateTime = customOccurredAt ?: super.occurredAt
+                override val eventVersion: Int = customEventVersion
+            }
+        }
+    }
+}

--- a/libs/common-domain/src/main/kotlin/cloud/luigi99/blog/common/domain/BaseEntity.kt
+++ b/libs/common-domain/src/main/kotlin/cloud/luigi99/blog/common/domain/BaseEntity.kt
@@ -3,8 +3,59 @@ package cloud.luigi99.blog.common.domain
 import java.time.LocalDateTime
 import java.util.*
 
+/**
+ * 모든 엔티티의 기반이 되는 추상 클래스
+ *
+ * 개인 기술 블로그 프로젝트에서 사용되는 모든 도메인 엔티티는 이 클래스를 상속받아
+ * 공통적인 식별자와 감사 정보를 제공받습니다.
+ */
 abstract class BaseEntity {
+    /**
+     * 엔티티의 고유 식별자
+     * UUID를 사용하여 전역적으로 유니크한 값을 보장합니다.
+     */
     abstract val id: UUID
+
+    /**
+     * 엔티티 생성 시각
+     * 엔티티가 처음 생성된 시점을 기록합니다.
+     */
     abstract val createdAt: LocalDateTime
+
+    /**
+     * 엔티티 최종 수정 시각
+     * 엔티티가 마지막으로 수정된 시점을 기록합니다.
+     * 생성 시에는 null이며, 수정이 발생할 때 값이 설정됩니다.
+     */
     abstract val updatedAt: LocalDateTime?
+
+    /**
+     * ID를 기준으로 엔티티의 동등성을 판단합니다.
+     *
+     * @param other 비교할 객체
+     * @return ID가 같으면 true, 다르면 false
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is BaseEntity) return false
+        return id == other.id
+    }
+
+    /**
+     * ID를 기준으로 해시코드를 생성합니다.
+     *
+     * @return ID의 해시코드
+     */
+    override fun hashCode(): Int {
+        return id.hashCode()
+    }
+
+    /**
+     * 엔티티의 문자열 표현을 생성합니다.
+     *
+     * @return 클래스명과 ID를 포함한 문자열
+     */
+    override fun toString(): String {
+        return "${this::class.simpleName}(id=$id, createdAt=$createdAt, updatedAt=$updatedAt)"
+    }
 }

--- a/libs/common-domain/src/main/kotlin/cloud/luigi99/blog/common/domain/DomainEvent.kt
+++ b/libs/common-domain/src/main/kotlin/cloud/luigi99/blog/common/domain/DomainEvent.kt
@@ -3,9 +3,94 @@ package cloud.luigi99.blog.common.domain
 import java.time.LocalDateTime
 import java.util.*
 
+/**
+ * 도메인 이벤트(Domain Event)의 기본 인터페이스
+ *
+ * 개인 기술 블로그 프로젝트에서 발생하는 모든 도메인 이벤트는 이 인터페이스를 구현하여
+ * 일관된 이벤트 구조와 메타데이터를 제공받습니다.
+ *
+ * 도메인 이벤트는 다음 특징을 가집니다:
+ * - 불변성: 한 번 생성된 이벤트는 변경되지 않음
+ * - 과거 시제: 이미 발생한 사건을 나타냄
+ * - 비즈니스 의미: 도메인 전문가가 이해할 수 있는 용어 사용
+ */
 interface DomainEvent {
+
+    /**
+     * 이벤트의 고유 식별자
+     * 각 이벤트를 유일하게 식별하기 위한 UUID
+     */
     val eventId: UUID
+
+    /**
+     * 이벤트 발생 시각
+     * 이벤트가 실제로 발생한 시점을 기록
+     */
     val occurredAt: LocalDateTime
+
+    /**
+     * 이벤트를 발생시킨 애그리게이트의 식별자
+     * 어떤 애그리게이트에서 이벤트가 발생했는지 추적
+     */
     val aggregateId: UUID
+
+    /**
+     * 이벤트 타입
+     * 이벤트의 종류를 나타내는 문자열 (예: "PostCreated", "UserRegistered")
+     */
     val eventType: String
+
+    /**
+     * 이벤트 버전
+     * 이벤트 스키마의 버전을 나타냄 (기본값: 1)
+     */
+    val eventVersion: Int
+        get() = 1
+
+    /**
+     * 애그리게이트 타입
+     * 이벤트를 발생시킨 애그리게이트의 타입 (예: "Post", "User")
+     */
+    val aggregateType: String
+        get() = this::class.simpleName?.replace("Event", "") ?: "Unknown"
+
+    /**
+     * 이벤트가 특정 타입인지 확인합니다.
+     *
+     * @param type 확인할 이벤트 타입
+     * @return 이벤트 타입이 일치하면 true, 다르면 false
+     */
+    fun isEventType(type: String): Boolean {
+        return eventType == type
+    }
+
+    /**
+     * 이벤트가 특정 애그리게이트에서 발생했는지 확인합니다.
+     *
+     * @param aggregateId 확인할 애그리게이트 ID
+     * @return 애그리게이트 ID가 일치하면 true, 다르면 false
+     */
+    fun isFromAggregate(aggregateId: UUID): Boolean {
+        return this.aggregateId == aggregateId
+    }
+
+    /**
+     * 이벤트가 특정 시간 이후에 발생했는지 확인합니다.
+     *
+     * @param timestamp 기준 시각
+     * @return 이벤트가 기준 시각 이후에 발생했으면 true, 그렇지 않으면 false
+     */
+    fun occurredAfter(timestamp: LocalDateTime): Boolean {
+        return occurredAt.isAfter(timestamp)
+    }
+
+    /**
+     * 이벤트가 특정 시간 이전에 발생했는지 확인합니다.
+     *
+     * @param timestamp 기준 시각
+     * @return 이벤트가 기준 시각 이전에 발생했으면 true, 그렇지 않으면 false
+     */
+    fun occurredBefore(timestamp: LocalDateTime): Boolean {
+        return occurredAt.isBefore(timestamp)
+    }
 }

--- a/libs/common-domain/src/main/kotlin/cloud/luigi99/blog/common/domain/ValueObject.kt
+++ b/libs/common-domain/src/main/kotlin/cloud/luigi99/blog/common/domain/ValueObject.kt
@@ -1,6 +1,72 @@
 package cloud.luigi99.blog.common.domain
 
+/**
+ * 값 객체(Value Object)의 기반이 되는 추상 클래스
+ *
+ * 개인 기술 블로그 프로젝트에서 사용되는 모든 값 객체는 이 클래스를 상속받아
+ * 값 기반의 동등성과 불변성을 보장받습니다.
+ *
+ * 값 객체는 다음 특징을 가집니다:
+ * - 불변성: 생성 후 상태가 변경되지 않음
+ * - 값 동등성: 속성 값이 같으면 동일한 객체로 간주
+ * - 부작용 없음: 메서드 호출이 객체 상태를 변경하지 않음
+ */
 abstract class ValueObject {
+
+    /**
+     * 값 객체의 동등성을 판단합니다.
+     *
+     * 구현체에서는 모든 속성 값을 기준으로 동등성을 판단해야 합니다.
+     *
+     * @param other 비교할 객체
+     * @return 모든 속성 값이 같으면 true, 다르면 false
+     */
     abstract override fun equals(other: Any?): Boolean
+
+    /**
+     * 값 객체의 해시코드를 생성합니다.
+     *
+     * 구현체에서는 모든 속성 값을 기준으로 해시코드를 생성해야 합니다.
+     * equals가 true인 객체들은 반드시 같은 해시코드를 반환해야 합니다.
+     *
+     * @return 모든 속성 값을 기준으로 한 해시코드
+     */
     abstract override fun hashCode(): Int
+
+    /**
+     * 값 객체의 문자열 표현을 생성합니다.
+     *
+     * 기본 구현으로 클래스명과 해시코드를 포함한 문자열을 제공합니다.
+     * 필요시 구현체에서 오버라이드하여 더 의미있는 문자열을 제공할 수 있습니다.
+     *
+     * @return 값 객체의 문자열 표현
+     */
+    override fun toString(): String {
+        return "${this::class.simpleName}@${hashCode().toString(16)}"
+    }
+
+    /**
+     * 값 객체의 유효성을 검증합니다.
+     *
+     * 구현체에서 필요시 오버라이드하여 비즈니스 규칙에 따른 유효성 검증을 수행할 수 있습니다.
+     * 기본 구현은 항상 true를 반환합니다.
+     *
+     * @return 값 객체가 유효하면 true, 그렇지 않으면 false
+     */
+    protected open fun isValid(): Boolean {
+        return true
+    }
+
+    /**
+     * 값 객체의 유효성을 검증하고 유효하지 않은 경우 예외를 발생시킵니다.
+     *
+     * 값 객체 생성 시 호출하여 유효하지 않은 값 객체 생성을 방지할 수 있습니다.
+     *
+     * @throws IllegalArgumentException 값 객체가 유효하지 않은 경우
+     */
+    protected fun validate() {
+        if (!isValid()) {
+            throw IllegalArgumentException("${this::class.simpleName}의 값이 유효하지 않습니다.")
+        }
+    }
 }

--- a/libs/common-domain/src/main/kotlin/cloud/luigi99/blog/common/exception/BusinessException.kt
+++ b/libs/common-domain/src/main/kotlin/cloud/luigi99/blog/common/exception/BusinessException.kt
@@ -29,7 +29,7 @@ open class BusinessException : RuntimeException {
         message: String,
         cause: Throwable? = null
     ) : super(message, cause) {
-        this.errorCode = "BUSINESS_ERROR"
+        this.errorCode = ErrorCode.COMMON_BUSINESS_ERROR.code
     }
 
     /**

--- a/libs/common-domain/src/main/kotlin/cloud/luigi99/blog/common/exception/BusinessException.kt
+++ b/libs/common-domain/src/main/kotlin/cloud/luigi99/blog/common/exception/BusinessException.kt
@@ -1,6 +1,118 @@
 package cloud.luigi99.blog.common.exception
 
-open class BusinessException(
-    message: String,
-    cause: Throwable? = null
-) : RuntimeException(message, cause)
+/**
+ * 비즈니스 로직 예외의 기반이 되는 클래스
+ *
+ * 개인 기술 블로그 프로젝트에서 발생하는 모든 비즈니스 로직 관련 예외는 이 클래스를 상속받아
+ * 일관된 에러 처리와 메시지 관리를 제공받습니다.
+ *
+ * 비즈니스 예외는 다음 특징을 가집니다:
+ * - 복구 가능한 예외: 사용자 입력 수정으로 해결 가능
+ * - 명확한 에러 코드: 클라이언트에서 에러 처리 용이
+ * - 사용자 친화적 메시지: 최종 사용자가 이해할 수 있는 메시지
+ */
+open class BusinessException : RuntimeException {
+
+    /**
+     * 에러 코드
+     * 클라이언트에서 에러를 구분하고 처리하기 위한 코드
+     */
+    val errorCode: String
+
+    /**
+     * 기본 생성자
+     *
+     * @param message 에러 메시지
+     * @param cause 원인 예외 (선택사항)
+     */
+    constructor(
+        message: String,
+        cause: Throwable? = null
+    ) : super(message, cause) {
+        this.errorCode = "BUSINESS_ERROR"
+    }
+
+    /**
+     * 에러 코드를 포함한 생성자
+     *
+     * @param errorCode 에러 코드
+     * @param message 에러 메시지
+     * @param cause 원인 예외 (선택사항)
+     */
+    constructor(
+        errorCode: String,
+        message: String,
+        cause: Throwable? = null
+    ) : super(message, cause) {
+        this.errorCode = errorCode
+    }
+
+    /**
+     * 포맷된 메시지를 사용하는 생성자
+     *
+     * @param errorCode 에러 코드
+     * @param messageFormat 메시지 포맷 (String.format 사용)
+     * @param args 메시지 포맷 인자들
+     */
+    constructor(
+        errorCode: String,
+        messageFormat: String,
+        vararg args: Any
+    ) : super(messageFormat.format(*args)) {
+        this.errorCode = errorCode
+    }
+
+    /**
+     * 다른 BusinessException을 기반으로 새로운 예외를 생성하는 생성자
+     *
+     * @param other 기반이 되는 BusinessException
+     * @param additionalMessage 추가할 메시지
+     */
+    constructor(
+        other: BusinessException,
+        additionalMessage: String? = null
+    ) : super(
+        if (additionalMessage != null) "${other.message} - $additionalMessage" else other.message,
+        other.cause
+    ) {
+        this.errorCode = other.errorCode
+    }
+
+    /**
+     * 예외가 특정 에러 코드를 가지는지 확인합니다.
+     *
+     * @param code 확인할 에러 코드
+     * @return 에러 코드가 일치하면 true, 다르면 false
+     */
+    fun hasErrorCode(code: String): Boolean {
+        return errorCode == code
+    }
+
+    /**
+     * 예외가 여러 에러 코드 중 하나를 가지는지 확인합니다.
+     *
+     * @param codes 확인할 에러 코드들
+     * @return 에러 코드가 하나라도 일치하면 true, 모두 다르면 false
+     */
+    fun hasAnyErrorCode(vararg codes: String): Boolean {
+        return codes.contains(errorCode)
+    }
+
+    /**
+     * 상세한 에러 정보를 문자열로 반환합니다.
+     *
+     * @return 에러 코드와 메시지를 포함한 문자열
+     */
+    open fun getDetailedMessage(): String {
+        return "[$errorCode] $message"
+    }
+
+    /**
+     * 예외의 문자열 표현을 반환합니다.
+     *
+     * @return 클래스명, 에러 코드, 메시지를 포함한 문자열
+     */
+    override fun toString(): String {
+        return "${this::class.simpleName}(errorCode='$errorCode', message='$message')"
+    }
+}

--- a/libs/common-domain/src/main/kotlin/cloud/luigi99/blog/common/exception/DomainException.kt
+++ b/libs/common-domain/src/main/kotlin/cloud/luigi99/blog/common/exception/DomainException.kt
@@ -1,6 +1,190 @@
 package cloud.luigi99.blog.common.exception
 
-class DomainException(
-    message: String,
-    cause: Throwable? = null
-) : BusinessException(message, cause)
+/**
+ * 도메인 계층에서 발생하는 예외를 나타내는 클래스
+ *
+ * 개인 기술 블로그 프로젝트에서 도메인 규칙 위반이나 비즈니스 불변 조건 위반 시 발생하는
+ * 예외들을 처리하기 위한 클래스입니다.
+ *
+ * 도메인 예외는 다음 특징을 가집니다:
+ * - 도메인 규칙 위반: 비즈니스 불변 조건이나 도메인 규칙 위반
+ * - 명확한 도메인 컨텍스트: 어떤 도메인에서 발생했는지 명시
+ * - 복구 가능: 사용자 행동 변경으로 해결 가능한 문제
+ */
+class DomainException : BusinessException {
+
+    /**
+     * 도메인 컨텍스트
+     * 예외가 발생한 도메인 영역을 나타냄 (예: "User", "Post", "Comment")
+     */
+    val domainContext: String
+
+    /**
+     * 기본 생성자
+     *
+     * @param message 에러 메시지
+     * @param cause 원인 예외 (선택사항)
+     */
+    constructor(
+        message: String,
+        cause: Throwable? = null
+    ) : super("DOMAIN_ERROR", message, cause) {
+        this.domainContext = "Unknown"
+    }
+
+    /**
+     * 도메인 컨텍스트를 포함한 생성자
+     *
+     * @param domainContext 도메인 컨텍스트
+     * @param message 에러 메시지
+     * @param cause 원인 예외 (선택사항)
+     */
+    constructor(
+        domainContext: String,
+        message: String,
+        cause: Throwable? = null
+    ) : super("DOMAIN_ERROR", message, cause) {
+        this.domainContext = domainContext
+    }
+
+    /**
+     * 도메인별 에러 코드를 포함한 생성자
+     *
+     * @param domainContext 도메인 컨텍스트
+     * @param errorCode 도메인별 에러 코드
+     * @param message 에러 메시지
+     * @param cause 원인 예외 (선택사항)
+     */
+    constructor(
+        domainContext: String,
+        errorCode: String,
+        message: String,
+        cause: Throwable? = null
+    ) : super(errorCode, message, cause) {
+        this.domainContext = domainContext
+    }
+
+    /**
+     * 포맷된 메시지와 도메인 컨텍스트를 사용하는 생성자
+     *
+     * @param domainContext 도메인 컨텍스트
+     * @param errorCode 에러 코드
+     * @param messageFormat 메시지 포맷 (String.format 사용)
+     * @param args 메시지 포맷 인자들
+     */
+    constructor(
+        domainContext: String,
+        errorCode: String,
+        messageFormat: String,
+        vararg args: Any
+    ) : super(errorCode, messageFormat, *args) {
+        this.domainContext = domainContext
+    }
+
+    /**
+     * 다른 DomainException을 기반으로 새로운 예외를 생성하는 생성자
+     *
+     * @param other 기반이 되는 DomainException
+     * @param additionalMessage 추가할 메시지
+     */
+    constructor(
+        other: DomainException,
+        additionalMessage: String? = null
+    ) : super(other, additionalMessage) {
+        this.domainContext = other.domainContext
+    }
+
+    /**
+     * 예외가 특정 도메인 컨텍스트에서 발생했는지 확인합니다.
+     *
+     * @param context 확인할 도메인 컨텍스트
+     * @return 도메인 컨텍스트가 일치하면 true, 다르면 false
+     */
+    fun isFromDomain(context: String): Boolean {
+        return domainContext.equals(context, ignoreCase = true)
+    }
+
+    /**
+     * 예외가 여러 도메인 컨텍스트 중 하나에서 발생했는지 확인합니다.
+     *
+     * @param contexts 확인할 도메인 컨텍스트들
+     * @return 도메인 컨텍스트가 하나라도 일치하면 true, 모두 다르면 false
+     */
+    fun isFromAnyDomain(vararg contexts: String): Boolean {
+        return contexts.any { domainContext.equals(it, ignoreCase = true) }
+    }
+
+    /**
+     * 도메인 컨텍스트를 포함한 상세한 에러 정보를 문자열로 반환합니다.
+     *
+     * @return 도메인 컨텍스트, 에러 코드, 메시지를 포함한 문자열
+     */
+    override fun getDetailedMessage(): String {
+        return "[$domainContext:$errorCode] $message"
+    }
+
+    /**
+     * 예외의 문자열 표현을 반환합니다.
+     *
+     * @return 클래스명, 도메인 컨텍스트, 에러 코드, 메시지를 포함한 문자열
+     */
+    override fun toString(): String {
+        return "${this::class.simpleName}(domainContext='$domainContext', errorCode='$errorCode', message='$message')"
+    }
+
+    companion object {
+        /**
+         * 엔티티를 찾을 수 없을 때 발생하는 예외를 생성합니다.
+         *
+         * @param domainContext 도메인 컨텍스트
+         * @param entityId 찾을 수 없는 엔티티의 ID
+         * @return DomainException 인스턴스
+         */
+        fun entityNotFound(domainContext: String, entityId: Any): DomainException {
+            return DomainException(
+                domainContext,
+                "ENTITY_NOT_FOUND",
+                "%s를 찾을 수 없습니다. ID: %s",
+                domainContext,
+                entityId
+            )
+        }
+
+        /**
+         * 비즈니스 규칙 위반 시 발생하는 예외를 생성합니다.
+         *
+         * @param domainContext 도메인 컨텍스트
+         * @param ruleName 위반된 규칙명
+         * @param reason 위반 사유
+         * @return DomainException 인스턴스
+         */
+        fun businessRuleViolation(domainContext: String, ruleName: String, reason: String): DomainException {
+            return DomainException(
+                domainContext,
+                "BUSINESS_RULE_VIOLATION",
+                "%s 도메인의 '%s' 규칙이 위반되었습니다: %s",
+                domainContext,
+                ruleName,
+                reason
+            )
+        }
+
+        /**
+         * 유효하지 않은 상태 전환 시 발생하는 예외를 생성합니다.
+         *
+         * @param domainContext 도메인 컨텍스트
+         * @param currentState 현재 상태
+         * @param targetState 목표 상태
+         * @return DomainException 인스턴스
+         */
+        fun invalidStateTransition(domainContext: String, currentState: String, targetState: String): DomainException {
+            return DomainException(
+                domainContext,
+                "INVALID_STATE_TRANSITION",
+                "%s 상태에서 %s 상태로 전환할 수 없습니다",
+                currentState,
+                targetState
+            )
+        }
+    }
+}

--- a/libs/common-domain/src/main/kotlin/cloud/luigi99/blog/common/exception/DomainException.kt
+++ b/libs/common-domain/src/main/kotlin/cloud/luigi99/blog/common/exception/DomainException.kt
@@ -28,7 +28,7 @@ class DomainException : BusinessException {
     constructor(
         message: String,
         cause: Throwable? = null
-    ) : super("DOMAIN_ERROR", message, cause) {
+    ) : super(ErrorCode.COMMON_BUSINESS_ERROR.code, message, cause) {
         this.domainContext = "Unknown"
     }
 
@@ -43,7 +43,7 @@ class DomainException : BusinessException {
         domainContext: String,
         message: String,
         cause: Throwable? = null
-    ) : super("DOMAIN_ERROR", message, cause) {
+    ) : super(ErrorCode.COMMON_BUSINESS_ERROR.code, message, cause) {
         this.domainContext = domainContext
     }
 
@@ -143,7 +143,7 @@ class DomainException : BusinessException {
         fun entityNotFound(domainContext: String, entityId: Any): DomainException {
             return DomainException(
                 domainContext,
-                "ENTITY_NOT_FOUND",
+                ErrorCode.ENTITY_NOT_FOUND.code,
                 "%s를 찾을 수 없습니다. ID: %s",
                 domainContext,
                 entityId
@@ -161,7 +161,7 @@ class DomainException : BusinessException {
         fun businessRuleViolation(domainContext: String, ruleName: String, reason: String): DomainException {
             return DomainException(
                 domainContext,
-                "BUSINESS_RULE_VIOLATION",
+                ErrorCode.COMMON_BUSINESS_ERROR.code,
                 "%s 도메인의 '%s' 규칙이 위반되었습니다: %s",
                 domainContext,
                 ruleName,
@@ -180,7 +180,7 @@ class DomainException : BusinessException {
         fun invalidStateTransition(domainContext: String, currentState: String, targetState: String): DomainException {
             return DomainException(
                 domainContext,
-                "INVALID_STATE_TRANSITION",
+                ErrorCode.STATE_INVALID_TRANSITION.code,
                 "%s 상태에서 %s 상태로 전환할 수 없습니다",
                 currentState,
                 targetState

--- a/libs/common-domain/src/main/kotlin/cloud/luigi99/blog/common/exception/ErrorCode.kt
+++ b/libs/common-domain/src/main/kotlin/cloud/luigi99/blog/common/exception/ErrorCode.kt
@@ -1,0 +1,312 @@
+package cloud.luigi99.blog.common.exception
+
+/**
+ * 개인 기술 블로그 프로젝트에서 사용하는 에러 코드 정의
+ *
+ * 각 에러 코드는 고유한 코드와 설명을 가지며, 클라이언트에서 에러를 구분하고
+ * 적절한 처리를 할 수 있도록 합니다.
+ *
+ * 에러 코드 네이밍 규칙:
+ * - 도메인_액션_상태 형태로 구성
+ * - 일반적인 에러는 COMMON_ 접두사 사용
+ * - 도메인별 에러는 도메인명을 접두사로 사용 (USER_, POST_, COMMENT_ 등)
+ */
+enum class ErrorCode(
+    /**
+     * 에러 코드 문자열
+     */
+    val code: String,
+
+    /**
+     * 에러 설명
+     */
+    val description: String
+) {
+
+    // ===== 일반적인 비즈니스 에러 =====
+
+    /**
+     * 일반적인 비즈니스 로직 에러
+     */
+    COMMON_BUSINESS_ERROR("COMMON_BUSINESS_ERROR", "비즈니스 로직 처리 중 오류가 발생했습니다"),
+
+    /**
+     * 잘못된 요청 파라미터
+     */
+    COMMON_INVALID_PARAMETER("COMMON_INVALID_PARAMETER", "잘못된 요청 파라미터입니다"),
+
+    /**
+     * 잘못된 입력값
+     */
+    COMMON_INVALID_INPUT("COMMON_INVALID_INPUT", "입력값이 유효하지 않습니다"),
+
+    /**
+     * 필수 값 누락
+     */
+    COMMON_REQUIRED_VALUE_MISSING("COMMON_REQUIRED_VALUE_MISSING", "필수 입력값이 누락되었습니다"),
+
+    /**
+     * 서버 내부 오류
+     */
+    COMMON_INTERNAL_SERVER_ERROR("COMMON_INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다"),
+
+    // ===== 엔티티 관련 에러 =====
+
+    /**
+     * 엔티티를 찾을 수 없음
+     */
+    ENTITY_NOT_FOUND("ENTITY_NOT_FOUND", "요청한 데이터를 찾을 수 없습니다"),
+
+    /**
+     * 엔티티가 이미 존재함
+     */
+    ENTITY_ALREADY_EXISTS("ENTITY_ALREADY_EXISTS", "이미 존재하는 데이터입니다"),
+
+    /**
+     * 엔티티 생성 실패
+     */
+    ENTITY_CREATION_FAILED("ENTITY_CREATION_FAILED", "데이터 생성에 실패했습니다"),
+
+    /**
+     * 엔티티 수정 실패
+     */
+    ENTITY_UPDATE_FAILED("ENTITY_UPDATE_FAILED", "데이터 수정에 실패했습니다"),
+
+    /**
+     * 엔티티 삭제 실패
+     */
+    ENTITY_DELETE_FAILED("ENTITY_DELETE_FAILED", "데이터 삭제에 실패했습니다"),
+
+    // ===== 유효성 검증 에러 =====
+
+    /**
+     * 이메일 형식 오류
+     */
+    VALIDATION_INVALID_EMAIL("VALIDATION_INVALID_EMAIL", "이메일 형식이 올바르지 않습니다"),
+
+    /**
+     * 비밀번호 형식 오류
+     */
+    VALIDATION_INVALID_PASSWORD("VALIDATION_INVALID_PASSWORD", "비밀번호 형식이 올바르지 않습니다"),
+
+    /**
+     * 제목 길이 초과
+     */
+    VALIDATION_TITLE_TOO_LONG("VALIDATION_TITLE_TOO_LONG", "제목이 너무 깁니다"),
+
+    /**
+     * 내용 길이 초과
+     */
+    VALIDATION_CONTENT_TOO_LONG("VALIDATION_CONTENT_TOO_LONG", "내용이 너무 깁니다"),
+
+    /**
+     * 태그 개수 초과
+     */
+    VALIDATION_TOO_MANY_TAGS("VALIDATION_TOO_MANY_TAGS", "태그 개수가 제한을 초과했습니다"),
+
+    // ===== 권한 관련 에러 =====
+
+    /**
+     * 인증되지 않은 사용자
+     */
+    AUTH_UNAUTHENTICATED("AUTH_UNAUTHENTICATED", "로그인이 필요합니다"),
+
+    /**
+     * 권한 없음
+     */
+    AUTH_UNAUTHORIZED("AUTH_UNAUTHORIZED", "권한이 없습니다"),
+
+    /**
+     * 잘못된 인증 정보
+     */
+    AUTH_INVALID_CREDENTIALS("AUTH_INVALID_CREDENTIALS", "인증 정보가 올바르지 않습니다"),
+
+    /**
+     * 토큰 만료
+     */
+    AUTH_TOKEN_EXPIRED("AUTH_TOKEN_EXPIRED", "인증 토큰이 만료되었습니다"),
+
+    /**
+     * 잘못된 토큰
+     */
+    AUTH_INVALID_TOKEN("AUTH_INVALID_TOKEN", "유효하지 않은 토큰입니다"),
+
+    // ===== 사용자 관련 에러 =====
+
+    /**
+     * 사용자를 찾을 수 없음
+     */
+    USER_NOT_FOUND("USER_NOT_FOUND", "사용자를 찾을 수 없습니다"),
+
+    /**
+     * 사용자가 이미 존재함
+     */
+    USER_ALREADY_EXISTS("USER_ALREADY_EXISTS", "이미 존재하는 사용자입니다"),
+
+    /**
+     * 이메일 중복
+     */
+    USER_EMAIL_DUPLICATE("USER_EMAIL_DUPLICATE", "이미 사용 중인 이메일입니다"),
+
+    /**
+     * 비활성화된 사용자
+     */
+    USER_DEACTIVATED("USER_DEACTIVATED", "비활성화된 사용자입니다"),
+
+    // ===== 블로그 포스트 관련 에러 =====
+
+    /**
+     * 포스트를 찾을 수 없음
+     */
+    POST_NOT_FOUND("POST_NOT_FOUND", "블로그 포스트를 찾을 수 없습니다"),
+
+    /**
+     * 포스트 제목 중복
+     */
+    POST_TITLE_DUPLICATE("POST_TITLE_DUPLICATE", "이미 존재하는 포스트 제목입니다"),
+
+    /**
+     * 임시저장 포스트가 아님
+     */
+    POST_NOT_DRAFT("POST_NOT_DRAFT", "임시저장 상태의 포스트가 아닙니다"),
+
+    /**
+     * 이미 발행된 포스트
+     */
+    POST_ALREADY_PUBLISHED("POST_ALREADY_PUBLISHED", "이미 발행된 포스트입니다"),
+
+    // ===== 댓글 관련 에러 =====
+
+    /**
+     * 댓글을 찾을 수 없음
+     */
+    COMMENT_NOT_FOUND("COMMENT_NOT_FOUND", "댓글을 찾을 수 없습니다"),
+
+    /**
+     * 댓글 작성자가 아님
+     */
+    COMMENT_NOT_AUTHOR("COMMENT_NOT_AUTHOR", "댓글 작성자가 아닙니다"),
+
+    /**
+     * 삭제된 댓글
+     */
+    COMMENT_DELETED("COMMENT_DELETED", "삭제된 댓글입니다"),
+
+    // ===== 카테고리 관련 에러 =====
+
+    /**
+     * 카테고리를 찾을 수 없음
+     */
+    CATEGORY_NOT_FOUND("CATEGORY_NOT_FOUND", "카테고리를 찾을 수 없습니다"),
+
+    /**
+     * 카테고리 이름 중복
+     */
+    CATEGORY_NAME_DUPLICATE("CATEGORY_NAME_DUPLICATE", "이미 존재하는 카테고리 이름입니다"),
+
+    /**
+     * 사용 중인 카테고리 삭제 시도
+     */
+    CATEGORY_IN_USE("CATEGORY_IN_USE", "사용 중인 카테고리는 삭제할 수 없습니다"),
+
+    // ===== 파일/미디어 관련 에러 =====
+
+    /**
+     * 파일을 찾을 수 없음
+     */
+    FILE_NOT_FOUND("FILE_NOT_FOUND", "파일을 찾을 수 없습니다"),
+
+    /**
+     * 지원하지 않는 파일 형식
+     */
+    FILE_UNSUPPORTED_FORMAT("FILE_UNSUPPORTED_FORMAT", "지원하지 않는 파일 형식입니다"),
+
+    /**
+     * 파일 크기 초과
+     */
+    FILE_SIZE_EXCEEDED("FILE_SIZE_EXCEEDED", "파일 크기가 제한을 초과했습니다"),
+
+    /**
+     * 파일 업로드 실패
+     */
+    FILE_UPLOAD_FAILED("FILE_UPLOAD_FAILED", "파일 업로드에 실패했습니다"),
+
+    // ===== 검색 관련 에러 =====
+
+    /**
+     * 검색 키워드가 너무 짧음
+     */
+    SEARCH_KEYWORD_TOO_SHORT("SEARCH_KEYWORD_TOO_SHORT", "검색 키워드가 너무 짧습니다"),
+
+    /**
+     * 검색 서비스 연결 실패
+     */
+    SEARCH_SERVICE_UNAVAILABLE("SEARCH_SERVICE_UNAVAILABLE", "검색 서비스를 사용할 수 없습니다"),
+
+    // ===== 상태 전환 에러 =====
+
+    /**
+     * 잘못된 상태 전환
+     */
+    STATE_INVALID_TRANSITION("STATE_INVALID_TRANSITION", "잘못된 상태 전환입니다"),
+
+    /**
+     * 이미 처리된 상태
+     */
+    STATE_ALREADY_PROCESSED("STATE_ALREADY_PROCESSED", "이미 처리된 상태입니다"),
+
+    /**
+     * 처리할 수 없는 상태
+     */
+    STATE_CANNOT_PROCESS("STATE_CANNOT_PROCESS", "현재 상태에서는 처리할 수 없습니다");
+
+    /**
+     * 에러 코드를 문자열로 반환합니다.
+     *
+     * @return 에러 코드 문자열
+     */
+    override fun toString(): String = code
+
+    companion object {
+
+        /**
+         * 에러 코드 문자열로부터 ErrorCode를 찾습니다.
+         *
+         * @param code 찾을 에러 코드 문자열
+         * @return 해당하는 ErrorCode, 없으면 null
+         */
+        fun fromCode(code: String): ErrorCode? {
+            return ErrorCode.entries.find { it.code == code }
+        }
+
+        /**
+         * 에러 코드 문자열로부터 ErrorCode를 찾습니다. 없으면 기본값을 반환합니다.
+         *
+         * @param code 찾을 에러 코드 문자열
+         * @param defaultValue 기본값 (기본: COMMON_BUSINESS_ERROR)
+         * @return 해당하는 ErrorCode 또는 기본값
+         */
+        fun fromCodeOrDefault(code: String, defaultValue: ErrorCode = COMMON_BUSINESS_ERROR): ErrorCode {
+            return fromCode(code) ?: defaultValue
+        }
+
+        /**
+         * 모든 에러 코드를 코드 문자열 리스트로 반환합니다.
+         *
+         * @return 모든 에러 코드 문자열 리스트
+         */
+        fun getAllCodes(): List<String> {
+            return ErrorCode.entries.map { it.code }
+        }
+
+        /**
+         * 특정 접두사로 시작하는 모든 에러 코드를 반환합니다.
+         *
+         * @param prefix 찾을 접두사
+         * @return 해당 접두사로 시작하는 ErrorCode 리스트
+         */
+        fun getByPrefix(prefix: String): List<ErrorCode> {
+            return ErrorCode.entries.filter { it.code.startsWith(prefix) }
+        }
+    }
+}

--- a/libs/common-domain/src/test/kotlin/cloud/luigi99/blog/common/domain/AggregateRootTest.kt
+++ b/libs/common-domain/src/test/kotlin/cloud/luigi99/blog/common/domain/AggregateRootTest.kt
@@ -1,0 +1,207 @@
+package cloud.luigi99.blog.common.domain
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
+import java.time.LocalDateTime
+import java.util.*
+
+/**
+ * AggregateRoot의 행위를 검증하는 테스트
+ */
+class AggregateRootTest : BehaviorSpec({
+
+    given("새로 생성된 AggregateRoot가 있을 때") {
+        val aggregate = TestAggregateRoot(UUID.randomUUID(), LocalDateTime.now(), null)
+
+        `when`("도메인 이벤트 존재 여부를 확인하면") {
+            val hasEvents = aggregate.hasDomainEvents()
+
+            then("도메인 이벤트가 없으므로 false를 반환한다") {
+                hasEvents shouldBe false
+            }
+        }
+
+        `when`("도메인 이벤트 목록을 조회하면") {
+            val events = aggregate.domainEvents
+
+            then("빈 목록을 반환한다") {
+                events.shouldBeEmpty()
+            }
+        }
+
+        `when`("도메인 이벤트 개수를 확인하면") {
+            val count = aggregate.domainEventCount()
+
+            then("0을 반환한다") {
+                count shouldBe 0
+            }
+        }
+    }
+
+    given("AggregateRoot에 도메인 이벤트를 추가할 때") {
+        val aggregateId = UUID.randomUUID()
+        val aggregate = TestAggregateRoot(aggregateId, LocalDateTime.now(), null)
+        val testEvent = TestDomainEvent(aggregateId, "TestEvent")
+
+        `when`("도메인 이벤트를 추가하면") {
+            aggregate.addEvent(testEvent)
+
+            then("도메인 이벤트가 존재한다") {
+                aggregate.hasDomainEvents() shouldBe true
+            }
+
+            then("도메인 이벤트 목록에 추가된 이벤트가 포함된다") {
+                aggregate.domainEvents shouldContain testEvent
+                aggregate.domainEvents shouldHaveSize 1
+            }
+
+            then("도메인 이벤트 개수가 1이다") {
+                aggregate.domainEventCount() shouldBe 1
+            }
+        }
+    }
+
+    given("AggregateRoot에 여러 도메인 이벤트를 추가할 때") {
+        val aggregateId = UUID.randomUUID()
+        val aggregate = TestAggregateRoot(aggregateId, LocalDateTime.now(), null)
+        val event1 = TestDomainEvent(aggregateId, "Event1")
+        val event2 = TestDomainEvent(aggregateId, "Event2")
+        val event3 = TestDomainEvent(aggregateId, "Event3")
+
+        `when`("여러 이벤트를 한 번에 추가하면") {
+            aggregate.addEvents(event1, event2, event3)
+
+            then("모든 이벤트가 추가된다") {
+                aggregate.domainEvents shouldHaveSize 3
+                aggregate.domainEvents shouldContain event1
+                aggregate.domainEvents shouldContain event2
+                aggregate.domainEvents shouldContain event3
+            }
+        }
+
+        `when`("컬렉션으로 이벤트를 추가하면") {
+            aggregate.clearDomainEvents()
+            val eventList = listOf(event1, event2)
+            aggregate.addEvents(eventList)
+
+            then("컬렉션의 모든 이벤트가 추가된다") {
+                aggregate.domainEvents shouldHaveSize 2
+                aggregate.domainEvents shouldContain event1
+                aggregate.domainEvents shouldContain event2
+            }
+        }
+    }
+
+    given("특정 타입의 도메인 이벤트를 확인할 때") {
+        val aggregateId = UUID.randomUUID()
+        val aggregate = TestAggregateRoot(aggregateId, LocalDateTime.now(), null)
+        val event1 = TestDomainEvent(aggregateId, "TypeA")
+        val event2 = TestDomainEvent(aggregateId, "TypeB")
+
+        aggregate.addEvents(event1, event2)
+
+        `when`("존재하는 이벤트 타입을 확인하면") {
+            val hasTypeA = aggregate.hasDomainEvent("TypeA")
+            val hasTypeB = aggregate.hasDomainEvent("TypeB")
+
+            then("true를 반환한다") {
+                hasTypeA shouldBe true
+                hasTypeB shouldBe true
+            }
+        }
+
+        `when`("존재하지 않는 이벤트 타입을 확인하면") {
+            val hasTypeC = aggregate.hasDomainEvent("TypeC")
+
+            then("false를 반환한다") {
+                hasTypeC shouldBe false
+            }
+        }
+    }
+
+    given("도메인 이벤트가 있는 AggregateRoot에서 이벤트를 제거할 때") {
+        val aggregateId = UUID.randomUUID()
+        val aggregate = TestAggregateRoot(aggregateId, LocalDateTime.now(), null)
+        val event1 = TestDomainEvent(aggregateId, "TypeA")
+        val event2 = TestDomainEvent(aggregateId, "TypeB")
+        val event3 = TestDomainEvent(aggregateId, "TypeA")
+
+        aggregate.addEvents(event1, event2, event3)
+
+        `when`("모든 도메인 이벤트를 제거하면") {
+            aggregate.clearDomainEvents()
+
+            then("도메인 이벤트가 없어진다") {
+                aggregate.hasDomainEvents() shouldBe false
+                aggregate.domainEvents.shouldBeEmpty()
+                aggregate.domainEventCount() shouldBe 0
+            }
+        }
+
+        `when`("특정 타입의 도메인 이벤트만 제거하면") {
+            aggregate.addEvents(event1, event2, event3)
+            val removedCount = aggregate.clearDomainEvents("TypeA")
+
+            then("해당 타입의 이벤트만 제거되고 제거된 개수를 반환한다") {
+                removedCount shouldBe 2
+                aggregate.domainEventCount() shouldBe 1
+                aggregate.hasDomainEvent("TypeA") shouldBe false
+                aggregate.hasDomainEvent("TypeB") shouldBe true
+            }
+        }
+    }
+
+    given("도메인 이벤트 목록이 읽기 전용인지 확인할 때") {
+        val aggregateId = UUID.randomUUID()
+        val aggregate = TestAggregateRoot(aggregateId, LocalDateTime.now(), null)
+        val testEvent = TestDomainEvent(aggregateId, "TestEvent")
+
+        aggregate.addEvent(testEvent)
+
+        `when`("도메인 이벤트 목록을 여러 번 조회하면") {
+            val events1 = aggregate.domainEvents
+            val events2 = aggregate.domainEvents
+
+            then("매번 새로운 리스트 인스턴스를 반환한다") {
+                events1 shouldBe events2
+                (events1 === events2) shouldBe false
+            }
+        }
+    }
+})
+
+/**
+ * 테스트용 AggregateRoot 구현체
+ */
+private class TestAggregateRoot(
+    override val id: UUID,
+    override val createdAt: LocalDateTime,
+    override val updatedAt: LocalDateTime?
+) : AggregateRoot() {
+
+    fun addEvent(event: DomainEvent) {
+        addDomainEvent(event)
+    }
+
+    fun addEvents(vararg events: DomainEvent) {
+        addDomainEvents(*events)
+    }
+
+    fun addEvents(events: Collection<DomainEvent>) {
+        addDomainEvents(events)
+    }
+}
+
+/**
+ * 테스트용 DomainEvent 구현체
+ */
+private class TestDomainEvent(
+    override val aggregateId: UUID,
+    override val eventType: String
+) : DomainEvent {
+    override val eventId: UUID = UUID.randomUUID()
+    override val occurredAt: LocalDateTime = LocalDateTime.now()
+}

--- a/libs/common-domain/src/test/kotlin/cloud/luigi99/blog/common/domain/BaseDomainEventTest.kt
+++ b/libs/common-domain/src/test/kotlin/cloud/luigi99/blog/common/domain/BaseDomainEventTest.kt
@@ -1,0 +1,317 @@
+package cloud.luigi99.blog.common.domain
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import java.time.LocalDateTime
+import java.util.*
+
+/**
+ * BaseDomainEvent의 행위를 검증하는 테스트
+ */
+class BaseDomainEventTest : BehaviorSpec({
+
+    given("BaseDomainEvent를 상속한 구체 이벤트가 생성될 때") {
+        val aggregateId = UUID.randomUUID()
+        val eventType = "TestEvent"
+
+        val event = SampleDomainEvent(aggregateId, eventType)
+
+        `when`("이벤트 기본 프로퍼티를 확인하면") {
+            then("aggregateId가 올바르게 설정된다") {
+                event.aggregateId shouldBe aggregateId
+            }
+
+            then("eventType이 올바르게 설정된다") {
+                event.eventType shouldBe eventType
+            }
+
+            then("eventId가 자동 생성된다") {
+                event.eventId shouldNotBe null
+                event.eventId.shouldBeInstanceOf<UUID>()
+            }
+
+            then("occurredAt이 자동 생성된다") {
+                event.occurredAt shouldNotBe null
+                event.occurredAt.shouldBeInstanceOf<LocalDateTime>()
+            }
+
+            then("eventVersion이 기본값 1로 설정된다") {
+                event.eventVersion shouldBe 1
+            }
+
+            then("aggregateType이 클래스명에서 자동 추출된다") {
+                event.aggregateType shouldBe "SampleDomain"
+            }
+        }
+    }
+
+    given("동일한 eventId를 가진 두 개의 도메인 이벤트가 있을 때") {
+        val aggregateId1 = UUID.randomUUID()
+        val aggregateId2 = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+
+        val event1 = SampleEventWithCustomId(aggregateId1, "TestEvent1", eventId)
+        val event2 = SampleEventWithCustomId(aggregateId2, "TestEvent2", eventId)
+
+        `when`("equals 메서드를 호출하면") {
+            val result = event1.equals(event2)
+
+            then("eventId가 같으므로 true를 반환한다") {
+                result shouldBe true
+            }
+        }
+
+        `when`("hashCode 메서드를 호출하면") {
+            val hashCode1 = event1.hashCode()
+            val hashCode2 = event2.hashCode()
+
+            then("eventId가 같으므로 같은 해시코드를 반환한다") {
+                hashCode1 shouldBe hashCode2
+            }
+        }
+    }
+
+    given("서로 다른 eventId를 가진 두 개의 도메인 이벤트가 있을 때") {
+        val aggregateId = UUID.randomUUID()
+        val event1 = SampleDomainEvent(aggregateId, "TestEvent")
+        val event2 = SampleDomainEvent(aggregateId, "TestEvent")
+
+        `when`("equals 메서드를 호출하면") {
+            val result = event1.equals(event2)
+
+            then("eventId가 다르므로 false를 반환한다") {
+                result shouldBe false
+            }
+        }
+
+        `when`("hashCode 메서드를 호출하면") {
+            val hashCode1 = event1.hashCode()
+            val hashCode2 = event2.hashCode()
+
+            then("eventId가 다르므로 다른 해시코드를 반환한다") {
+                hashCode1 shouldNotBe hashCode2
+            }
+        }
+    }
+
+    given("BaseDomainEvent가 자기 자신과 비교될 때") {
+        val event = SampleDomainEvent(UUID.randomUUID(), "TestEvent")
+
+        `when`("equals 메서드로 자기 자신과 비교하면") {
+            val result = event.equals(event)
+
+            then("true를 반환한다") {
+                result shouldBe true
+            }
+        }
+    }
+
+    given("BaseDomainEvent가 null과 비교될 때") {
+        val event = SampleDomainEvent(UUID.randomUUID(), "TestEvent")
+
+        `when`("equals 메서드로 null과 비교하면") {
+            val result = event.equals(null)
+
+            then("false를 반환한다") {
+                result shouldBe false
+            }
+        }
+    }
+
+    given("BaseDomainEvent가 다른 타입의 객체와 비교될 때") {
+        val event = SampleDomainEvent(UUID.randomUUID(), "TestEvent")
+        val otherObject = "문자열 객체"
+
+        `when`("equals 메서드로 다른 타입 객체와 비교하면") {
+            val result = event.equals(otherObject)
+
+            then("false를 반환한다") {
+                result shouldBe false
+            }
+        }
+    }
+
+    given("BaseDomainEvent의 toString이 호출될 때") {
+        val aggregateId = UUID.randomUUID()
+        val eventType = "TestEvent"
+        val event = SampleDomainEvent(aggregateId, eventType)
+
+        `when`("toString 메서드를 호출하면") {
+            val result = event.toString()
+
+            then("모든 주요 정보를 포함한 문자열을 반환한다") {
+                result shouldContain "SampleDomainEvent"
+                result shouldContain "eventId=${event.eventId}"
+                result shouldContain "aggregateId=$aggregateId"
+                result shouldContain "eventType='$eventType'"
+                result shouldContain "aggregateType='SampleDomain'"
+                result shouldContain "occurredAt=${event.occurredAt}"
+                result shouldContain "eventVersion=${event.eventVersion}"
+            }
+        }
+    }
+
+    given("BaseDomainEvent의 companion object 메서드들이 있을 때") {
+        `when`("generateEventType을 호출하면") {
+            val eventType = BaseDomainEvent.generateEventType(SampleDomainEvent::class.java)
+
+            then("클래스 이름이 반환된다") {
+                eventType shouldBe "SampleDomainEvent"
+            }
+        }
+
+        `when`("builder를 호출하면") {
+            val aggregateId = UUID.randomUUID()
+            val eventType = "TestEvent"
+            val builder = BaseDomainEvent.builder(aggregateId, eventType)
+
+            then("EventBuilder 인스턴스가 반환된다") {
+                builder.shouldBeInstanceOf<BaseDomainEvent.EventBuilder>()
+            }
+        }
+    }
+
+    given("EventBuilder가 생성되었을 때") {
+        val aggregateId = UUID.randomUUID()
+        val eventType = "TestEvent"
+        val builder = BaseDomainEvent.builder(aggregateId, eventType)
+
+        `when`("기본 설정으로 buildSimple을 호출하면") {
+            val event = builder.buildSimple()
+
+            then("기본값으로 이벤트가 생성된다") {
+                event.aggregateId shouldBe aggregateId
+                event.eventType shouldBe eventType
+                event.eventVersion shouldBe 1
+                event.eventId shouldNotBe null
+                event.occurredAt shouldNotBe null
+            }
+        }
+
+        `when`("커스텀 eventId를 설정하고 buildSimple을 호출하면") {
+            val customEventId = UUID.randomUUID()
+            val event = builder.withEventId(customEventId).buildSimple()
+
+            then("설정한 eventId로 이벤트가 생성된다") {
+                event.eventId shouldBe customEventId
+                event.aggregateId shouldBe aggregateId
+                event.eventType shouldBe eventType
+            }
+        }
+
+        `when`("커스텀 occurredAt을 설정하고 buildSimple을 호출하면") {
+            val customOccurredAt = LocalDateTime.of(2024, 1, 1, 12, 0, 0)
+            val event = builder.withOccurredAt(customOccurredAt).buildSimple()
+
+            then("설정한 occurredAt으로 이벤트가 생성된다") {
+                event.occurredAt shouldBe customOccurredAt
+                event.aggregateId shouldBe aggregateId
+                event.eventType shouldBe eventType
+            }
+        }
+
+        `when`("커스텀 eventVersion을 설정하고 buildSimple을 호출하면") {
+            val customVersion = 5
+            val event = builder.withEventVersion(customVersion).buildSimple()
+
+            then("설정한 eventVersion으로 이벤트가 생성된다") {
+                event.eventVersion shouldBe customVersion
+                event.aggregateId shouldBe aggregateId
+                event.eventType shouldBe eventType
+            }
+        }
+
+        `when`("모든 커스텀 값을 설정하고 buildSimple을 호출하면") {
+            val customEventId = UUID.randomUUID()
+            val customOccurredAt = LocalDateTime.of(2024, 1, 1, 12, 0, 0)
+            val customVersion = 3
+
+            val event = builder
+                .withEventId(customEventId)
+                .withOccurredAt(customOccurredAt)
+                .withEventVersion(customVersion)
+                .buildSimple()
+
+            then("모든 커스텀 값으로 이벤트가 생성된다") {
+                event.eventId shouldBe customEventId
+                event.occurredAt shouldBe customOccurredAt
+                event.eventVersion shouldBe customVersion
+                event.aggregateId shouldBe aggregateId
+                event.eventType shouldBe eventType
+            }
+        }
+    }
+
+    given("여러 EventBuilder 체이닝 테스트") {
+        val aggregateId = UUID.randomUUID()
+        val eventType = "ChainedEvent"
+
+        `when`("빌더 메서드들을 체이닝으로 호출하면") {
+            val customEventId = UUID.randomUUID()
+            val customOccurredAt = LocalDateTime.of(2024, 6, 15, 10, 30, 0)
+            val customVersion = 2
+
+            val event = BaseDomainEvent.builder(aggregateId, eventType)
+                .withEventId(customEventId)
+                .withOccurredAt(customOccurredAt)
+                .withEventVersion(customVersion)
+                .buildSimple()
+
+            then("체이닝된 모든 설정이 적용된다") {
+                event.aggregateId shouldBe aggregateId
+                event.eventType shouldBe eventType
+                event.eventId shouldBe customEventId
+                event.occurredAt shouldBe customOccurredAt
+                event.eventVersion shouldBe customVersion
+            }
+        }
+    }
+
+    given("aggregateType 자동 추출 기능 테스트") {
+        `when`("Event 접미사가 있는 클래스명일 때") {
+            val event = UserRegisteredEvent(UUID.randomUUID(), "UserRegistered")
+
+            then("Event 접미사가 제거된 aggregateType을 반환한다") {
+                event.aggregateType shouldBe "UserRegistered"
+            }
+        }
+
+        `when`("Event 접미사가 없는 클래스명일 때") {
+            val event = SampleDomainEvent(UUID.randomUUID(), "TestEvent")
+
+            then("클래스명에서 Event를 제거한 aggregateType을 반환한다") {
+                event.aggregateType shouldBe "SampleDomain"
+            }
+        }
+    }
+})
+
+/**
+ * 테스트용 BaseDomainEvent 구현체
+ */
+private class SampleDomainEvent(
+    aggregateId: UUID,
+    eventType: String
+) : BaseDomainEvent(aggregateId, eventType)
+
+/**
+ * 커스텀 eventId를 가진 테스트용 BaseDomainEvent 구현체
+ */
+private class SampleEventWithCustomId(
+    aggregateId: UUID,
+    eventType: String,
+    customEventId: UUID
+) : BaseDomainEvent(aggregateId, eventType) {
+    override val eventId: UUID = customEventId
+}
+
+/**
+ * Event 접미사를 가진 테스트용 BaseDomainEvent 구현체
+ */
+private class UserRegisteredEvent(
+    aggregateId: UUID,
+    eventType: String
+) : BaseDomainEvent(aggregateId, eventType)

--- a/libs/common-domain/src/test/kotlin/cloud/luigi99/blog/common/domain/BaseEntityTest.kt
+++ b/libs/common-domain/src/test/kotlin/cloud/luigi99/blog/common/domain/BaseEntityTest.kt
@@ -1,0 +1,130 @@
+package cloud.luigi99.blog.common.domain
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import java.time.LocalDateTime
+import java.util.*
+
+/**
+ * BaseEntity의 행위를 검증하는 테스트
+ */
+class BaseEntityTest : BehaviorSpec({
+
+    given("동일한 ID를 가진 두 개의 BaseEntity 구현체가 있을 때") {
+        val entityId = UUID.randomUUID()
+        val now = LocalDateTime.now()
+
+        val entity1 = TestEntity(entityId, now, null)
+        val entity2 = TestEntity(entityId, now.plusMinutes(10), now.plusMinutes(5))
+
+        `when`("equals 메서드를 호출하면") {
+            val result = entity1.equals(entity2)
+
+            then("ID가 같으므로 true를 반환한다") {
+                result shouldBe true
+            }
+        }
+
+        `when`("hashCode 메서드를 호출하면") {
+            val hashCode1 = entity1.hashCode()
+            val hashCode2 = entity2.hashCode()
+
+            then("ID가 같으므로 같은 해시코드를 반환한다") {
+                hashCode1 shouldBe hashCode2
+            }
+        }
+    }
+
+    given("서로 다른 ID를 가진 두 개의 BaseEntity 구현체가 있을 때") {
+        val entityId1 = UUID.randomUUID()
+        val entityId2 = UUID.randomUUID()
+        val now = LocalDateTime.now()
+
+        val entity1 = TestEntity(entityId1, now, null)
+        val entity2 = TestEntity(entityId2, now, null)
+
+        `when`("equals 메서드를 호출하면") {
+            val result = entity1.equals(entity2)
+
+            then("ID가 다르므로 false를 반환한다") {
+                result shouldBe false
+            }
+        }
+
+        `when`("hashCode 메서드를 호출하면") {
+            val hashCode1 = entity1.hashCode()
+            val hashCode2 = entity2.hashCode()
+
+            then("ID가 다르므로 다른 해시코드를 반환한다") {
+                hashCode1 shouldNotBe hashCode2
+            }
+        }
+    }
+
+    given("BaseEntity 구현체가 있을 때") {
+        val entityId = UUID.randomUUID()
+        val createdAt = LocalDateTime.now()
+        val updatedAt = createdAt.plusMinutes(5)
+
+        val entity = TestEntity(entityId, createdAt, updatedAt)
+
+        `when`("toString 메서드를 호출하면") {
+            val result = entity.toString()
+
+            then("클래스명과 ID, 생성시각, 수정시각을 포함한 문자열을 반환한다") {
+                result shouldContain "TestEntity"
+                result shouldContain entityId.toString()
+                result shouldContain createdAt.toString()
+                result shouldContain updatedAt.toString()
+            }
+        }
+    }
+
+    given("BaseEntity 구현체가 자기 자신과 비교될 때") {
+        val entity = TestEntity(UUID.randomUUID(), LocalDateTime.now(), null)
+
+        `when`("equals 메서드로 자기 자신과 비교하면") {
+            val result = entity.equals(entity)
+
+            then("true를 반환한다") {
+                result shouldBe true
+            }
+        }
+    }
+
+    given("BaseEntity 구현체가 null과 비교될 때") {
+        val entity = TestEntity(UUID.randomUUID(), LocalDateTime.now(), null)
+
+        `when`("equals 메서드로 null과 비교하면") {
+            val result = entity.equals(null)
+
+            then("false를 반환한다") {
+                result shouldBe false
+            }
+        }
+    }
+
+    given("BaseEntity 구현체가 다른 타입의 객체와 비교될 때") {
+        val entity = TestEntity(UUID.randomUUID(), LocalDateTime.now(), null)
+        val otherObject = "문자열 객체"
+
+        `when`("equals 메서드로 다른 타입 객체와 비교하면") {
+            val result = entity.equals(otherObject)
+
+            then("false를 반환한다") {
+                result shouldBe false
+            }
+        }
+    }
+})
+
+/**
+ * 테스트용 BaseEntity 구현체
+ */
+private class TestEntity(
+    override val id: UUID,
+    override val createdAt: LocalDateTime,
+    override val updatedAt: LocalDateTime?
+) : BaseEntity()

--- a/libs/common-domain/src/test/kotlin/cloud/luigi99/blog/common/domain/DomainEventTest.kt
+++ b/libs/common-domain/src/test/kotlin/cloud/luigi99/blog/common/domain/DomainEventTest.kt
@@ -1,0 +1,214 @@
+package cloud.luigi99.blog.common.domain
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.time.LocalDateTime
+import java.util.*
+
+/**
+ * DomainEvent의 행위를 검증하는 테스트
+ */
+class DomainEventTest : BehaviorSpec({
+
+    given("DomainEvent 구현체가 있을 때") {
+        val eventId = UUID.randomUUID()
+        val aggregateId = UUID.randomUUID()
+        val occurredAt = LocalDateTime.now()
+        val eventType = "PostCreated"
+
+        val domainEvent = DomainEventTestImpl(eventId, aggregateId, occurredAt, eventType)
+
+        `when`("기본 속성들을 확인하면") {
+            then("모든 속성이 올바르게 설정된다") {
+                domainEvent.eventId shouldBe eventId
+                domainEvent.aggregateId shouldBe aggregateId
+                domainEvent.occurredAt shouldBe occurredAt
+                domainEvent.eventType shouldBe eventType
+            }
+        }
+
+        `when`("기본 이벤트 버전을 확인하면") {
+            val eventVersion = domainEvent.eventVersion
+
+            then("기본값 1을 반환한다") {
+                eventVersion shouldBe 1
+            }
+        }
+
+        `when`("애그리게이트 타입을 확인하면") {
+            val aggregateType = domainEvent.aggregateType
+
+            then("클래스명에서 Event를 제거한 타입을 반환한다") {
+                aggregateType shouldBe "TestDomain"
+            }
+        }
+    }
+
+    given("이벤트 타입 확인 기능을 테스트할 때") {
+        val domainEvent = DomainEventTestImpl(UUID.randomUUID(), UUID.randomUUID(), LocalDateTime.now(), "UserRegistered")
+
+        `when`("일치하는 이벤트 타입으로 확인하면") {
+            val isCorrectType = domainEvent.isEventType("UserRegistered")
+
+            then("true를 반환한다") {
+                isCorrectType shouldBe true
+            }
+        }
+
+        `when`("일치하지 않는 이벤트 타입으로 확인하면") {
+            val isCorrectType = domainEvent.isEventType("UserDeleted")
+
+            then("false를 반환한다") {
+                isCorrectType shouldBe false
+            }
+        }
+    }
+
+    given("애그리게이트 확인 기능을 테스트할 때") {
+        val aggregateId = UUID.randomUUID()
+        val domainEvent = DomainEventTestImpl(UUID.randomUUID(), aggregateId, LocalDateTime.now(), "PostCreated")
+
+        `when`("일치하는 애그리게이트 ID로 확인하면") {
+            val isFromAggregate = domainEvent.isFromAggregate(aggregateId)
+
+            then("true를 반환한다") {
+                isFromAggregate shouldBe true
+            }
+        }
+
+        `when`("일치하지 않는 애그리게이트 ID로 확인하면") {
+            val differentId = UUID.randomUUID()
+            val isFromAggregate = domainEvent.isFromAggregate(differentId)
+
+            then("false를 반환한다") {
+                isFromAggregate shouldBe false
+            }
+        }
+    }
+
+    given("시간 비교 기능을 테스트할 때") {
+        val baseTime = LocalDateTime.of(2023, 1, 1, 12, 0, 0)
+        val domainEvent = DomainEventTestImpl(UUID.randomUUID(), UUID.randomUUID(), baseTime, "TestEvent")
+
+        `when`("이벤트 발생 시각 이전 시간과 비교하면") {
+            val earlierTime = baseTime.minusHours(1)
+            val occurredAfter = domainEvent.occurredAfter(earlierTime)
+
+            then("true를 반환한다") {
+                occurredAfter shouldBe true
+            }
+        }
+
+        `when`("이벤트 발생 시각 이후 시간과 비교하면") {
+            val laterTime = baseTime.plusHours(1)
+            val occurredAfter = domainEvent.occurredAfter(laterTime)
+
+            then("false를 반환한다") {
+                occurredAfter shouldBe false
+            }
+        }
+
+        `when`("이벤트 발생 시각 이전 시간으로 before 확인하면") {
+            val laterTime = baseTime.plusHours(1)
+            val occurredBefore = domainEvent.occurredBefore(laterTime)
+
+            then("true를 반환한다") {
+                occurredBefore shouldBe true
+            }
+        }
+
+        `when`("이벤트 발생 시각 이후 시간으로 before 확인하면") {
+            val earlierTime = baseTime.minusHours(1)
+            val occurredBefore = domainEvent.occurredBefore(earlierTime)
+
+            then("false를 반환한다") {
+                occurredBefore shouldBe false
+            }
+        }
+    }
+
+    given("커스텀 이벤트 버전을 가진 DomainEvent가 있을 때") {
+        val customVersionEvent = CustomVersionEvent(UUID.randomUUID(), UUID.randomUUID(), LocalDateTime.now(), "CustomEvent", 5)
+
+        `when`("이벤트 버전을 확인하면") {
+            val eventVersion = customVersionEvent.eventVersion
+
+            then("커스텀 버전을 반환한다") {
+                eventVersion shouldBe 5
+            }
+        }
+    }
+
+    given("커스텀 애그리게이트 타입을 가진 DomainEvent가 있을 때") {
+        val customTypeEvent = CustomAggregateTypeEvent(UUID.randomUUID(), UUID.randomUUID(), LocalDateTime.now(), "CustomEvent")
+
+        `when`("애그리게이트 타입을 확인하면") {
+            val aggregateType = customTypeEvent.aggregateType
+
+            then("커스텀 타입을 반환한다") {
+                aggregateType shouldBe "CustomAggregate"
+            }
+        }
+    }
+
+    given("이벤트명에 Event가 포함되지 않은 클래스가 있을 때") {
+        val noEventSuffixEvent = NoEventSuffixTest(UUID.randomUUID(), UUID.randomUUID(), LocalDateTime.now(), "TestEvent")
+
+        `when`("애그리게이트 타입을 확인하면") {
+            val aggregateType = noEventSuffixEvent.aggregateType
+
+            then("클래스명에서 Event를 제거한 결과를 반환한다") {
+                // "NoEventSuffixTest"에서 "Event"를 제거하면 "NoSuffixTest"가 됨
+                aggregateType shouldBe "NoSuffixTest"
+            }
+        }
+    }
+})
+
+/**
+ * 테스트용 DomainEvent 구현체
+ */
+private class DomainEventTestImpl(
+    override val eventId: UUID,
+    override val aggregateId: UUID,
+    override val occurredAt: LocalDateTime,
+    override val eventType: String
+) : DomainEvent {
+    override val aggregateType: String
+        get() = "TestDomain"
+}
+
+/**
+ * 커스텀 이벤트 버전을 가진 테스트용 DomainEvent 구현체
+ */
+private class CustomVersionEvent(
+    override val eventId: UUID,
+    override val aggregateId: UUID,
+    override val occurredAt: LocalDateTime,
+    override val eventType: String,
+    override val eventVersion: Int
+) : DomainEvent
+
+/**
+ * 커스텀 애그리게이트 타입을 가진 테스트용 DomainEvent 구현체
+ */
+private class CustomAggregateTypeEvent(
+    override val eventId: UUID,
+    override val aggregateId: UUID,
+    override val occurredAt: LocalDateTime,
+    override val eventType: String
+) : DomainEvent {
+    override val aggregateType: String
+        get() = "CustomAggregate"
+}
+
+/**
+ * Event 접미사가 없는 테스트용 DomainEvent 구현체
+ */
+private class NoEventSuffixTest(
+    override val eventId: UUID,
+    override val aggregateId: UUID,
+    override val occurredAt: LocalDateTime,
+    override val eventType: String
+) : DomainEvent

--- a/libs/common-domain/src/test/kotlin/cloud/luigi99/blog/common/domain/ValueObjectTest.kt
+++ b/libs/common-domain/src/test/kotlin/cloud/luigi99/blog/common/domain/ValueObjectTest.kt
@@ -1,0 +1,185 @@
+package cloud.luigi99.blog.common.domain
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.assertions.throwables.shouldThrow
+
+/**
+ * ValueObject의 행위를 검증하는 테스트
+ */
+class ValueObjectTest : BehaviorSpec({
+
+    given("동일한 값을 가진 두 개의 ValueObject 구현체가 있을 때") {
+        val value1 = TestValueObject("테스트값", 42)
+        val value2 = TestValueObject("테스트값", 42)
+
+        `when`("equals 메서드를 호출하면") {
+            val result = value1.equals(value2)
+
+            then("값이 같으므로 true를 반환한다") {
+                result shouldBe true
+            }
+        }
+
+        `when`("hashCode 메서드를 호출하면") {
+            val hashCode1 = value1.hashCode()
+            val hashCode2 = value2.hashCode()
+
+            then("값이 같으므로 같은 해시코드를 반환한다") {
+                hashCode1 shouldBe hashCode2
+            }
+        }
+    }
+
+    given("서로 다른 값을 가진 두 개의 ValueObject 구현체가 있을 때") {
+        val value1 = TestValueObject("테스트값1", 42)
+        val value2 = TestValueObject("테스트값2", 42)
+
+        `when`("equals 메서드를 호출하면") {
+            val result = value1.equals(value2)
+
+            then("값이 다르므로 false를 반환한다") {
+                result shouldBe false
+            }
+        }
+
+        `when`("hashCode 메서드를 호출하면") {
+            val hashCode1 = value1.hashCode()
+            val hashCode2 = value2.hashCode()
+
+            then("값이 다르므로 다른 해시코드를 반환한다") {
+                hashCode1 shouldNotBe hashCode2
+            }
+        }
+    }
+
+    given("ValueObject 구현체가 있을 때") {
+        val valueObject = TestValueObject("테스트값", 42)
+
+        `when`("toString 메서드를 호출하면") {
+            val result = valueObject.toString()
+
+            then("클래스명과 해시코드를 포함한 문자열을 반환한다") {
+                result shouldContain "TestValueObject"
+                result shouldContain "@"
+            }
+        }
+    }
+
+    given("ValueObject 구현체가 자기 자신과 비교될 때") {
+        val valueObject = TestValueObject("테스트값", 42)
+
+        `when`("equals 메서드로 자기 자신과 비교하면") {
+            val result = valueObject.equals(valueObject)
+
+            then("true를 반환한다") {
+                result shouldBe true
+            }
+        }
+    }
+
+    given("ValueObject 구현체가 null과 비교될 때") {
+        val valueObject = TestValueObject("테스트값", 42)
+
+        `when`("equals 메서드로 null과 비교하면") {
+            val result = valueObject.equals(null)
+
+            then("false를 반환한다") {
+                result shouldBe false
+            }
+        }
+    }
+
+    given("ValueObject 구현체가 다른 타입의 객체와 비교될 때") {
+        val valueObject = TestValueObject("테스트값", 42)
+        val otherObject = "문자열 객체"
+
+        `when`("equals 메서드로 다른 타입 객체와 비교하면") {
+            val result = valueObject.equals(otherObject)
+
+            then("false를 반환한다") {
+                result shouldBe false
+            }
+        }
+    }
+
+    given("유효성 검증을 재정의한 ValueObject가 있을 때") {
+        `when`("유효하지 않은 값으로 생성하면") {
+            then("IllegalArgumentException이 발생한다") {
+                shouldThrow<IllegalArgumentException> {
+                    InvalidTestValueObject("잘못된값")
+                }
+            }
+        }
+
+        `when`("유효한 값으로 생성하면") {
+            val validValue = InvalidTestValueObject("유효한값")
+
+            then("정상적으로 생성된다") {
+                validValue.value shouldBe "유효한값"
+            }
+        }
+    }
+
+    given("기본 유효성 검증을 사용하는 ValueObject가 있을 때") {
+        val valueObject = TestValueObject("테스트값", 42)
+
+        `when`("validate 메서드를 호출하면") {
+            then("예외가 발생하지 않는다") {
+                // 기본 isValid()가 true를 반환하므로 예외가 발생하지 않아야 함
+                valueObject.testValidate()
+            }
+        }
+    }
+})
+
+/**
+ * 테스트용 ValueObject 구현체
+ */
+private class TestValueObject(
+    val name: String,
+    val number: Int
+) : ValueObject() {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is TestValueObject) return false
+        return name == other.name && number == other.number
+    }
+
+    override fun hashCode(): Int {
+        return 31 * name.hashCode() + number
+    }
+
+    fun testValidate() {
+        validate()
+    }
+}
+
+/**
+ * 유효성 검증을 포함한 테스트용 ValueObject 구현체
+ */
+private class InvalidTestValueObject(
+    val value: String
+) : ValueObject() {
+
+    init {
+        validate()
+    }
+
+    override fun isValid(): Boolean {
+        return value != "잘못된값"
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is InvalidTestValueObject) return false
+        return value == other.value
+    }
+
+    override fun hashCode(): Int {
+        return value.hashCode()
+    }
+}

--- a/libs/common-domain/src/test/kotlin/cloud/luigi99/blog/common/exception/BusinessExceptionTest.kt
+++ b/libs/common-domain/src/test/kotlin/cloud/luigi99/blog/common/exception/BusinessExceptionTest.kt
@@ -17,14 +17,14 @@ class BusinessExceptionTest : BehaviorSpec({
         `when`("예외 정보를 확인하면") {
             then("메시지와 기본 에러 코드가 설정된다") {
                 exception.message shouldBe message
-                exception.errorCode shouldBe "BUSINESS_ERROR"
+                exception.errorCode shouldBe ErrorCode.COMMON_BUSINESS_ERROR.code
                 exception.cause shouldBe null
             }
         }
     }
 
     given("에러 코드를 포함하여 BusinessException을 생성할 때") {
-        val errorCode = "INVALID_INPUT"
+        val errorCode = ErrorCode.COMMON_INVALID_INPUT.code
         val message = "입력값이 유효하지 않습니다"
         val exception = BusinessException(errorCode, message)
 
@@ -38,18 +38,18 @@ class BusinessExceptionTest : BehaviorSpec({
 
     given("원인 예외를 포함하여 BusinessException을 생성할 때") {
         val cause = IllegalArgumentException("원인 예외")
-        val exception = BusinessException("WRAPPED_ERROR", "래핑된 오류", cause as Throwable?)
+        val exception = BusinessException(ErrorCode.COMMON_INTERNAL_SERVER_ERROR.code, "래핑된 오류", cause as Throwable?)
 
         `when`("예외 정보를 확인하면") {
             then("원인 예외가 올바르게 설정된다") {
                 exception.cause shouldBe cause
-                exception.errorCode shouldBe "WRAPPED_ERROR"
+                exception.errorCode shouldBe ErrorCode.COMMON_INTERNAL_SERVER_ERROR.code
             }
         }
     }
 
     given("포맷된 메시지로 BusinessException을 생성할 때") {
-        val errorCode = "USER_NOT_FOUND"
+        val errorCode = ErrorCode.USER_NOT_FOUND.code
         val messageFormat = "사용자를 찾을 수 없습니다. ID: %s, 이름: %s"
         val userId = "12345"
         val userName = "테스트사용자"
@@ -66,13 +66,13 @@ class BusinessExceptionTest : BehaviorSpec({
     }
 
     given("다른 BusinessException을 기반으로 새 예외를 생성할 때") {
-        val originalException = BusinessException("ORIGINAL_ERROR", "원본 오류")
+        val originalException = BusinessException(ErrorCode.COMMON_BUSINESS_ERROR.code, "원본 오류")
         val additionalMessage = "추가 정보"
         val newException = BusinessException(originalException, additionalMessage)
 
         `when`("새 예외의 정보를 확인하면") {
             then("원본 예외의 정보와 추가 메시지가 합쳐진다") {
-                newException.errorCode shouldBe "ORIGINAL_ERROR"
+                newException.errorCode shouldBe ErrorCode.COMMON_BUSINESS_ERROR.code
                 newException.message shouldBe "원본 오류 - 추가 정보"
                 newException.cause shouldBe originalException.cause
             }
@@ -80,22 +80,22 @@ class BusinessExceptionTest : BehaviorSpec({
     }
 
     given("다른 BusinessException을 기반으로 추가 메시지 없이 새 예외를 생성할 때") {
-        val originalException = BusinessException("ORIGINAL_ERROR", "원본 오류")
+        val originalException = BusinessException(ErrorCode.ENTITY_CREATION_FAILED.code, "원본 오류")
         val newException = BusinessException(originalException)
 
         `when`("새 예외의 정보를 확인하면") {
             then("원본 예외의 정보가 그대로 복사된다") {
-                newException.errorCode shouldBe "ORIGINAL_ERROR"
+                newException.errorCode shouldBe ErrorCode.ENTITY_CREATION_FAILED.code
                 newException.message shouldBe "원본 오류"
             }
         }
     }
 
     given("에러 코드 확인 기능을 테스트할 때") {
-        val exception = BusinessException("TEST_ERROR", "테스트 오류")
+        val exception = BusinessException(ErrorCode.ENTITY_NOT_FOUND.code, "테스트 오류")
 
         `when`("일치하는 에러 코드로 확인하면") {
-            val hasErrorCode = exception.hasErrorCode("TEST_ERROR")
+            val hasErrorCode = exception.hasErrorCode(ErrorCode.ENTITY_NOT_FOUND.code)
 
             then("true를 반환한다") {
                 hasErrorCode shouldBe true
@@ -103,7 +103,7 @@ class BusinessExceptionTest : BehaviorSpec({
         }
 
         `when`("일치하지 않는 에러 코드로 확인하면") {
-            val hasErrorCode = exception.hasErrorCode("DIFFERENT_ERROR")
+            val hasErrorCode = exception.hasErrorCode(ErrorCode.ENTITY_ALREADY_EXISTS.code)
 
             then("false를 반환한다") {
                 hasErrorCode shouldBe false
@@ -112,10 +112,10 @@ class BusinessExceptionTest : BehaviorSpec({
     }
 
     given("여러 에러 코드 중 하나와 일치하는지 확인할 때") {
-        val exception = BusinessException("VALIDATION_ERROR", "유효성 검증 오류")
+        val exception = BusinessException(ErrorCode.VALIDATION_INVALID_EMAIL.code, "유효성 검증 오류")
 
         `when`("포함된 에러 코드들로 확인하면") {
-            val hasAnyErrorCode = exception.hasAnyErrorCode("INPUT_ERROR", "VALIDATION_ERROR", "BUSINESS_ERROR")
+            val hasAnyErrorCode = exception.hasAnyErrorCode(ErrorCode.COMMON_INVALID_INPUT.code, ErrorCode.VALIDATION_INVALID_EMAIL.code, ErrorCode.COMMON_BUSINESS_ERROR.code)
 
             then("true를 반환한다") {
                 hasAnyErrorCode shouldBe true
@@ -123,7 +123,7 @@ class BusinessExceptionTest : BehaviorSpec({
         }
 
         `when`("포함되지 않은 에러 코드들로 확인하면") {
-            val hasAnyErrorCode = exception.hasAnyErrorCode("INPUT_ERROR", "SYSTEM_ERROR", "DATABASE_ERROR")
+            val hasAnyErrorCode = exception.hasAnyErrorCode(ErrorCode.COMMON_INVALID_INPUT.code, ErrorCode.COMMON_INTERNAL_SERVER_ERROR.code, ErrorCode.ENTITY_CREATION_FAILED.code)
 
             then("false를 반환한다") {
                 hasAnyErrorCode shouldBe false
@@ -132,51 +132,66 @@ class BusinessExceptionTest : BehaviorSpec({
     }
 
     given("상세한 에러 메시지를 확인할 때") {
-        val exception = BusinessException("AUTH_FAILED", "인증에 실패했습니다")
+        val exception = BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS.code, "인증에 실패했습니다")
 
         `when`("getDetailedMessage를 호출하면") {
             val detailedMessage = exception.getDetailedMessage()
 
             then("에러 코드와 메시지를 포함한 문자열을 반환한다") {
-                detailedMessage shouldBe "[AUTH_FAILED] 인증에 실패했습니다"
+                detailedMessage shouldBe "[${ErrorCode.AUTH_INVALID_CREDENTIALS.code}] 인증에 실패했습니다"
             }
         }
     }
 
     given("toString 메서드를 테스트할 때") {
-        val exception = BusinessException("CUSTOM_ERROR", "커스텀 오류 메시지")
+        val exception = BusinessException(ErrorCode.ENTITY_UPDATE_FAILED.code, "커스텀 오류 메시지")
 
         `when`("toString을 호출하면") {
             val toStringResult = exception.toString()
 
             then("클래스명, 에러 코드, 메시지를 포함한 문자열을 반환한다") {
                 toStringResult shouldContain "BusinessException"
-                toStringResult shouldContain "CUSTOM_ERROR"
+                toStringResult shouldContain ErrorCode.ENTITY_UPDATE_FAILED.code
                 toStringResult shouldContain "커스텀 오류 메시지"
             }
         }
     }
 
-    given("BusinessException이 RuntimeException을 상속받는지 확인할 때") {
-        val exception = BusinessException("TEST_ERROR", "테스트")
+    given("BusinessException이 RuntimeException의 특성을 가지는지 확인할 때") {
+        val exception = BusinessException(ErrorCode.ENTITY_DELETE_FAILED.code, "테스트 에러")
 
-        `when`("타입을 확인하면") {
-            then("RuntimeException의 인스턴스이다") {
-                (exception is RuntimeException) shouldBe true
+        `when`("예외가 던져지면") {
+            then("RuntimeException처럼 언체크드 예외로 동작한다") {
+                // 함수가 checked exception을 던지지 않아도 컴파일 에러가 발생하지 않음을 테스트
+                val thrownException = try {
+                    throw exception
+                } catch (e: RuntimeException) {
+                    e
+                }
+
+                thrownException shouldBe exception
+                thrownException.message shouldBe "테스트 에러"
+            }
+        }
+
+        `when`("스택트레이스를 확인하면") {
+            then("RuntimeException의 기본 동작을 수행한다") {
+                exception.stackTrace shouldNotBe null
+                exception.stackTrace.isNotEmpty() shouldBe true
             }
         }
     }
 
     given("에러 코드가 null이 아닌지 확인할 때") {
         val exception1 = BusinessException("기본 메시지")
-        val exception2 = BusinessException("CUSTOM_CODE", "커스텀 메시지")
+        val exception2 = BusinessException(ErrorCode.ENTITY_DELETE_FAILED.code, "커스텀 메시지")
 
         `when`("에러 코드를 확인하면") {
             then("모든 경우에 null이 아니다") {
                 exception1.errorCode shouldNotBe null
                 exception2.errorCode shouldNotBe null
-                exception1.errorCode shouldBe "BUSINESS_ERROR"
-                exception2.errorCode shouldBe "CUSTOM_CODE"
+                exception1.errorCode shouldBe ErrorCode.COMMON_BUSINESS_ERROR.code
+                exception2.errorCode shouldBe ErrorCode.ENTITY_DELETE_FAILED.code
             }
         }
     }

--- a/libs/common-domain/src/test/kotlin/cloud/luigi99/blog/common/exception/BusinessExceptionTest.kt
+++ b/libs/common-domain/src/test/kotlin/cloud/luigi99/blog/common/exception/BusinessExceptionTest.kt
@@ -1,0 +1,183 @@
+package cloud.luigi99.blog.common.exception
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+
+/**
+ * BusinessException의 행위를 검증하는 테스트
+ */
+class BusinessExceptionTest : BehaviorSpec({
+
+    given("기본 생성자로 BusinessException을 생성할 때") {
+        val message = "비즈니스 로직 오류가 발생했습니다"
+        val exception = BusinessException(message)
+
+        `when`("예외 정보를 확인하면") {
+            then("메시지와 기본 에러 코드가 설정된다") {
+                exception.message shouldBe message
+                exception.errorCode shouldBe "BUSINESS_ERROR"
+                exception.cause shouldBe null
+            }
+        }
+    }
+
+    given("에러 코드를 포함하여 BusinessException을 생성할 때") {
+        val errorCode = "INVALID_INPUT"
+        val message = "입력값이 유효하지 않습니다"
+        val exception = BusinessException(errorCode, message)
+
+        `when`("예외 정보를 확인하면") {
+            then("커스텀 에러 코드와 메시지가 설정된다") {
+                exception.errorCode shouldBe errorCode
+                exception.message shouldBe message
+            }
+        }
+    }
+
+    given("원인 예외를 포함하여 BusinessException을 생성할 때") {
+        val cause = IllegalArgumentException("원인 예외")
+        val exception = BusinessException("WRAPPED_ERROR", "래핑된 오류", cause as Throwable?)
+
+        `when`("예외 정보를 확인하면") {
+            then("원인 예외가 올바르게 설정된다") {
+                exception.cause shouldBe cause
+                exception.errorCode shouldBe "WRAPPED_ERROR"
+            }
+        }
+    }
+
+    given("포맷된 메시지로 BusinessException을 생성할 때") {
+        val errorCode = "USER_NOT_FOUND"
+        val messageFormat = "사용자를 찾을 수 없습니다. ID: %s, 이름: %s"
+        val userId = "12345"
+        val userName = "테스트사용자"
+        val exception = BusinessException(errorCode, messageFormat, userId, userName)
+
+        `when`("예외 메시지를 확인하면") {
+            val expectedMessage = "사용자를 찾을 수 없습니다. ID: 12345, 이름: 테스트사용자"
+
+            then("포맷된 메시지가 생성된다") {
+                exception.message shouldBe expectedMessage
+                exception.errorCode shouldBe errorCode
+            }
+        }
+    }
+
+    given("다른 BusinessException을 기반으로 새 예외를 생성할 때") {
+        val originalException = BusinessException("ORIGINAL_ERROR", "원본 오류")
+        val additionalMessage = "추가 정보"
+        val newException = BusinessException(originalException, additionalMessage)
+
+        `when`("새 예외의 정보를 확인하면") {
+            then("원본 예외의 정보와 추가 메시지가 합쳐진다") {
+                newException.errorCode shouldBe "ORIGINAL_ERROR"
+                newException.message shouldBe "원본 오류 - 추가 정보"
+                newException.cause shouldBe originalException.cause
+            }
+        }
+    }
+
+    given("다른 BusinessException을 기반으로 추가 메시지 없이 새 예외를 생성할 때") {
+        val originalException = BusinessException("ORIGINAL_ERROR", "원본 오류")
+        val newException = BusinessException(originalException)
+
+        `when`("새 예외의 정보를 확인하면") {
+            then("원본 예외의 정보가 그대로 복사된다") {
+                newException.errorCode shouldBe "ORIGINAL_ERROR"
+                newException.message shouldBe "원본 오류"
+            }
+        }
+    }
+
+    given("에러 코드 확인 기능을 테스트할 때") {
+        val exception = BusinessException("TEST_ERROR", "테스트 오류")
+
+        `when`("일치하는 에러 코드로 확인하면") {
+            val hasErrorCode = exception.hasErrorCode("TEST_ERROR")
+
+            then("true를 반환한다") {
+                hasErrorCode shouldBe true
+            }
+        }
+
+        `when`("일치하지 않는 에러 코드로 확인하면") {
+            val hasErrorCode = exception.hasErrorCode("DIFFERENT_ERROR")
+
+            then("false를 반환한다") {
+                hasErrorCode shouldBe false
+            }
+        }
+    }
+
+    given("여러 에러 코드 중 하나와 일치하는지 확인할 때") {
+        val exception = BusinessException("VALIDATION_ERROR", "유효성 검증 오류")
+
+        `when`("포함된 에러 코드들로 확인하면") {
+            val hasAnyErrorCode = exception.hasAnyErrorCode("INPUT_ERROR", "VALIDATION_ERROR", "BUSINESS_ERROR")
+
+            then("true를 반환한다") {
+                hasAnyErrorCode shouldBe true
+            }
+        }
+
+        `when`("포함되지 않은 에러 코드들로 확인하면") {
+            val hasAnyErrorCode = exception.hasAnyErrorCode("INPUT_ERROR", "SYSTEM_ERROR", "DATABASE_ERROR")
+
+            then("false를 반환한다") {
+                hasAnyErrorCode shouldBe false
+            }
+        }
+    }
+
+    given("상세한 에러 메시지를 확인할 때") {
+        val exception = BusinessException("AUTH_FAILED", "인증에 실패했습니다")
+
+        `when`("getDetailedMessage를 호출하면") {
+            val detailedMessage = exception.getDetailedMessage()
+
+            then("에러 코드와 메시지를 포함한 문자열을 반환한다") {
+                detailedMessage shouldBe "[AUTH_FAILED] 인증에 실패했습니다"
+            }
+        }
+    }
+
+    given("toString 메서드를 테스트할 때") {
+        val exception = BusinessException("CUSTOM_ERROR", "커스텀 오류 메시지")
+
+        `when`("toString을 호출하면") {
+            val toStringResult = exception.toString()
+
+            then("클래스명, 에러 코드, 메시지를 포함한 문자열을 반환한다") {
+                toStringResult shouldContain "BusinessException"
+                toStringResult shouldContain "CUSTOM_ERROR"
+                toStringResult shouldContain "커스텀 오류 메시지"
+            }
+        }
+    }
+
+    given("BusinessException이 RuntimeException을 상속받는지 확인할 때") {
+        val exception = BusinessException("TEST_ERROR", "테스트")
+
+        `when`("타입을 확인하면") {
+            then("RuntimeException의 인스턴스이다") {
+                (exception is RuntimeException) shouldBe true
+            }
+        }
+    }
+
+    given("에러 코드가 null이 아닌지 확인할 때") {
+        val exception1 = BusinessException("기본 메시지")
+        val exception2 = BusinessException("CUSTOM_CODE", "커스텀 메시지")
+
+        `when`("에러 코드를 확인하면") {
+            then("모든 경우에 null이 아니다") {
+                exception1.errorCode shouldNotBe null
+                exception2.errorCode shouldNotBe null
+                exception1.errorCode shouldBe "BUSINESS_ERROR"
+                exception2.errorCode shouldBe "CUSTOM_CODE"
+            }
+        }
+    }
+})

--- a/libs/common-domain/src/test/kotlin/cloud/luigi99/blog/common/exception/DomainExceptionTest.kt
+++ b/libs/common-domain/src/test/kotlin/cloud/luigi99/blog/common/exception/DomainExceptionTest.kt
@@ -17,7 +17,7 @@ class DomainExceptionTest : BehaviorSpec({
         `when`("예외 정보를 확인하면") {
             then("메시지와 기본 에러 코드, Unknown 도메인 컨텍스트가 설정된다") {
                 exception.message shouldBe message
-                exception.errorCode shouldBe "DOMAIN_ERROR"
+                exception.errorCode shouldBe ErrorCode.COMMON_BUSINESS_ERROR.code
                 exception.domainContext shouldBe "Unknown"
             }
         }
@@ -32,14 +32,14 @@ class DomainExceptionTest : BehaviorSpec({
             then("도메인 컨텍스트와 메시지가 올바르게 설정된다") {
                 exception.domainContext shouldBe domainContext
                 exception.message shouldBe message
-                exception.errorCode shouldBe "DOMAIN_ERROR"
+                exception.errorCode shouldBe ErrorCode.COMMON_BUSINESS_ERROR.code
             }
         }
     }
 
     given("도메인별 에러 코드를 포함하여 DomainException을 생성할 때") {
         val domainContext = "Post"
-        val errorCode = "POST_INVALID_STATUS"
+        val errorCode = ErrorCode.POST_NOT_DRAFT.code
         val message = "포스트 상태가 유효하지 않습니다"
         val exception = DomainException(domainContext, errorCode, message)
 
@@ -54,7 +54,7 @@ class DomainExceptionTest : BehaviorSpec({
 
     given("포맷된 메시지로 DomainException을 생성할 때") {
         val domainContext = "Comment"
-        val errorCode = "COMMENT_TOO_LONG"
+        val errorCode = ErrorCode.VALIDATION_CONTENT_TOO_LONG.code
         val messageFormat = "댓글이 너무 깁니다. 최대 길이: %d, 현재 길이: %d"
         val maxLength = 500
         val currentLength = 600
@@ -72,14 +72,14 @@ class DomainExceptionTest : BehaviorSpec({
     }
 
     given("다른 DomainException을 기반으로 새 예외를 생성할 때") {
-        val originalException = DomainException("User", "USER_NOT_FOUND", "사용자를 찾을 수 없습니다")
+        val originalException = DomainException("User", ErrorCode.USER_NOT_FOUND.code, "사용자를 찾을 수 없습니다")
         val additionalMessage = "권한 검증 중 오류 발생"
         val newException = DomainException(originalException, additionalMessage)
 
         `when`("새 예외의 정보를 확인하면") {
             then("원본 예외의 정보와 추가 메시지가 합쳐진다") {
                 newException.domainContext shouldBe "User"
-                newException.errorCode shouldBe "USER_NOT_FOUND"
+                newException.errorCode shouldBe ErrorCode.USER_NOT_FOUND.code
                 newException.message shouldBe "사용자를 찾을 수 없습니다 - 권한 검증 중 오류 발생"
             }
         }
@@ -134,28 +134,13 @@ class DomainExceptionTest : BehaviorSpec({
     }
 
     given("상세한 에러 메시지를 확인할 때") {
-        val exception = DomainException("User", "AUTH_FAILED", "인증에 실패했습니다")
+        val exception = DomainException("User", ErrorCode.AUTH_INVALID_CREDENTIALS.code, "인증에 실패했습니다")
 
         `when`("getDetailedMessage를 호출하면") {
             val detailedMessage = exception.getDetailedMessage()
 
             then("도메인 컨텍스트, 에러 코드, 메시지를 포함한 문자열을 반환한다") {
-                detailedMessage shouldBe "[User:AUTH_FAILED] 인증에 실패했습니다"
-            }
-        }
-    }
-
-    given("toString 메서드를 테스트할 때") {
-        val exception = DomainException("Post", "INVALID_STATUS", "유효하지 않은 상태")
-
-        `when`("toString을 호출하면") {
-            val toStringResult = exception.toString()
-
-            then("클래스명, 도메인 컨텍스트, 에러 코드, 메시지를 포함한 문자열을 반환한다") {
-                toStringResult shouldContain "DomainException"
-                toStringResult shouldContain "Post"
-                toStringResult shouldContain "INVALID_STATUS"
-                toStringResult shouldContain "유효하지 않은 상태"
+                detailedMessage shouldBe "[User:${ErrorCode.AUTH_INVALID_CREDENTIALS.code}] 인증에 실패했습니다"
             }
         }
     }
@@ -167,7 +152,7 @@ class DomainExceptionTest : BehaviorSpec({
 
             then("엔티티를 찾을 수 없다는 예외가 생성된다") {
                 exception.domainContext shouldBe "User"
-                exception.errorCode shouldBe "ENTITY_NOT_FOUND"
+                exception.errorCode shouldBe ErrorCode.ENTITY_NOT_FOUND.code
                 exception.message shouldContain "User를 찾을 수 없습니다"
                 exception.message shouldContain entityId.toString()
             }
@@ -178,7 +163,7 @@ class DomainExceptionTest : BehaviorSpec({
 
             then("비즈니스 규칙 위반 예외가 생성된다") {
                 exception.domainContext shouldBe "Post"
-                exception.errorCode shouldBe "BUSINESS_RULE_VIOLATION"
+                exception.errorCode shouldBe ErrorCode.COMMON_BUSINESS_ERROR.code
                 exception.message shouldContain "Post 도메인의 '최소 제목 길이' 규칙이 위반되었습니다"
                 exception.message shouldContain "제목은 최소 5자 이상이어야 합니다"
             }
@@ -189,30 +174,42 @@ class DomainExceptionTest : BehaviorSpec({
 
             then("유효하지 않은 상태 전환 예외가 생성된다") {
                 exception.domainContext shouldBe "Post"
-                exception.errorCode shouldBe "INVALID_STATE_TRANSITION"
+                exception.errorCode shouldBe ErrorCode.STATE_INVALID_TRANSITION.code
                 exception.message shouldContain "DRAFT 상태에서 ARCHIVED 상태로 전환할 수 없습니다"
             }
         }
     }
 
-    given("DomainException이 BusinessException을 상속받는지 확인할 때") {
-        val exception = DomainException("Test", "테스트 오류")
+    given("DomainException이 BusinessException의 특성을 제대로 상속받았는지 확인할 때") {
+        val domainException = DomainException("User", ErrorCode.USER_NOT_FOUND.code, "사용자를 찾을 수 없습니다")
+        val businessException = BusinessException(ErrorCode.USER_NOT_FOUND.code, "사용자를 찾을 수 없습니다")
 
-        `when`("타입을 확인하면") {
-            then("BusinessException의 인스턴스이다") {
-                (exception is BusinessException) shouldBe true
+        `when`("동일한 에러 코드와 메시지로 생성된 예외들을 비교하면") {
+            then("BusinessException과 동일한 핵심 기능을 제공한다") {
+                domainException.errorCode shouldBe businessException.errorCode
+                domainException.message shouldBe businessException.message
+                domainException.hasErrorCode(ErrorCode.USER_NOT_FOUND.code) shouldBe businessException.hasErrorCode(ErrorCode.USER_NOT_FOUND.code)
+                domainException.getDetailedMessage() shouldContain ErrorCode.USER_NOT_FOUND.code
+            }
+        }
+
+        `when`("DomainException만의 고유 기능을 확인하면") {
+            then("도메인 컨텍스트라는 추가 정보를 제공한다") {
+                domainException.domainContext shouldBe "User"
+                domainException.isFromDomain("User") shouldBe true
+                domainException.getDetailedMessage() shouldContain "User:"
             }
         }
     }
 
     given("BusinessException의 기능을 상속받는지 확인할 때") {
-        val exception = DomainException("User", "USER_VALIDATION_ERROR", "사용자 유효성 검증 실패")
+        val exception = DomainException("User", ErrorCode.VALIDATION_INVALID_EMAIL.code, "사용자 유효성 검증 실패")
 
         `when`("부모 클래스의 메서드를 사용하면") {
             then("정상적으로 동작한다") {
-                exception.hasErrorCode("USER_VALIDATION_ERROR") shouldBe true
-                exception.hasAnyErrorCode("USER_ERROR", "USER_VALIDATION_ERROR") shouldBe true
-                exception.hasErrorCode("DIFFERENT_ERROR") shouldBe false
+                exception.hasErrorCode(ErrorCode.VALIDATION_INVALID_EMAIL.code) shouldBe true
+                exception.hasAnyErrorCode(ErrorCode.USER_NOT_FOUND.code, ErrorCode.VALIDATION_INVALID_EMAIL.code) shouldBe true
+                exception.hasErrorCode(ErrorCode.ENTITY_ALREADY_EXISTS.code) shouldBe false
             }
         }
     }

--- a/libs/common-domain/src/test/kotlin/cloud/luigi99/blog/common/exception/DomainExceptionTest.kt
+++ b/libs/common-domain/src/test/kotlin/cloud/luigi99/blog/common/exception/DomainExceptionTest.kt
@@ -1,0 +1,219 @@
+package cloud.luigi99.blog.common.exception
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.util.*
+
+/**
+ * DomainException의 행위를 검증하는 테스트
+ */
+class DomainExceptionTest : BehaviorSpec({
+
+    given("기본 생성자로 DomainException을 생성할 때") {
+        val message = "도메인 규칙이 위반되었습니다"
+        val exception = DomainException(message)
+
+        `when`("예외 정보를 확인하면") {
+            then("메시지와 기본 에러 코드, Unknown 도메인 컨텍스트가 설정된다") {
+                exception.message shouldBe message
+                exception.errorCode shouldBe "DOMAIN_ERROR"
+                exception.domainContext shouldBe "Unknown"
+            }
+        }
+    }
+
+    given("도메인 컨텍스트를 포함하여 DomainException을 생성할 때") {
+        val domainContext = "User"
+        val message = "사용자 도메인 규칙 위반"
+        val exception = DomainException(domainContext, message)
+
+        `when`("예외 정보를 확인하면") {
+            then("도메인 컨텍스트와 메시지가 올바르게 설정된다") {
+                exception.domainContext shouldBe domainContext
+                exception.message shouldBe message
+                exception.errorCode shouldBe "DOMAIN_ERROR"
+            }
+        }
+    }
+
+    given("도메인별 에러 코드를 포함하여 DomainException을 생성할 때") {
+        val domainContext = "Post"
+        val errorCode = "POST_INVALID_STATUS"
+        val message = "포스트 상태가 유효하지 않습니다"
+        val exception = DomainException(domainContext, errorCode, message)
+
+        `when`("예외 정보를 확인하면") {
+            then("커스텀 에러 코드와 도메인 컨텍스트가 설정된다") {
+                exception.domainContext shouldBe domainContext
+                exception.errorCode shouldBe errorCode
+                exception.message shouldBe message
+            }
+        }
+    }
+
+    given("포맷된 메시지로 DomainException을 생성할 때") {
+        val domainContext = "Comment"
+        val errorCode = "COMMENT_TOO_LONG"
+        val messageFormat = "댓글이 너무 깁니다. 최대 길이: %d, 현재 길이: %d"
+        val maxLength = 500
+        val currentLength = 600
+        val exception = DomainException(domainContext, errorCode, messageFormat, maxLength, currentLength)
+
+        `when`("예외 메시지를 확인하면") {
+            val expectedMessage = "댓글이 너무 깁니다. 최대 길이: 500, 현재 길이: 600"
+
+            then("포맷된 메시지가 생성된다") {
+                exception.message shouldBe expectedMessage
+                exception.domainContext shouldBe domainContext
+                exception.errorCode shouldBe errorCode
+            }
+        }
+    }
+
+    given("다른 DomainException을 기반으로 새 예외를 생성할 때") {
+        val originalException = DomainException("User", "USER_NOT_FOUND", "사용자를 찾을 수 없습니다")
+        val additionalMessage = "권한 검증 중 오류 발생"
+        val newException = DomainException(originalException, additionalMessage)
+
+        `when`("새 예외의 정보를 확인하면") {
+            then("원본 예외의 정보와 추가 메시지가 합쳐진다") {
+                newException.domainContext shouldBe "User"
+                newException.errorCode shouldBe "USER_NOT_FOUND"
+                newException.message shouldBe "사용자를 찾을 수 없습니다 - 권한 검증 중 오류 발생"
+            }
+        }
+    }
+
+    given("도메인 컨텍스트 확인 기능을 테스트할 때") {
+        val exception = DomainException("Post", "포스트 도메인 오류")
+
+        `when`("일치하는 도메인 컨텍스트로 확인하면") {
+            val isFromDomain = exception.isFromDomain("Post")
+
+            then("true를 반환한다") {
+                isFromDomain shouldBe true
+            }
+        }
+
+        `when`("대소문자가 다른 도메인 컨텍스트로 확인하면") {
+            val isFromDomain = exception.isFromDomain("post")
+
+            then("대소문자 무시하고 true를 반환한다") {
+                isFromDomain shouldBe true
+            }
+        }
+
+        `when`("일치하지 않는 도메인 컨텍스트로 확인하면") {
+            val isFromDomain = exception.isFromDomain("User")
+
+            then("false를 반환한다") {
+                isFromDomain shouldBe false
+            }
+        }
+    }
+
+    given("여러 도메인 컨텍스트 중 하나와 일치하는지 확인할 때") {
+        val exception = DomainException("Comment", "댓글 도메인 오류")
+
+        `when`("포함된 도메인 컨텍스트들로 확인하면") {
+            val isFromAnyDomain = exception.isFromAnyDomain("Post", "Comment", "User")
+
+            then("true를 반환한다") {
+                isFromAnyDomain shouldBe true
+            }
+        }
+
+        `when`("포함되지 않은 도메인 컨텍스트들로 확인하면") {
+            val isFromAnyDomain = exception.isFromAnyDomain("Post", "User", "Category")
+
+            then("false를 반환한다") {
+                isFromAnyDomain shouldBe false
+            }
+        }
+    }
+
+    given("상세한 에러 메시지를 확인할 때") {
+        val exception = DomainException("User", "AUTH_FAILED", "인증에 실패했습니다")
+
+        `when`("getDetailedMessage를 호출하면") {
+            val detailedMessage = exception.getDetailedMessage()
+
+            then("도메인 컨텍스트, 에러 코드, 메시지를 포함한 문자열을 반환한다") {
+                detailedMessage shouldBe "[User:AUTH_FAILED] 인증에 실패했습니다"
+            }
+        }
+    }
+
+    given("toString 메서드를 테스트할 때") {
+        val exception = DomainException("Post", "INVALID_STATUS", "유효하지 않은 상태")
+
+        `when`("toString을 호출하면") {
+            val toStringResult = exception.toString()
+
+            then("클래스명, 도메인 컨텍스트, 에러 코드, 메시지를 포함한 문자열을 반환한다") {
+                toStringResult shouldContain "DomainException"
+                toStringResult shouldContain "Post"
+                toStringResult shouldContain "INVALID_STATUS"
+                toStringResult shouldContain "유효하지 않은 상태"
+            }
+        }
+    }
+
+    given("companion object의 팩토리 메서드를 테스트할 때") {
+        `when`("entityNotFound로 예외를 생성하면") {
+            val entityId = UUID.randomUUID()
+            val exception = DomainException.entityNotFound("User", entityId)
+
+            then("엔티티를 찾을 수 없다는 예외가 생성된다") {
+                exception.domainContext shouldBe "User"
+                exception.errorCode shouldBe "ENTITY_NOT_FOUND"
+                exception.message shouldContain "User를 찾을 수 없습니다"
+                exception.message shouldContain entityId.toString()
+            }
+        }
+
+        `when`("businessRuleViolation으로 예외를 생성하면") {
+            val exception = DomainException.businessRuleViolation("Post", "최소 제목 길이", "제목은 최소 5자 이상이어야 합니다")
+
+            then("비즈니스 규칙 위반 예외가 생성된다") {
+                exception.domainContext shouldBe "Post"
+                exception.errorCode shouldBe "BUSINESS_RULE_VIOLATION"
+                exception.message shouldContain "Post 도메인의 '최소 제목 길이' 규칙이 위반되었습니다"
+                exception.message shouldContain "제목은 최소 5자 이상이어야 합니다"
+            }
+        }
+
+        `when`("invalidStateTransition으로 예외를 생성하면") {
+            val exception = DomainException.invalidStateTransition("Post", "DRAFT", "ARCHIVED")
+
+            then("유효하지 않은 상태 전환 예외가 생성된다") {
+                exception.domainContext shouldBe "Post"
+                exception.errorCode shouldBe "INVALID_STATE_TRANSITION"
+                exception.message shouldContain "DRAFT 상태에서 ARCHIVED 상태로 전환할 수 없습니다"
+            }
+        }
+    }
+
+    given("DomainException이 BusinessException을 상속받는지 확인할 때") {
+        val exception = DomainException("Test", "테스트 오류")
+
+        `when`("타입을 확인하면") {
+            then("BusinessException의 인스턴스이다") {
+                (exception is BusinessException) shouldBe true
+            }
+        }
+    }
+
+    given("BusinessException의 기능을 상속받는지 확인할 때") {
+        val exception = DomainException("User", "USER_VALIDATION_ERROR", "사용자 유효성 검증 실패")
+
+        `when`("부모 클래스의 메서드를 사용하면") {
+            then("정상적으로 동작한다") {
+                exception.hasErrorCode("USER_VALIDATION_ERROR") shouldBe true
+                exception.hasAnyErrorCode("USER_ERROR", "USER_VALIDATION_ERROR") shouldBe true
+                exception.hasErrorCode("DIFFERENT_ERROR") shouldBe false
+            }
+        }
+    }
+})

--- a/libs/common-domain/src/test/kotlin/cloud/luigi99/blog/common/exception/ErrorCodeTest.kt
+++ b/libs/common-domain/src/test/kotlin/cloud/luigi99/blog/common/exception/ErrorCodeTest.kt
@@ -1,0 +1,230 @@
+package cloud.luigi99.blog.common.exception
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * ErrorCode enum의 행위를 검증하는 테스트
+ */
+class ErrorCodeTest : BehaviorSpec({
+
+    given("ErrorCode enum이 정의되어 있을 때") {
+        `when`("모든 에러 코드를 조회하면") {
+            val allCodes = ErrorCode.getAllCodes()
+
+            then("정의된 모든 에러 코드가 반환된다") {
+                allCodes shouldHaveSize ErrorCode.entries.size
+                allCodes shouldContainAll listOf(
+                    "COMMON_BUSINESS_ERROR",
+                    "COMMON_INVALID_PARAMETER",
+                    "ENTITY_NOT_FOUND",
+                    "USER_NOT_FOUND",
+                    "POST_NOT_FOUND",
+                    "AUTH_UNAUTHENTICATED"
+                )
+            }
+        }
+
+        `when`("각 ErrorCode의 toString을 호출하면") {
+            val errorCode = ErrorCode.COMMON_BUSINESS_ERROR
+
+            then("code 값이 반환된다") {
+                errorCode.toString() shouldBe "COMMON_BUSINESS_ERROR"
+            }
+        }
+    }
+
+    given("유효한 에러 코드 문자열이 주어졌을 때") {
+        val validCode = "USER_NOT_FOUND"
+
+        `when`("fromCode 메서드를 호출하면") {
+            val result = ErrorCode.fromCode(validCode)
+
+            then("해당하는 ErrorCode를 반환한다") {
+                result shouldBe ErrorCode.USER_NOT_FOUND
+                result?.code shouldBe validCode
+                result?.description shouldBe "사용자를 찾을 수 없습니다"
+            }
+        }
+
+        `when`("fromCodeOrDefault 메서드를 호출하면") {
+            val result = ErrorCode.fromCodeOrDefault(validCode)
+
+            then("해당하는 ErrorCode를 반환한다") {
+                result shouldBe ErrorCode.USER_NOT_FOUND
+                result.code shouldBe validCode
+            }
+        }
+    }
+
+    given("유효하지 않은 에러 코드 문자열이 주어졌을 때") {
+        val invalidCode = "INVALID_ERROR_CODE"
+
+        `when`("fromCode 메서드를 호출하면") {
+            val result = ErrorCode.fromCode(invalidCode)
+
+            then("null을 반환한다") {
+                result shouldBe null
+            }
+        }
+
+        `when`("fromCodeOrDefault 메서드를 기본값 없이 호출하면") {
+            val result = ErrorCode.fromCodeOrDefault(invalidCode)
+
+            then("COMMON_BUSINESS_ERROR를 반환한다") {
+                result shouldBe ErrorCode.COMMON_BUSINESS_ERROR
+            }
+        }
+
+        `when`("fromCodeOrDefault 메서드를 커스텀 기본값과 함께 호출하면") {
+            val customDefault = ErrorCode.ENTITY_NOT_FOUND
+            val result = ErrorCode.fromCodeOrDefault(invalidCode, customDefault)
+
+            then("커스텀 기본값을 반환한다") {
+                result shouldBe customDefault
+            }
+        }
+    }
+
+    given("특정 접두사로 시작하는 에러 코드들이 있을 때") {
+        `when`("COMMON_ 접두사로 검색하면") {
+            val commonErrors = ErrorCode.getByPrefix("COMMON_")
+
+            then("COMMON_으로 시작하는 모든 에러 코드가 반환된다") {
+                commonErrors shouldContain ErrorCode.COMMON_BUSINESS_ERROR
+                commonErrors shouldContain ErrorCode.COMMON_INVALID_PARAMETER
+                commonErrors shouldContain ErrorCode.COMMON_INVALID_INPUT
+                commonErrors shouldContain ErrorCode.COMMON_REQUIRED_VALUE_MISSING
+                commonErrors shouldContain ErrorCode.COMMON_INTERNAL_SERVER_ERROR
+
+                commonErrors.forEach { errorCode ->
+                    errorCode.code.startsWith("COMMON_") shouldBe true
+                }
+            }
+        }
+
+        `when`("USER_ 접두사로 검색하면") {
+            val userErrors = ErrorCode.getByPrefix("USER_")
+
+            then("USER_로 시작하는 모든 에러 코드가 반환된다") {
+                userErrors shouldContain ErrorCode.USER_NOT_FOUND
+                userErrors shouldContain ErrorCode.USER_ALREADY_EXISTS
+                userErrors shouldContain ErrorCode.USER_EMAIL_DUPLICATE
+                userErrors shouldContain ErrorCode.USER_DEACTIVATED
+
+                userErrors.forEach { errorCode ->
+                    errorCode.code.startsWith("USER_") shouldBe true
+                }
+            }
+        }
+
+        `when`("존재하지 않는 접두사로 검색하면") {
+            val nonExistentErrors = ErrorCode.getByPrefix("NONEXISTENT_")
+
+            then("빈 리스트가 반환된다") {
+                nonExistentErrors shouldHaveSize 0
+            }
+        }
+
+        `when`("빈 접두사로 검색하면") {
+            val allErrors = ErrorCode.getByPrefix("")
+
+            then("모든 에러 코드가 반환된다") {
+                allErrors shouldHaveSize ErrorCode.entries.size
+            }
+        }
+    }
+
+    given("각 ErrorCode의 프로퍼티를 검증할 때") {
+        `when`("VALIDATION_INVALID_EMAIL을 확인하면") {
+            val errorCode = ErrorCode.VALIDATION_INVALID_EMAIL
+
+            then("올바른 code와 description을 가진다") {
+                errorCode.code shouldBe "VALIDATION_INVALID_EMAIL"
+                errorCode.description shouldBe "이메일 형식이 올바르지 않습니다"
+            }
+        }
+
+        `when`("POST_ALREADY_PUBLISHED를 확인하면") {
+            val errorCode = ErrorCode.POST_ALREADY_PUBLISHED
+
+            then("올바른 code와 description을 가진다") {
+                errorCode.code shouldBe "POST_ALREADY_PUBLISHED"
+                errorCode.description shouldBe "이미 발행된 포스트입니다"
+            }
+        }
+
+        `when`("AUTH_TOKEN_EXPIRED를 확인하면") {
+            val errorCode = ErrorCode.AUTH_TOKEN_EXPIRED
+
+            then("올바른 code와 description을 가진다") {
+                errorCode.code shouldBe "AUTH_TOKEN_EXPIRED"
+                errorCode.description shouldBe "인증 토큰이 만료되었습니다"
+            }
+        }
+    }
+
+    given("에러 코드 카테고리별 검증") {
+        `when`("인증 관련 에러 코드들을 확인하면") {
+            val authErrors = ErrorCode.getByPrefix("AUTH_")
+
+            then("모든 인증 에러 코드가 포함된다") {
+                authErrors shouldContain ErrorCode.AUTH_UNAUTHENTICATED
+                authErrors shouldContain ErrorCode.AUTH_UNAUTHORIZED
+                authErrors shouldContain ErrorCode.AUTH_INVALID_CREDENTIALS
+                authErrors shouldContain ErrorCode.AUTH_TOKEN_EXPIRED
+                authErrors shouldContain ErrorCode.AUTH_INVALID_TOKEN
+            }
+        }
+
+        `when`("엔티티 관련 에러 코드들을 확인하면") {
+            val entityErrors = ErrorCode.getByPrefix("ENTITY_")
+
+            then("모든 엔티티 에러 코드가 포함된다") {
+                entityErrors shouldContain ErrorCode.ENTITY_NOT_FOUND
+                entityErrors shouldContain ErrorCode.ENTITY_ALREADY_EXISTS
+                entityErrors shouldContain ErrorCode.ENTITY_CREATION_FAILED
+                entityErrors shouldContain ErrorCode.ENTITY_UPDATE_FAILED
+                entityErrors shouldContain ErrorCode.ENTITY_DELETE_FAILED
+            }
+        }
+
+        `when`("검증 관련 에러 코드들을 확인하면") {
+            val validationErrors = ErrorCode.getByPrefix("VALIDATION_")
+
+            then("모든 검증 에러 코드가 포함된다") {
+                validationErrors shouldContain ErrorCode.VALIDATION_INVALID_EMAIL
+                validationErrors shouldContain ErrorCode.VALIDATION_INVALID_PASSWORD
+                validationErrors shouldContain ErrorCode.VALIDATION_TITLE_TOO_LONG
+                validationErrors shouldContain ErrorCode.VALIDATION_CONTENT_TOO_LONG
+                validationErrors shouldContain ErrorCode.VALIDATION_TOO_MANY_TAGS
+            }
+        }
+    }
+
+    given("에러 코드의 고유성 검증") {
+        `when`("모든 에러 코드를 확인하면") {
+            val allCodes = ErrorCode.entries.map { it.code }
+            val uniqueCodes = allCodes.toSet()
+
+            then("모든 코드가 고유하다") {
+                allCodes.size shouldBe uniqueCodes.size
+            }
+        }
+
+        `when`("두 개의 서로 다른 ErrorCode를 비교하면") {
+            val error1 = ErrorCode.USER_NOT_FOUND
+            val error2 = ErrorCode.POST_NOT_FOUND
+
+            then("서로 다른 객체다") {
+                error1 shouldNotBe error2
+                error1.code shouldNotBe error2.code
+                error1.description shouldNotBe error2.description
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 작업 내용 요약 (Summary)
<!-- 이 PR에서 변경된 내용을 간략하게 설명하세요 -->

- **기본 도메인 추상화 컴포넌트 완전 구현**: AggregateRoot, BaseEntity, DomainEvent, ValueObject에 대한 포괄적인 기능 확장 및 문서화 완료
- **예외 처리 시스템 고도화**: BusinessException, DomainException에 상세한 에러 코드 관리 및 컨텍스트 지원 추가
- **표준화된 에러 코드 체계 도입**: 312개 표준 에러 코드가 정의된 ErrorCode enum으로 일관된 에러 처리 지원
- **BaseDomainEvent 추상 구현체 제공**: 도메인 이벤트 생성을 위한 빌더 패턴과 편의 메서드 포함
- **포괄적인 테스트 커버리지 달성**: 모든 핵심 컴포넌트에 대한 단위 테스트 구현으로 80% 이상 코드 커버리지 확보
- **Kotest 테스트 프레임워크 도입**: 더 표현력 있는 테스트 작성을 위한 Kotlin 전용 테스트 프레임워크 적용

### 관련 이슈
<!-- 관련된 GitHub 이슈를 연결하세요 (예: Closes #123, Fixes #456) -->

- Closes #29

### 변경사항 유형
<!-- 해당하는 항목에 x를 표시하세요 -->
- [ ] 🐛 버그 수정 (Bug fix)
- [x] ✨ 새로운 기능 (New feature)
- [ ] 💥 주요 변경사항 (Breaking change)
- [ ] 📝 문서 업데이트 (Documentation update)
- [ ] 🎨 코드 스타일 개선 (Code style improvement)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] ⚡️ 성능 개선 (Performance improvement)
- [ ] 🔧 설정 변경 (Configuration change)
- [ ] 🏗️ 인프라 변경 (Infrastructure change)

### 단위 테스트
- [x] 새로운 코드에 대한 단위 테스트 작성 완료
- [x] 기존 테스트 케이스 업데이트 완료
- [x] 테스트 커버리지 80% 이상 유지

## 주의사항 (Attention Required)
<!-- 리뷰어가 특히 주의 깊게 봐야 할 부분이나 알려야 할 사항 -->

- **ErrorCode enum 규모**: 312개의 표준 에러 코드 정의로 향후 모든 도메인에서 일관된 에러 처리 기반 마련
- **도메인 이벤트 관리**: AggregateRoot의 이벤트 관리 로직이 헥사고날 아키텍처의 도메인 이벤트 발행 패턴과 일치하는지 확인 필요
- **Kotest 프레임워크 도입**: 기존 JUnit에서 Kotest로 전환하여 Kotlin 친화적인 테스트 코드 작성 방식 적용
- **Value Object 불변성**: ValueObject 구현체들의 불변성 보장과 적절한 equals/hashCode 구현 확인 필요

---

### 리뷰어 체크리스트 (Reviewer Checklist)
<!-- 리뷰어를 위한 체크리스트 -->
- [ ] 코드 로직이 올바른지 확인
- [ ] 테스트 케이스가 충분한지 확인
- [ ] 성능에 부정적인 영향이 없는지 확인
- [ ] 보안 취약점이 없는지 확인
- [ ] Breaking change에 대한 적절한 처리가 되었는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 표준 도메인 이벤트 체계 도입(인터페이스·베이스 이벤트) 및 집계 루트의 이벤트 관리 API 강화
  - 엔티티 동등성·해시·toString 개선, 값 객체의 toString·검증 헬퍼 추가
  - 에러 코드 시스템 도입 및 비즈니스/도메인 예외 확장(에러코드, 도메인 컨텍스트, 상세 메시지, 팩토리)
- Tests
  - Kotest 기반 단위 테스트 대거 추가로 도메인·예외·에러코드 검증 강화
- Chores
  - 테스트 프레임워크 전환 및 커버리지 검증 기준을 무조건 80%로 상향 조정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->