### PR TITLE
feat: libs/adapter 모듈 구현

### DIFF
--- a/libs/adapter/message/spring/build.gradle.kts
+++ b/libs/adapter/message/spring/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    springBootConventions
+}
+
+dependencies {
+    implementation(project(":libs:common"))
+}

--- a/libs/adapter/message/spring/src/main/kotlin/cloud/luigi99/blog/adapter/message/spring/EventConfiguration.kt
+++ b/libs/adapter/message/spring/src/main/kotlin/cloud/luigi99/blog/adapter/message/spring/EventConfiguration.kt
@@ -1,0 +1,18 @@
+package cloud.luigi99.blog.adapter.message.spring
+
+import cloud.luigi99.blog.common.application.port.out.EventContextManager
+import cloud.luigi99.blog.common.domain.event.EventManager
+import jakarta.annotation.PostConstruct
+import mu.KotlinLogging
+import org.springframework.context.annotation.Configuration
+
+private val log = KotlinLogging.logger {}
+
+@Configuration
+class EventConfiguration(private val eventContextManager: EventContextManager) {
+    @PostConstruct
+    fun init() {
+        log.info { "Initializing EventManager with SpringEventContextManager" }
+        EventManager.eventContextManager = eventContextManager
+    }
+}

--- a/libs/adapter/message/spring/src/main/kotlin/cloud/luigi99/blog/adapter/message/spring/SpringDomainEventPublisher.kt
+++ b/libs/adapter/message/spring/src/main/kotlin/cloud/luigi99/blog/adapter/message/spring/SpringDomainEventPublisher.kt
@@ -1,0 +1,17 @@
+package cloud.luigi99.blog.adapter.message.spring
+
+import cloud.luigi99.blog.common.application.port.out.DomainEventPublisher
+import cloud.luigi99.blog.common.domain.event.DomainEvent
+import mu.KotlinLogging
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+private val log = KotlinLogging.logger {}
+
+@Component
+class SpringDomainEventPublisher(private val eventPublisher: ApplicationEventPublisher) : DomainEventPublisher {
+    override fun publish(event: DomainEvent) {
+        log.debug { "Publishing event: ${event::class.simpleName}" }
+        eventPublisher.publishEvent(event)
+    }
+}

--- a/libs/adapter/message/spring/src/main/kotlin/cloud/luigi99/blog/adapter/message/spring/SpringEventContextManager.kt
+++ b/libs/adapter/message/spring/src/main/kotlin/cloud/luigi99/blog/adapter/message/spring/SpringEventContextManager.kt
@@ -1,0 +1,30 @@
+package cloud.luigi99.blog.adapter.message.spring
+
+import cloud.luigi99.blog.common.application.port.out.EventContextManager
+import cloud.luigi99.blog.common.domain.event.DomainEvent
+import mu.KotlinLogging
+import org.springframework.stereotype.Component
+
+private val log = KotlinLogging.logger {}
+
+@Component
+class SpringEventContextManager : EventContextManager {
+    private val events = ThreadLocal.withInitial { mutableListOf<DomainEvent>() }
+
+    override fun add(event: DomainEvent) {
+        events.get().add(event)
+        log.debug { "Added domain event: ${event::class.simpleName}" }
+    }
+
+    override fun clear() {
+        events.get().clear()
+        events.remove()
+        log.debug { "Cleared domain events for current thread" }
+    }
+
+    override fun getDomainEventsAndClear(): List<DomainEvent> {
+        val eventList = events.get().toList()
+        clear()
+        return eventList
+    }
+}

--- a/libs/adapter/persistence/jpa/build.gradle.kts
+++ b/libs/adapter/persistence/jpa/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    springBootConventions
+}
+
+dependencies {
+    implementation(project(":libs:common"))
+    implementation(libs.spring.boot.starter.data.jpa)
+}

--- a/libs/adapter/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/adapter/persistence/jpa/JpaAggregateRoot.kt
+++ b/libs/adapter/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/adapter/persistence/jpa/JpaAggregateRoot.kt
@@ -1,0 +1,30 @@
+package cloud.luigi99.blog.adapter.persistence.jpa
+
+import cloud.luigi99.blog.common.domain.AggregateRoot
+import cloud.luigi99.blog.common.domain.ValueObject
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.domain.Persistable
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class JpaAggregateRoot<ID : ValueObject> :
+    AggregateRoot<ID>(),
+    Persistable<ID> {
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    override var createdAt: LocalDateTime? = null
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    override var updatedAt: LocalDateTime? = null
+
+    override fun isNew(): Boolean = createdAt == null
+
+    override fun getId(): ID = entityId
+}

--- a/libs/adapter/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/adapter/persistence/jpa/JpaConfig.kt
+++ b/libs/adapter/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/adapter/persistence/jpa/JpaConfig.kt
@@ -1,0 +1,20 @@
+package cloud.luigi99.blog.adapter.persistence.jpa
+
+import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+
+@Configuration
+@EnableJpaAuditing
+@EnableJpaRepositories(
+    basePackages = [
+        "cloud.luigi99.blog",
+    ],
+)
+@EntityScan(
+    basePackages = [
+        "cloud.luigi99.blog",
+    ],
+)
+class JpaConfig

--- a/libs/adapter/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/adapter/persistence/jpa/JpaDomainEntity.kt
+++ b/libs/adapter/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/adapter/persistence/jpa/JpaDomainEntity.kt
@@ -1,0 +1,30 @@
+package cloud.luigi99.blog.adapter.persistence.jpa
+
+import cloud.luigi99.blog.common.domain.DomainEntity
+import cloud.luigi99.blog.common.domain.ValueObject
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.domain.Persistable
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class JpaDomainEntity<ID : ValueObject> :
+    DomainEntity<ID>(),
+    Persistable<ID> {
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    override var createdAt: LocalDateTime? = null
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    override var updatedAt: LocalDateTime? = null
+
+    override fun isNew(): Boolean = createdAt == null
+
+    override fun getId(): ID = entityId
+}

--- a/libs/adapter/persistence/redis/build.gradle.kts
+++ b/libs/adapter/persistence/redis/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    springBootConventions
+}
+
+dependencies {
+    implementation(project(":libs:common"))
+    implementation(libs.bundles.redis)
+}

--- a/libs/adapter/persistence/redis/src/main/kotlin/cloud/luigi99/blog/adapter/persistence/redis/RedisConfig.kt
+++ b/libs/adapter/persistence/redis/src/main/kotlin/cloud/luigi99/blog/adapter/persistence/redis/RedisConfig.kt
@@ -1,0 +1,24 @@
+package cloud.luigi99.blog.adapter.persistence.redis
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+@Configuration
+@EnableRedisRepositories(basePackages = ["cloud.luigi99.blog"])
+class RedisConfig {
+    @Bean
+    fun redisTemplate(connectionFactory: RedisConnectionFactory): RedisTemplate<String, Any> {
+        val template = RedisTemplate<String, Any>()
+        template.connectionFactory = connectionFactory
+        template.keySerializer = StringRedisSerializer()
+        template.valueSerializer = GenericJackson2JsonRedisSerializer()
+        template.hashKeySerializer = StringRedisSerializer()
+        template.hashValueSerializer = GenericJackson2JsonRedisSerializer()
+        return template
+    }
+}

--- a/libs/adapter/persistence/redis/src/main/kotlin/cloud/luigi99/blog/adapter/persistence/redis/RedisDomainEntity.kt
+++ b/libs/adapter/persistence/redis/src/main/kotlin/cloud/luigi99/blog/adapter/persistence/redis/RedisDomainEntity.kt
@@ -1,0 +1,16 @@
+package cloud.luigi99.blog.adapter.persistence.redis
+
+import cloud.luigi99.blog.common.domain.DomainEntity
+import cloud.luigi99.blog.common.domain.ValueObject
+import org.springframework.data.redis.core.TimeToLive
+import java.time.LocalDateTime
+
+abstract class RedisDomainEntity<ID : ValueObject> : DomainEntity<ID>() {
+    @TimeToLive
+    var ttl: Long? = null
+
+    override var createdAt: LocalDateTime? = null
+    override var updatedAt: LocalDateTime? = null
+
+    fun getId(): ID = entityId
+}

--- a/libs/adapter/web/build.gradle.kts
+++ b/libs/adapter/web/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    springBootConventions
+}
+
+dependencies {
+    implementation(project(":libs:common"))
+    implementation(libs.bundles.spring.boot.web)
+}

--- a/libs/adapter/web/src/main/kotlin/cloud/luigi99/blog/adapter/web/CommonResponse.kt
+++ b/libs/adapter/web/src/main/kotlin/cloud/luigi99/blog/adapter/web/CommonResponse.kt
@@ -1,0 +1,34 @@
+package cloud.luigi99.blog.adapter.web
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.Instant
+
+@Schema(description = "공통 응답 객체")
+data class CommonResponse<T>(
+    @Schema(description = "성공 여부", example = "true")
+    val success: Boolean,
+    @Schema(description = "응답 데이터")
+    val data: T? = null,
+    @Schema(description = "에러 정보")
+    val error: ErrorDetail? = null,
+    @Schema(description = "응답 시간")
+    val timestamp: Instant = Instant.now(),
+) {
+    companion object {
+        fun <T> success(data: T): CommonResponse<T> = CommonResponse(success = true, data = data)
+
+        fun <T> error(code: String, message: String): CommonResponse<T> =
+            CommonResponse(
+                success = false,
+                error = ErrorDetail(code, message),
+            )
+    }
+
+    @Schema(description = "에러 상세 정보")
+    data class ErrorDetail(
+        @Schema(description = "에러 코드", example = "COMMON_001")
+        val code: String,
+        @Schema(description = "에러 메시지", example = "잘못된 요청입니다.")
+        val message: String,
+    )
+}


### PR DESCRIPTION
## 📋 개요
- 데이터 영속성과 API 응답을 처리하기 위한 여러 공통 어댑터의 기반을 구현했습니다.
- **JPA Persistence Adapter**: `JpaAggregateRoot`와 `JpaDomainEntity`를 추가하여 공통 엔티티 로직을 구현하고, `JpaConfig`로 JPA 설정을 구성했습니다.
- **Redis Persistence Adapter**: `RedisDomainEntity`와 `RedisConfig`를 추가하여 Redis 연동을 위한 기본 설정을 마련했습니다.
- **Web Adapter**: 모든 API에서 일관된 응답 형식을 제공하기 위해 `CommonResponse` 래퍼 객체를 구현했습니다.
- 각 어댑터 모듈에 필요한 Gradle 설정을 추가했습니다.

## 🔗 관련 이슈
- Closes #11

## ☑️ 체크리스트
- [ ] 코딩 컨벤션을 준수했나요? (`./gradlew ktlintCheck`)
- [ ] 모든 테스트를 통과했나요? (`./gradlew test`)
- [ ] 불필요한 주석이나 로그는 제거했나요?