### PR TITLE
feat: Member Adapter 모듈 구현

### DIFF
--- a/modules/member/adapter/in/web/build.gradle.kts
+++ b/modules/member/adapter/in/web/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    springBootConventions
+}
+
+dependencies {
+    implementation(project(":libs:common"))
+    implementation(project(":modules:member:domain"))
+    implementation(project(":modules:member:application"))
+    implementation(project(":libs:adapter:web"))
+
+    implementation(libs.bundles.spring.boot.web)
+    implementation(libs.bundles.spring.boot.security)
+
+    testImplementation(libs.bundles.kotlin.test)
+}

--- a/modules/member/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/member/adapter/in/web/member/MemberApi.kt
+++ b/modules/member/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/member/adapter/in/web/member/MemberApi.kt
@@ -1,0 +1,152 @@
+package cloud.luigi99.blog.member.adapter.`in`.web.member
+
+import cloud.luigi99.blog.adapter.web.dto.CommonResponse
+import cloud.luigi99.blog.member.adapter.`in`.web.member.dto.MemberResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+
+@Tag(name = "Member", description = "회원 정보 조회 API")
+interface MemberApi {
+    @Operation(
+        summary = "현재 로그인한 회원 정보 조회",
+        description = "JWT 토큰을 통해 인증된 현재 사용자의 기본 정보를 조회합니다.",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "회원 정보 조회 성공",
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "인증되지 않은 사용자",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "Unauthorized",
+                                value = """
+                        {
+                          "success": false,
+                          "data": null,
+                          "error": {
+                            "code": "AUTH_001",
+                            "message": "인증에 실패했습니다."
+                          },
+                          "timestamp": "2025-12-05T10:00:00Z"
+                        }
+                        """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "회원을 찾을 수 없음",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "MemberNotFound",
+                                value = """
+                        {
+                          "success": false,
+                          "data": null,
+                          "error": {
+                            "code": "MEMBER_001",
+                            "message": "회원을 찾을 수 없습니다."
+                          },
+                          "timestamp": "2025-12-05T10:00:00Z"
+                        }
+                        """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getCurrentMember(
+        @AuthenticationPrincipal memberId: String,
+    ): ResponseEntity<CommonResponse<MemberResponse>>
+
+    @Operation(
+        summary = "회원 탈퇴",
+        description = "현재 로그인한 회원의 계정을 탈퇴합니다. 회원과 관련된 모든 데이터가 삭제됩니다.",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "204",
+                description = "회원 탈퇴 성공",
+                content = [Content(schema = Schema(hidden = true))],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "인증되지 않은 사용자",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "Unauthorized",
+                                value = """
+                        {
+                          "success": false,
+                          "data": null,
+                          "error": {
+                            "code": "AUTH_001",
+                            "message": "인증에 실패했습니다."
+                          },
+                          "timestamp": "2025-12-10T12:00:00Z"
+                        }
+                        """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "회원을 찾을 수 없음",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "MemberNotFound",
+                                value = """
+                        {
+                          "success": false,
+                          "data": null,
+                          "error": {
+                            "code": "MEMBER_001",
+                            "message": "회원을 찾을 수 없습니다."
+                          },
+                          "timestamp": "2025-12-10T12:00:00Z"
+                        }
+                        """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun deleteMember(
+        @AuthenticationPrincipal memberId: String,
+    ): ResponseEntity<Unit>
+}

--- a/modules/member/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/member/adapter/in/web/member/MemberController.kt
+++ b/modules/member/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/member/adapter/in/web/member/MemberController.kt
@@ -1,0 +1,64 @@
+package cloud.luigi99.blog.member.adapter.`in`.web.member
+
+import cloud.luigi99.blog.adapter.web.dto.CommonResponse
+import cloud.luigi99.blog.member.adapter.`in`.web.member.dto.MemberResponse
+import cloud.luigi99.blog.member.application.member.port.`in`.command.DeleteMemberUseCase
+import cloud.luigi99.blog.member.application.member.port.`in`.command.MemberCommandFacade
+import cloud.luigi99.blog.member.application.member.port.`in`.query.GetCurrentMemberUseCase
+import cloud.luigi99.blog.member.application.member.port.`in`.query.MemberQueryFacade
+import mu.KotlinLogging
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 회원 컨트롤러
+ *
+ * 회원 정보 조회 및 회원 탈퇴 등 회원 관련 요청을 처리합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/members")
+class MemberController(
+    private val memberQueryFacade: MemberQueryFacade,
+    private val memberCommandFacade: MemberCommandFacade,
+) : MemberApi {
+    @GetMapping("/me")
+    override fun getCurrentMember(
+        @AuthenticationPrincipal memberId: String,
+    ): ResponseEntity<CommonResponse<MemberResponse>> {
+        log.info { "Getting current member info for: $memberId" }
+
+        val response =
+            memberQueryFacade.getCurrentMember().execute(
+                GetCurrentMemberUseCase.Query(memberId),
+            )
+
+        return ResponseEntity.ok(
+            CommonResponse.success(
+                MemberResponse(
+                    memberId = response.memberId,
+                    email = response.email,
+                    username = response.username,
+                ),
+            ),
+        )
+    }
+
+    @DeleteMapping
+    override fun deleteMember(
+        @AuthenticationPrincipal memberId: String,
+    ): ResponseEntity<Unit> {
+        log.info { "Deleting member: $memberId" }
+
+        memberCommandFacade.deleteMember().execute(
+            DeleteMemberUseCase.Command(memberId = memberId),
+        )
+
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/modules/member/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/member/adapter/in/web/member/dto/MemberResponse.kt
+++ b/modules/member/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/member/adapter/in/web/member/dto/MemberResponse.kt
@@ -1,0 +1,12 @@
+package cloud.luigi99.blog.member.adapter.`in`.web.member.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class MemberResponse(
+    @param:Schema(description = "회원 ID", example = "123e4567-e89b-12d3-a456-426614174000")
+    val memberId: String,
+    @param:Schema(description = "이메일", example = "user@example.com")
+    val email: String,
+    @param:Schema(description = "사용자 이름", example = "Luigi99")
+    val username: String,
+)

--- a/modules/member/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/member/adapter/in/web/profile/ProfileApi.kt
+++ b/modules/member/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/member/adapter/in/web/profile/ProfileApi.kt
@@ -1,0 +1,179 @@
+package cloud.luigi99.blog.member.adapter.`in`.web.profile
+
+import cloud.luigi99.blog.adapter.web.dto.CommonResponse
+import cloud.luigi99.blog.member.adapter.`in`.web.profile.dto.ProfileResponse
+import cloud.luigi99.blog.member.adapter.`in`.web.profile.dto.UpdateProfileRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.RequestBody
+
+@Tag(name = "Profile", description = "프로필 관리 API")
+interface ProfileApi {
+    @Operation(
+        summary = "프로필 조회",
+        description = "사용자의 프로필 정보를 조회합니다.",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "프로필 조회 성공",
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "인증되지 않은 사용자",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "Unauthorized",
+                                value = """
+                        {
+                          "success": false,
+                          "data": null,
+                          "error": {
+                            "code": "AUTH_001",
+                            "message": "인증에 실패했습니다."
+                          },
+                          "timestamp": "2025-12-05T10:00:00Z"
+                        }
+                        """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "프로필을 찾을 수 없음",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "ProfileNotFound",
+                                value = """
+                        {
+                          "success": false,
+                          "data": null,
+                          "error": {
+                            "code": "PROFILE_001",
+                            "message": "프로필을 찾을 수 없습니다."
+                          },
+                          "timestamp": "2025-12-05T10:00:00Z"
+                        }
+                        """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getProfile(
+        @AuthenticationPrincipal memberId: String,
+    ): ResponseEntity<CommonResponse<ProfileResponse>>
+
+    @Operation(
+        summary = "프로필 수정",
+        description = "현재 로그인한 사용자의 프로필 정보를 수정합니다.",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "프로필 수정 성공",
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 데이터",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "BadRequest",
+                                value = """
+                        {
+                          "success": false,
+                          "data": null,
+                          "error": {
+                            "code": "COMMON_001",
+                            "message": "잘못된 요청입니다."
+                          },
+                          "timestamp": "2025-12-05T10:00:00Z"
+                        }
+                        """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "인증되지 않은 사용자",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "Unauthorized",
+                                value = """
+                        {
+                          "success": false,
+                          "data": null,
+                          "error": {
+                            "code": "AUTH_001",
+                            "message": "인증에 실패했습니다."
+                          },
+                          "timestamp": "2025-12-05T10:00:00Z"
+                        }
+                        """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "프로필을 찾을 수 없음",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "ProfileNotFound",
+                                value = """
+                        {
+                          "success": false,
+                          "data": null,
+                          "error": {
+                            "code": "PROFILE_001",
+                            "message": "프로필을 찾을 수 없습니다."
+                          },
+                          "timestamp": "2025-12-05T10:00:00Z"
+                        }
+                        """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun updateProfile(
+        @AuthenticationPrincipal memberId: String,
+        @RequestBody request: UpdateProfileRequest,
+    ): ResponseEntity<CommonResponse<ProfileResponse>>
+}

--- a/modules/member/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/member/adapter/in/web/profile/ProfileController.kt
+++ b/modules/member/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/member/adapter/in/web/profile/ProfileController.kt
@@ -1,0 +1,100 @@
+package cloud.luigi99.blog.member.adapter.`in`.web.profile
+
+import cloud.luigi99.blog.adapter.web.dto.CommonResponse
+import cloud.luigi99.blog.member.adapter.`in`.web.profile.dto.ProfileResponse
+import cloud.luigi99.blog.member.adapter.`in`.web.profile.dto.UpdateProfileRequest
+import cloud.luigi99.blog.member.application.member.port.`in`.command.MemberCommandFacade
+import cloud.luigi99.blog.member.application.member.port.`in`.command.UpdateMemberProfileUseCase
+import cloud.luigi99.blog.member.application.member.port.`in`.query.GetMemberProfileUseCase
+import cloud.luigi99.blog.member.application.member.port.`in`.query.MemberQueryFacade
+import cloud.luigi99.blog.member.domain.profile.exception.ProfileException
+import mu.KotlinLogging
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+private val log = KotlinLogging.logger {}
+
+@RestController
+@RequestMapping("/api/v1/profile")
+class ProfileController(
+    private val memberQueryFacade: MemberQueryFacade,
+    private val memberCommandFacade: MemberCommandFacade,
+) : ProfileApi {
+    @GetMapping
+    override fun getProfile(
+        @AuthenticationPrincipal memberId: String,
+    ): ResponseEntity<CommonResponse<ProfileResponse>> {
+        log.info { "Getting profile for member: $memberId" }
+
+        val response =
+            memberQueryFacade.getMemberProfile().execute(
+                GetMemberProfileUseCase.Query(memberId = memberId),
+            )
+
+        val profile =
+            response.profile
+                ?: throw ProfileException("Profile not found for member: $memberId")
+
+        return ResponseEntity.ok(
+            CommonResponse.success(
+                ProfileResponse(
+                    profileId = profile.profileId,
+                    memberId = response.memberId,
+                    nickname = profile.nickname,
+                    bio = profile.bio,
+                    profileImageUrl = profile.profileImageUrl,
+                    jobTitle = profile.jobTitle,
+                    techStack = profile.techStack,
+                    githubUrl = profile.githubUrl,
+                    contactEmail = profile.contactEmail,
+                    websiteUrl = profile.websiteUrl,
+                ),
+            ),
+        )
+    }
+
+    @PutMapping
+    override fun updateProfile(
+        @AuthenticationPrincipal memberId: String,
+        @RequestBody request: UpdateProfileRequest,
+    ): ResponseEntity<CommonResponse<ProfileResponse>> {
+        log.info { "Updating profile for member: $memberId" }
+
+        val response =
+            memberCommandFacade.updateProfile().execute(
+                UpdateMemberProfileUseCase.Command(
+                    memberId = memberId,
+                    nickname = request.nickname,
+                    bio = request.bio,
+                    profileImageUrl = request.profileImageUrl,
+                    jobTitle = request.jobTitle,
+                    techStack = request.techStack,
+                    githubUrl = request.githubUrl,
+                    contactEmail = request.contactEmail,
+                    websiteUrl = request.websiteUrl,
+                ),
+            )
+
+        return ResponseEntity.ok(
+            CommonResponse.success(
+                ProfileResponse(
+                    profileId = response.profileId,
+                    memberId = memberId,
+                    nickname = response.nickname,
+                    bio = response.bio,
+                    profileImageUrl = response.profileImageUrl,
+                    jobTitle = response.jobTitle,
+                    techStack = response.techStack,
+                    githubUrl = response.githubUrl,
+                    contactEmail = response.contactEmail,
+                    websiteUrl = response.websiteUrl,
+                ),
+            ),
+        )
+    }
+}

--- a/modules/member/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/member/adapter/in/web/profile/dto/ProfileResponse.kt
+++ b/modules/member/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/member/adapter/in/web/profile/dto/ProfileResponse.kt
@@ -1,0 +1,26 @@
+package cloud.luigi99.blog.member.adapter.`in`.web.profile.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class ProfileResponse(
+    @param:Schema(description = "프로필 ID", example = "987fcdeb-51a2-43d1-b567-890123456789")
+    val profileId: String,
+    @param:Schema(description = "회원 ID", example = "123e4567-e89b-12d3-a456-426614174000")
+    val memberId: String,
+    @param:Schema(description = "닉네임", example = "CodingWizard")
+    val nickname: String,
+    @param:Schema(description = "자기소개", example = "안녕하세요, 백엔드 개발자입니다.")
+    val bio: String?,
+    @param:Schema(description = "프로필 이미지 URL", example = "https://example.com/images/profile.jpg")
+    val profileImageUrl: String?,
+    @param:Schema(description = "직업/직무", example = "Backend Developer")
+    val jobTitle: String?,
+    @param:Schema(description = "기술 스택", example = "[\"Kotlin\", \"Spring Boot\", \"JPA\"]")
+    val techStack: List<String>,
+    @param:Schema(description = "GitHub URL", example = "https://github.com/luigi99")
+    val githubUrl: String?,
+    @param:Schema(description = "연락처 이메일", example = "contact@luigi99.cloud")
+    val contactEmail: String?,
+    @param:Schema(description = "개인 웹사이트 URL", example = "https://luigi99.cloud")
+    val websiteUrl: String?,
+)

--- a/modules/member/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/member/adapter/in/web/profile/dto/UpdateProfileRequest.kt
+++ b/modules/member/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/member/adapter/in/web/profile/dto/UpdateProfileRequest.kt
@@ -1,0 +1,22 @@
+package cloud.luigi99.blog.member.adapter.`in`.web.profile.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class UpdateProfileRequest(
+    @param:Schema(description = "닉네임", example = "CodingMaster")
+    val nickname: String?,
+    @param:Schema(description = "자기소개", example = "새로운 소개글입니다.")
+    val bio: String?,
+    @param:Schema(description = "프로필 이미지 URL", example = "https://example.com/images/new_profile.jpg")
+    val profileImageUrl: String?,
+    @param:Schema(description = "직업/직무", example = "Full Stack Developer")
+    val jobTitle: String?,
+    @param:Schema(description = "기술 스택", example = "[\"Java\", \"React\", \"AWS\"]")
+    val techStack: List<String>?,
+    @param:Schema(description = "GitHub URL", example = "https://github.com/new-user")
+    val githubUrl: String?,
+    @param:Schema(description = "연락처 이메일", example = "new.email@example.com")
+    val contactEmail: String?,
+    @param:Schema(description = "개인 웹사이트 URL", example = "https://new-website.com")
+    val websiteUrl: String?,
+)

--- a/modules/member/adapter/out/persistence/jpa/build.gradle.kts
+++ b/modules/member/adapter/out/persistence/jpa/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    springBootConventions
+}
+
+dependencies {
+    implementation(project(":libs:common"))
+    implementation(project(":modules:member:domain"))
+    implementation(project(":modules:member:application"))
+    implementation(project(":libs:adapter:persistence:jpa"))
+    implementation(project(":libs:adapter:message:spring"))
+
+    implementation(libs.spring.boot.starter.data.jpa)
+
+    testImplementation(libs.bundles.kotlin.test)
+}

--- a/modules/member/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/member/MemberJpaEntity.kt
+++ b/modules/member/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/member/MemberJpaEntity.kt
@@ -1,0 +1,42 @@
+package cloud.luigi99.blog.member.adapter.out.persistence.jpa.member
+
+import cloud.luigi99.blog.adapter.persistence.jpa.JpaAggregateRoot
+import cloud.luigi99.blog.member.adapter.out.persistence.jpa.profile.ProfileJpaEntity
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+import org.hibernate.annotations.DynamicUpdate
+import java.util.UUID
+
+@Entity
+@Table(name = "member")
+@DynamicUpdate
+class MemberJpaEntity private constructor(
+    @Id
+    @Column(name = "id")
+    val id: UUID,
+    @Column(name = "email", nullable = false, unique = true)
+    val email: String,
+    @Column(name = "username", nullable = false, length = 100)
+    val username: String,
+    @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true)
+    @JoinColumn(name = "profile_id")
+    var profile: ProfileJpaEntity? = null,
+) : JpaAggregateRoot<MemberId>() {
+    override val entityId: MemberId
+        get() = MemberId(id)
+
+    companion object {
+        fun from(entityId: UUID, email: String, username: String): MemberJpaEntity =
+            MemberJpaEntity(
+                id = entityId,
+                email = email,
+                username = username,
+            )
+    }
+}

--- a/modules/member/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/member/MemberJpaRepository.kt
+++ b/modules/member/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/member/MemberJpaRepository.kt
@@ -1,0 +1,20 @@
+package cloud.luigi99.blog.member.adapter.out.persistence.jpa.member
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface MemberJpaRepository : JpaRepository<MemberJpaEntity, UUID> {
+    @Query("SELECT m FROM MemberJpaEntity m WHERE m.email = :email")
+    fun findByEmailValue(
+        @Param("email") email: String,
+    ): MemberJpaEntity?
+
+    @Query("SELECT COUNT(m) > 0 FROM MemberJpaEntity m WHERE m.email = :email")
+    fun existsByEmailValue(
+        @Param("email") email: String,
+    ): Boolean
+}

--- a/modules/member/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/member/MemberMapper.kt
+++ b/modules/member/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/member/MemberMapper.kt
@@ -1,0 +1,36 @@
+package cloud.luigi99.blog.member.adapter.out.persistence.jpa.member
+
+import cloud.luigi99.blog.member.adapter.out.persistence.jpa.profile.ProfileMapper
+import cloud.luigi99.blog.member.domain.member.model.Member
+import cloud.luigi99.blog.member.domain.member.vo.Email
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import cloud.luigi99.blog.member.domain.member.vo.Username
+
+object MemberMapper {
+    fun toDomain(entity: MemberJpaEntity): Member =
+        Member.from(
+            entityId = MemberId(entity.id),
+            email = Email(entity.email),
+            username = Username(entity.username),
+            profile = entity.profile?.let { ProfileMapper.toDomain(it) },
+            createdAt = entity.createdAt,
+            updatedAt = entity.updatedAt,
+        )
+
+    fun toEntity(member: Member): MemberJpaEntity {
+        val memberJpaEntity =
+            MemberJpaEntity
+                .from(
+                    entityId = member.entityId.value,
+                    email = member.email.value,
+                    username = member.username.value,
+                ).apply {
+                    createdAt = member.createdAt
+                    updatedAt = member.updatedAt
+                }
+
+        memberJpaEntity.profile = member.profile?.let { ProfileMapper.toEntity(it) }
+
+        return memberJpaEntity
+    }
+}

--- a/modules/member/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/member/MemberRepositoryAdapter.kt
+++ b/modules/member/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/member/MemberRepositoryAdapter.kt
@@ -1,0 +1,81 @@
+package cloud.luigi99.blog.member.adapter.out.persistence.jpa.member
+
+import cloud.luigi99.blog.common.application.port.out.DomainEventPublisher
+import cloud.luigi99.blog.common.application.port.out.EventContextManager
+import cloud.luigi99.blog.member.application.member.port.out.MemberRepository
+import cloud.luigi99.blog.member.domain.member.model.Member
+import cloud.luigi99.blog.member.domain.member.vo.Email
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import mu.KotlinLogging
+import org.springframework.stereotype.Repository
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 회원 저장소 어댑터 구현체
+ *
+ * JPA 리포지토리를 사용하여 회원 데이터를 영속화하고, 도메인 이벤트를 발행합니다.
+ */
+@Repository
+class MemberRepositoryAdapter(
+    private val jpaRepository: MemberJpaRepository,
+    private val eventContextManager: EventContextManager,
+    private val domainEventPublisher: DomainEventPublisher,
+) : MemberRepository {
+    /**
+     * 회원 엔티티를 저장합니다.
+     * 저장 후 누적된 도메인 이벤트를 발행합니다.
+     *
+     * @param entity 저장할 회원 엔티티
+     * @return 저장된 회원 엔티티
+     */
+    override fun save(entity: Member): Member {
+        log.debug { "Saving member: ${entity.entityId}" }
+
+        val memberJpaEntity = MemberMapper.toEntity(entity)
+        val saved = jpaRepository.save(memberJpaEntity)
+
+        val events = eventContextManager.getDomainEventsAndClear()
+        events.forEach { domainEventPublisher.publish(it) }
+
+        log.debug { "Successfully saved member: ${saved.entityId}" }
+        return MemberMapper.toDomain(saved)
+    }
+
+    /**
+     * ID로 회원을 조회합니다.
+     */
+    override fun findById(id: MemberId): Member? {
+        log.debug { "Finding member by ID: $id" }
+
+        return jpaRepository
+            .findById(id.value)
+            .map { MemberMapper.toDomain(it) }
+            .orElse(null)
+    }
+
+    /**
+     * 이메일로 회원을 조회합니다.
+     */
+    override fun findByEmail(email: Email): Member? {
+        log.debug { "Finding member by email: $email" }
+        return jpaRepository.findByEmailValue(email.value)?.let { MemberMapper.toDomain(it) }
+    }
+
+    /**
+     * 이메일 중복 여부를 확인합니다.
+     */
+    override fun existsByEmail(email: Email): Boolean {
+        log.debug { "Checking if member exists with email: $email" }
+        return jpaRepository.existsByEmailValue(email.value)
+    }
+
+    /**
+     * ID로 회원을 삭제합니다.
+     */
+    override fun deleteById(id: MemberId) {
+        log.debug { "Deleting member by ID: $id" }
+        jpaRepository.deleteById(id.value)
+        log.info { "Deleted member: $id" }
+    }
+}

--- a/modules/member/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/profile/ProfileJpaEntity.kt
+++ b/modules/member/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/profile/ProfileJpaEntity.kt
@@ -1,0 +1,66 @@
+package cloud.luigi99.blog.member.adapter.out.persistence.jpa.profile
+
+import cloud.luigi99.blog.adapter.persistence.jpa.JpaDomainEntity
+import cloud.luigi99.blog.member.domain.profile.vo.ProfileId
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.DynamicUpdate
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import java.util.UUID
+
+@Entity
+@Table(name = "profile")
+@DynamicUpdate
+class ProfileJpaEntity private constructor(
+    @Id
+    @Column(name = "id")
+    val id: UUID,
+    @Column(name = "nickname", nullable = false, length = 100)
+    val nickname: String,
+    @Column(name = "bio", length = 500)
+    val bio: String?,
+    @Column(name = "profile_image_url", length = 2000)
+    val profileImageUrl: String?,
+    @Column(name = "job_title", length = 100)
+    val jobTitle: String?,
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "tech_stack", columnDefinition = "JSON")
+    val techStack: List<String> = emptyList(),
+    @Column(name = "github_url", length = 500)
+    val githubUrl: String?,
+    @Column(name = "contact_email", length = 255)
+    val contactEmail: String?,
+    @Column(name = "website_url", length = 500)
+    val websiteUrl: String?,
+) : JpaDomainEntity<ProfileId>() {
+    override val entityId: ProfileId
+        get() = ProfileId(id)
+
+    companion object {
+        fun from(
+            entityId: UUID,
+            nickname: String,
+            bio: String?,
+            profileImageUrl: String?,
+            jobTitle: String?,
+            techStack: List<String>,
+            githubUrl: String?,
+            contactEmail: String?,
+            websiteUrl: String?,
+        ): ProfileJpaEntity =
+            ProfileJpaEntity(
+                id = entityId,
+                nickname = nickname,
+                bio = bio,
+                profileImageUrl = profileImageUrl,
+                jobTitle = jobTitle,
+                techStack = techStack,
+                githubUrl = githubUrl,
+                contactEmail = contactEmail,
+                websiteUrl = websiteUrl,
+            )
+    }
+}

--- a/modules/member/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/profile/ProfileMapper.kt
+++ b/modules/member/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/profile/ProfileMapper.kt
@@ -1,0 +1,47 @@
+package cloud.luigi99.blog.member.adapter.out.persistence.jpa.profile
+
+import cloud.luigi99.blog.member.domain.profile.model.Profile
+import cloud.luigi99.blog.member.domain.profile.vo.Bio
+import cloud.luigi99.blog.member.domain.profile.vo.ContactEmail
+import cloud.luigi99.blog.member.domain.profile.vo.JobTitle
+import cloud.luigi99.blog.member.domain.profile.vo.Nickname
+import cloud.luigi99.blog.member.domain.profile.vo.TechStack
+import cloud.luigi99.blog.member.domain.profile.vo.Url
+
+object ProfileMapper {
+    fun toDomain(entity: ProfileJpaEntity): Profile =
+        Profile.from(
+            entityId = entity.entityId,
+            nickname = Nickname(entity.nickname),
+            bio = entity.bio?.let { Bio(it) },
+            profileImageUrl = entity.profileImageUrl?.let { Url(it) },
+            jobTitle = entity.jobTitle?.let { JobTitle(it) },
+            techStack = TechStack(entity.techStack),
+            githubUrl = entity.githubUrl?.let { Url(it) },
+            contactEmail = entity.contactEmail?.let { ContactEmail(it) },
+            websiteUrl = entity.websiteUrl?.let { Url(it) },
+            createdAt = entity.createdAt,
+            updatedAt = entity.updatedAt,
+        )
+
+    fun toEntity(domain: Profile): ProfileJpaEntity {
+        val profileEntity =
+            ProfileJpaEntity
+                .from(
+                    entityId = domain.entityId.value,
+                    nickname = domain.nickname.value,
+                    bio = domain.bio?.value,
+                    profileImageUrl = domain.profileImageUrl?.value,
+                    jobTitle = domain.jobTitle?.value,
+                    techStack = domain.techStack.values,
+                    githubUrl = domain.githubUrl?.value,
+                    contactEmail = domain.contactEmail?.value,
+                    websiteUrl = domain.websiteUrl?.value,
+                ).apply {
+                    this.createdAt = domain.createdAt
+                    this.updatedAt = domain.updatedAt
+                }
+
+        return profileEntity
+    }
+}


### PR DESCRIPTION
## 📋 개요
- 회원 및 프로필 JPA Persistence Adapter 구현
  - `ProfileJpaEntity`, `MemberJpaEntity` 및 관련 Mapper 추가
  - 저장소 어댑터 구현으로 저장, 조회, 삭제 로직 처리
  - 도메인 이벤트 발행 기능 포함
- 회원 및 프로필 API 엔드포인트 추가
  - 프로필 조회 (`GET /api/v1/profile`) 및 수정 (`PUT /api/v1/profile`) API
  - 회원 조회 (`GET /api/v1/members/me`) 및 탈퇴 (`DELETE /api/v1/members`) API
  - Swagger 문서화, 예시 응답, 데이터 클래스 추가
- 모듈 초기 설정:
  - Persistence 및 Web Adapter 관련 `build.gradle.kts` 설정 파일 생성
  - 필요한 의존성 추가 (JPA, Spring Boot Web/Security, Kotlin Test 등)

## 🔗 관련 이슈
- Closes #26

## ☑️ 체크리스트
- [ ] 코딩 컨벤션을 준수했나요? (`./gradlew ktlintCheck`)
- [ ] 모든 테스트를 통과했나요? (`./gradlew test`)
- [ ] 불필요한 주석이나 로그는 제거했나요?