### PR TITLE
feat: Auth Credentials Domain 모듈 구현

### DIFF
--- a/modules/auth/credentials/domain/build.gradle.kts
+++ b/modules/auth/credentials/domain/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    conventions
+    `java-library`
+}
+
+dependencies {
+    api(project(":libs:common"))
+    api(project(":modules:member:domain"))
+    testImplementation(libs.bundles.kotlin.test)
+}

--- a/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/enums/OAuthProvider.kt
+++ b/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/enums/OAuthProvider.kt
@@ -1,0 +1,15 @@
+package cloud.luigi99.blog.auth.credentials.domain.enums
+
+enum class OAuthProvider {
+    GITHUB,
+    ;
+
+    companion object {
+        fun from(value: String): OAuthProvider =
+            try {
+                valueOf(value.uppercase())
+            } catch (e: IllegalArgumentException) {
+                throw IllegalArgumentException("Unsupported OAuth provider: $value", e)
+            }
+    }
+}

--- a/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/enums/Role.kt
+++ b/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/enums/Role.kt
@@ -1,0 +1,14 @@
+package cloud.luigi99.blog.auth.credentials.domain.enums
+
+enum class Role {
+    USER,
+    ADMIN,
+    ;
+
+    val authority: String
+        get() = "ROLE_$name"
+
+    companion object {
+        fun getDefault(): Role = USER
+    }
+}

--- a/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/event/MemberLoggedInEvent.kt
+++ b/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/event/MemberLoggedInEvent.kt
@@ -1,0 +1,6 @@
+package cloud.luigi99.blog.auth.credentials.domain.event
+
+import cloud.luigi99.blog.common.domain.event.DomainEvent
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+
+data class MemberLoggedInEvent(val memberId: MemberId) : DomainEvent

--- a/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/exception/MemberCredentialsException.kt
+++ b/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/exception/MemberCredentialsException.kt
@@ -1,0 +1,7 @@
+package cloud.luigi99.blog.auth.credentials.domain.exception
+
+import cloud.luigi99.blog.common.exception.BusinessException
+import cloud.luigi99.blog.common.exception.ErrorCode
+
+class MemberCredentialsException(message: String = "Member credentials not found") :
+    BusinessException(ErrorCode.CREDENTIAL_NOT_FOUND, message)

--- a/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/model/MemberCredentials.kt
+++ b/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/model/MemberCredentials.kt
@@ -1,0 +1,59 @@
+package cloud.luigi99.blog.auth.credentials.domain.model
+
+import cloud.luigi99.blog.auth.credentials.domain.enums.Role
+import cloud.luigi99.blog.auth.credentials.domain.event.MemberLoggedInEvent
+import cloud.luigi99.blog.auth.credentials.domain.vo.CredentialsId
+import cloud.luigi99.blog.auth.credentials.domain.vo.LastLoginTime
+import cloud.luigi99.blog.auth.credentials.domain.vo.OAuthInfo
+import cloud.luigi99.blog.common.domain.AggregateRoot
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import java.time.LocalDateTime
+
+class MemberCredentials private constructor(
+    override val entityId: CredentialsId,
+    val memberId: MemberId,
+    val oauthInfo: OAuthInfo,
+    var role: Role,
+    var lastLoginAt: LastLoginTime? = null,
+) : AggregateRoot<CredentialsId>() {
+    fun updateLastLogin() {
+        this.lastLoginAt = LastLoginTime.now()
+        this.registerEvent(MemberLoggedInEvent(this.memberId))
+    }
+
+    fun updateRole(newRole: Role) {
+        this.role = newRole
+    }
+
+    companion object {
+        fun create(memberId: MemberId, oauthInfo: OAuthInfo): MemberCredentials =
+            MemberCredentials(
+                entityId = CredentialsId.generate(),
+                memberId = memberId,
+                oauthInfo = oauthInfo,
+                role = Role.getDefault(),
+            )
+
+        fun from(
+            entityId: CredentialsId,
+            memberId: MemberId,
+            oauthInfo: OAuthInfo,
+            role: Role,
+            lastLoginAt: LastLoginTime?,
+            createdAt: LocalDateTime?,
+            updatedAt: LocalDateTime?,
+        ): MemberCredentials {
+            val credentials =
+                MemberCredentials(
+                    entityId = entityId,
+                    memberId = memberId,
+                    oauthInfo = oauthInfo,
+                    role = role,
+                    lastLoginAt = lastLoginAt,
+                )
+            credentials.createdAt = createdAt
+            credentials.updatedAt = updatedAt
+            return credentials
+        }
+    }
+}

--- a/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/vo/CredentialsId.kt
+++ b/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/vo/CredentialsId.kt
@@ -1,0 +1,18 @@
+package cloud.luigi99.blog.auth.credentials.domain.vo
+
+import cloud.luigi99.blog.common.domain.ValueObject
+import java.io.Serializable
+import java.util.UUID
+
+@JvmInline
+value class CredentialsId(val value: UUID) :
+    ValueObject,
+    Serializable {
+    companion object {
+        fun generate(): CredentialsId = CredentialsId(UUID.randomUUID())
+
+        fun from(value: String): CredentialsId = CredentialsId(UUID.fromString(value))
+    }
+
+    override fun toString(): String = value.toString()
+}

--- a/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/vo/LastLoginTime.kt
+++ b/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/vo/LastLoginTime.kt
@@ -1,0 +1,10 @@
+package cloud.luigi99.blog.auth.credentials.domain.vo
+
+import cloud.luigi99.blog.common.domain.ValueObject
+import java.time.LocalDateTime
+
+data class LastLoginTime(val value: LocalDateTime) : ValueObject {
+    companion object {
+        fun now(): LastLoginTime = LastLoginTime(LocalDateTime.now())
+    }
+}

--- a/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/vo/OAuthInfo.kt
+++ b/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/vo/OAuthInfo.kt
@@ -1,0 +1,15 @@
+package cloud.luigi99.blog.auth.credentials.domain.vo
+
+import cloud.luigi99.blog.auth.credentials.domain.enums.OAuthProvider
+import cloud.luigi99.blog.common.domain.ValueObject
+
+data class OAuthInfo(val provider: OAuthProvider, val providerId: String) : ValueObject {
+    init {
+        require(
+            OAuthProvider.entries
+                .toTypedArray()
+                .contains(provider),
+        ) { "Invalid OAuth provider: $provider" }
+        require(providerId.isNotBlank()) { "Provider ID cannot be blank" }
+    }
+}


### PR DESCRIPTION
## 📋 개요
- 인증 모듈의 도메인 모델을 구현하고 Gradle 빌드 스크립트를 설정합니다.
  - `OAuthProvider` 및 `Role` 열거형 추가
  - 도메인 이벤트 `MemberLoggedInEvent` 정의
  - `MemberCredentials`와 관련된 값 객체(`CredentialsId`, `LastLoginTime`, `OAuthInfo`) 구현
  - `MemberCredentialsException` 예외 클래스 추가
  - 인증 모듈의 Gradle 빌드 스크립트 생성 및 의존성 설정

## 🔗 관련 이슈
- Closes #29

## ☑️ 체크리스트
- [ ] 코딩 컨벤션을 준수했나요? (`./gradlew ktlintCheck`)
- [ ] 모든 테스트를 통과했나요? (`./gradlew test`)
- [ ] 불필요한 주석이나 로그는 제거했나요?