### PR TITLE
feat: Auth Credentials Application 모듈 구현

### DIFF
--- a/modules/auth/credentials/application/build.gradle.kts
+++ b/modules/auth/credentials/application/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    springBootConventions
+}
+
+dependencies {
+    implementation(project(":libs:common"))
+    api(project(":modules:auth:credentials:domain"))
+    api(project(":modules:member:application"))
+    compileOnly(project(":modules:member:domain"))
+
+    implementation(libs.spring.boot.starter.core)
+    implementation(libs.spring.boot.starter.data.jpa)
+
+    testImplementation(libs.bundles.kotlin.test)
+}

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/command/CredentialsCommandFacade.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/command/CredentialsCommandFacade.kt
@@ -1,0 +1,9 @@
+package cloud.luigi99.blog.auth.credentials.application.port.`in`.command
+
+interface CredentialsCommandFacade {
+    fun login(): LoginUseCase
+
+    fun update(): UpdateCredentialsUseCase
+
+    fun delete(): DeleteCredentialsUseCase
+}

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/command/DeleteCredentialsUseCase.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/command/DeleteCredentialsUseCase.kt
@@ -1,0 +1,12 @@
+package cloud.luigi99.blog.auth.credentials.application.port.`in`.command
+
+/**
+ * 회원 인증 정보 삭제 유스케이스
+ *
+ * 회원 탈퇴 시 인증 정보를 삭제합니다.
+ */
+interface DeleteCredentialsUseCase {
+    fun execute(command: Command)
+
+    data class Command(val memberId: String)
+}

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/command/LoginUseCase.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/command/LoginUseCase.kt
@@ -1,0 +1,21 @@
+package cloud.luigi99.blog.auth.credentials.application.port.`in`.command
+
+import cloud.luigi99.blog.auth.credentials.domain.enums.Role
+
+interface LoginUseCase {
+    fun execute(command: Command): Response
+
+    data class Command(
+        val email: String,
+        val username: String,
+        val provider: String,
+        val providerId: String,
+    )
+
+    data class Response(
+        val memberId: String,
+        val email: String,
+        val username: String,
+        val role: Role,
+    )
+}

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/command/UpdateCredentialsUseCase.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/command/UpdateCredentialsUseCase.kt
@@ -1,0 +1,9 @@
+package cloud.luigi99.blog.auth.credentials.application.port.`in`.command
+
+import cloud.luigi99.blog.auth.credentials.domain.enums.Role
+
+interface UpdateCredentialsUseCase {
+    fun execute(command: Command)
+
+    data class Command(val memberId: String, val role: Role)
+}

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/query/CredentialsQueryFacade.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/query/CredentialsQueryFacade.kt
@@ -1,0 +1,5 @@
+package cloud.luigi99.blog.auth.credentials.application.port.`in`.query
+
+interface CredentialsQueryFacade {
+    fun getMemberCredentials(): GetMemberCredentialsUseCase
+}

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/query/GetMemberCredentialsUseCase.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/query/GetMemberCredentialsUseCase.kt
@@ -1,0 +1,19 @@
+package cloud.luigi99.blog.auth.credentials.application.port.`in`.query
+
+import cloud.luigi99.blog.auth.credentials.domain.enums.Role
+import java.time.LocalDateTime
+
+interface GetMemberCredentialsUseCase {
+    fun execute(query: Query): Response
+
+    data class Query(val memberId: String)
+
+    data class Response(
+        val credentialsId: String,
+        val memberId: String,
+        val oauthProvider: String,
+        val oauthProviderId: String,
+        val role: Role,
+        val lastLoginAt: LocalDateTime?,
+    )
+}

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/out/MemberClient.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/out/MemberClient.kt
@@ -1,0 +1,9 @@
+package cloud.luigi99.blog.auth.credentials.application.port.out
+
+interface MemberClient {
+    fun execute(request: Request): Response
+
+    data class Request(val email: String, val username: String)
+
+    data class Response(val memberId: String, val email: String, val username: String)
+}

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/out/MemberCredentialsRepository.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/out/MemberCredentialsRepository.kt
@@ -1,0 +1,15 @@
+package cloud.luigi99.blog.auth.credentials.application.port.out
+
+import cloud.luigi99.blog.auth.credentials.domain.model.MemberCredentials
+import cloud.luigi99.blog.auth.credentials.domain.vo.OAuthInfo
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+
+interface MemberCredentialsRepository {
+    fun save(credentials: MemberCredentials): MemberCredentials
+
+    fun findByOAuthInfo(oauthInfo: OAuthInfo): MemberCredentials?
+
+    fun findByMemberId(memberId: MemberId): MemberCredentials?
+
+    fun deleteByMemberId(memberId: MemberId)
+}

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/service/command/CredentialsCommandService.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/service/command/CredentialsCommandService.kt
@@ -1,0 +1,25 @@
+package cloud.luigi99.blog.auth.credentials.application.service.command
+
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.CredentialsCommandFacade
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.DeleteCredentialsUseCase
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.LoginUseCase
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.UpdateCredentialsUseCase
+import org.springframework.stereotype.Service
+
+/**
+ * 자격증명 관리 Facade 구현체
+ *
+ * 로그인, 인증 정보 업데이트, 인증 정보 삭제 유스케이스를 제공합니다.
+ */
+@Service
+class CredentialsCommandService(
+    private val loginUseCase: LoginUseCase,
+    private val updateCredentialsUseCase: UpdateCredentialsUseCase,
+    private val deleteCredentialsUseCase: DeleteCredentialsUseCase,
+) : CredentialsCommandFacade {
+    override fun login(): LoginUseCase = loginUseCase
+
+    override fun update(): UpdateCredentialsUseCase = updateCredentialsUseCase
+
+    override fun delete(): DeleteCredentialsUseCase = deleteCredentialsUseCase
+}

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/service/command/DeleteCredentialsService.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/service/command/DeleteCredentialsService.kt
@@ -1,0 +1,30 @@
+package cloud.luigi99.blog.auth.credentials.application.service.command
+
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.DeleteCredentialsUseCase
+import cloud.luigi99.blog.auth.credentials.application.port.out.MemberCredentialsRepository
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 회원 인증 정보 삭제 서비스
+ *
+ * 회원 탈퇴 시 인증 정보를 삭제합니다.
+ */
+@Service
+class DeleteCredentialsService(private val memberCredentialsRepository: MemberCredentialsRepository) :
+    DeleteCredentialsUseCase {
+    @Transactional
+    override fun execute(command: DeleteCredentialsUseCase.Command) {
+        val memberId = MemberId.from(command.memberId)
+
+        log.info { "Deleting credentials for member: $memberId" }
+
+        memberCredentialsRepository.deleteByMemberId(memberId)
+
+        log.info { "Successfully deleted credentials for member: $memberId" }
+    }
+}

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/service/command/LoginService.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/service/command/LoginService.kt
@@ -1,0 +1,88 @@
+package cloud.luigi99.blog.auth.credentials.application.service.command
+
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.LoginUseCase
+import cloud.luigi99.blog.auth.credentials.application.port.out.MemberClient
+import cloud.luigi99.blog.auth.credentials.application.port.out.MemberCredentialsRepository
+import cloud.luigi99.blog.auth.credentials.domain.enums.OAuthProvider
+import cloud.luigi99.blog.auth.credentials.domain.model.MemberCredentials
+import cloud.luigi99.blog.auth.credentials.domain.vo.OAuthInfo
+import cloud.luigi99.blog.common.application.port.out.DomainEventPublisher
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 로그인 유스케이스 구현체
+ *
+ * OAuth2 인증 정보를 바탕으로 회원 자격증명을 처리합니다.
+ * 회원 생성은 member 모듈에(Gateway 경유), 토큰 발급은 token 모듈에 위임합니다.
+ */
+@Service
+class LoginService(
+    private val memberCredentialsRepository: MemberCredentialsRepository,
+    private val memberClient: MemberClient,
+    private val domainEventPublisher: DomainEventPublisher,
+) : LoginUseCase {
+    /**
+     * 로그인 명령을 실행합니다.
+     *
+     * 기존 회원이면 자격증명 업데이트를, 신규 회원이면 회원 생성 후 자격증명 생성을 수행합니다.
+     *
+     * @param command 로그인 요청 명령 객체
+     * @return 로그인 응답 객체
+     */
+    @Transactional
+    override fun execute(command: LoginUseCase.Command): LoginUseCase.Response {
+        log.info { "Processing OAuth authentication for email: ${command.email}" }
+
+        val oauthInfo =
+            OAuthInfo(
+                provider = OAuthProvider.from(command.provider),
+                providerId = command.providerId,
+            )
+
+        val existingCredentials = memberCredentialsRepository.findByOAuthInfo(oauthInfo)
+
+        val credentials =
+            existingCredentials?.also {
+                it.updateLastLogin()
+            } ?: newMember(oauthInfo, command)
+
+        memberCredentialsRepository.save(credentials)
+
+        credentials.getEvents().forEach { domainEventPublisher.publish(it) }
+
+        log.info { "Successfully authenticated member ${credentials.memberId}" }
+
+        return LoginUseCase.Response(
+            memberId =
+                credentials.memberId.value
+                    .toString(),
+            email = command.email,
+            username = command.username,
+            role = credentials.role,
+        )
+    }
+
+    private fun newMember(oauthInfo: OAuthInfo, command: LoginUseCase.Command): MemberCredentials {
+        val response =
+            memberClient.execute(
+                MemberClient.Request(
+                    email = command.email,
+                    username = command.username,
+                ),
+            )
+
+        val newCredentials =
+            MemberCredentials.create(
+                memberId = MemberId.from(response.memberId),
+                oauthInfo = oauthInfo,
+            )
+        newCredentials.updateLastLogin()
+
+        return newCredentials
+    }
+}

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/service/command/UpdateCredentialsService.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/service/command/UpdateCredentialsService.kt
@@ -1,0 +1,41 @@
+package cloud.luigi99.blog.auth.credentials.application.service.command
+
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.UpdateCredentialsUseCase
+import cloud.luigi99.blog.auth.credentials.application.port.out.MemberCredentialsRepository
+import cloud.luigi99.blog.auth.credentials.domain.exception.MemberCredentialsException
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 인증 정보 업데이트 유스케이스 구현체
+ *
+ * 회원의 권한을 변경합니다.
+ */
+@Service
+class UpdateCredentialsService(private val memberCredentialsRepository: MemberCredentialsRepository) :
+    UpdateCredentialsUseCase {
+    /**
+     * 인증 정보 업데이트 명령을 실행합니다.
+     *
+     * @param command 업데이트 요청 명령 객체
+     * @throws MemberCredentialsException 인증 정보를 찾을 수 없는 경우
+     */
+    @Transactional
+    override fun execute(command: UpdateCredentialsUseCase.Command) {
+        log.info { "Updating credentials for member: ${command.memberId}" }
+
+        val memberId = MemberId.from(command.memberId)
+        val credentials =
+            memberCredentialsRepository.findByMemberId(memberId)
+                ?: throw MemberCredentialsException()
+
+        credentials.updateRole(command.role)
+        memberCredentialsRepository.save(credentials)
+
+        log.info { "Successfully updated credentials for member ${command.memberId} to role ${command.role}" }
+    }
+}

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/service/query/CredentialsQueryService.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/service/query/CredentialsQueryService.kt
@@ -1,0 +1,11 @@
+package cloud.luigi99.blog.auth.credentials.application.service.query
+
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.query.CredentialsQueryFacade
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.query.GetMemberCredentialsUseCase
+import org.springframework.stereotype.Service
+
+@Service
+class CredentialsQueryService(private val getMemberCredentialsUseCase: GetMemberCredentialsUseCase) :
+    CredentialsQueryFacade {
+    override fun getMemberCredentials(): GetMemberCredentialsUseCase = getMemberCredentialsUseCase
+}

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/service/query/GetMemberCredentialsService.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/service/query/GetMemberCredentialsService.kt
@@ -1,0 +1,31 @@
+package cloud.luigi99.blog.auth.credentials.application.service.query
+
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.query.GetMemberCredentialsUseCase
+import cloud.luigi99.blog.auth.credentials.application.port.out.MemberCredentialsRepository
+import cloud.luigi99.blog.auth.credentials.domain.exception.MemberCredentialsException
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import org.springframework.stereotype.Service
+
+@Service
+class GetMemberCredentialsService(private val memberCredentialsRepository: MemberCredentialsRepository) :
+    GetMemberCredentialsUseCase {
+    override fun execute(query: GetMemberCredentialsUseCase.Query): GetMemberCredentialsUseCase.Response {
+        val memberId = MemberId.from(query.memberId)
+        val credentials =
+            memberCredentialsRepository.findByMemberId(memberId)
+                ?: throw MemberCredentialsException()
+
+        return GetMemberCredentialsUseCase.Response(
+            credentialsId =
+                credentials.entityId.value
+                    .toString(),
+            memberId =
+                credentials.memberId.value
+                    .toString(),
+            oauthProvider = credentials.oauthInfo.provider.name,
+            oauthProviderId = credentials.oauthInfo.providerId,
+            role = credentials.role,
+            lastLoginAt = credentials.lastLoginAt?.value,
+        )
+    }
+}


### PR DESCRIPTION
## 📋 개요
<!-- 이 PR이 무엇을 해결하거나 추가하는지 간략하게 설명해주세요. -->
- 회원 인증을 위한 애플리케이션 유스케이스와 서비스를 구현했습니다.
  - 로그인, 인증 정보 수정, 삭제, 조회를 위한 유스케이스 추가
  - 해당 유스케이스를 위임하는 Facade 서비스 구현
- 애플리케이션 유스케이스에 대한 인터페이스 정의
  - Command 및 Query 유스케이스 정의
  - `MemberClient` 및 `MemberCredentialsRepository` 인터페이스 추가
- `credentials application` 모듈의 Gradle 설정 파일 구성

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 링크해주세요. ex) #123 -->
- Closes #30

## ☑️ 체크리스트
- [ ] 코딩 컨벤션을 준수했나요? (`./gradlew ktlintCheck`)
- [ ] 모든 테스트를 통과했나요? (`./gradlew test`)
- [ ] 불필요한 주석이나 로그는 제거했나요?