### PR TITLE
feat: Auth Credentials Adapter 모듈 구현

### DIFF
--- a/modules/auth/credentials/adapter/in/event/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/event/MemberDeletedEventListener.kt
+++ b/modules/auth/credentials/adapter/in/event/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/event/MemberDeletedEventListener.kt
@@ -1,0 +1,34 @@
+package cloud.luigi99.blog.auth.credentials.adapter.`in`.event
+
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.CredentialsCommandFacade
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.DeleteCredentialsUseCase
+import cloud.luigi99.blog.member.domain.member.event.MemberDeletedEvent
+import mu.KotlinLogging
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 회원 탈퇴 이벤트 리스너
+ *
+ * 회원이 탈퇴하면 해당 회원의 인증 정보를 삭제합니다.
+ */
+@Component
+class MemberDeletedEventListener(private val credentialsCommandFacade: CredentialsCommandFacade) {
+    @EventListener
+    @Transactional
+    fun handleMemberDeleted(event: MemberDeletedEvent) {
+        log.info { "Handling MemberDeletedEvent for member: ${event.memberId}" }
+
+        credentialsCommandFacade.delete().execute(
+            DeleteCredentialsUseCase.Command(
+                event.memberId.value
+                    .toString(),
+            ),
+        )
+
+        log.info { "Successfully deleted credentials for member: ${event.memberId}" }
+    }
+}

--- a/modules/auth/credentials/adapter/in/web/build.gradle.kts
+++ b/modules/auth/credentials/adapter/in/web/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    springBootConventions
+}
+
+dependencies {
+    implementation(project(":libs:common"))
+    implementation(project(":modules:auth:credentials:domain"))
+    implementation(project(":modules:auth:credentials:application"))
+    implementation(project(":modules:auth:token:application"))
+    implementation(project(":libs:adapter:web"))
+
+    implementation(libs.bundles.spring.boot.web)
+    implementation(libs.bundles.spring.boot.security)
+
+    testImplementation(libs.bundles.kotlin.test)
+}

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/MemberCredentialsApi.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/MemberCredentialsApi.kt
@@ -1,0 +1,180 @@
+package cloud.luigi99.blog.auth.credentials.adapter.`in`.web
+
+import cloud.luigi99.blog.adapter.web.dto.CommonResponse
+import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.dto.CredentialsResponse
+import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.dto.UpdateCredentialsRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+
+@Tag(name = "MemberCredentials", description = "회원 인증 정보 관리 API")
+interface MemberCredentialsApi {
+    @Operation(
+        summary = "현재 로그인한 회원 인증 정보 조회",
+        description = "JWT 토큰을 통해 인증된 현재 사용자의 인증 정보(OAuth 제공자, 권한 등)를 조회합니다.",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "인증 정보 조회 성공",
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "인증되지 않은 사용자",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "Unauthorized",
+                                value = """
+                                {
+                                  "success": false,
+                                  "data": null,
+                                  "error": {
+                                    "code": "AUTH_001",
+                                    "message": "인증에 실패했습니다."
+                                  },
+                                  "timestamp": "2025-12-10T12:00:00Z"
+                                }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "인증 정보를 찾을 수 없음",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "CredentialsNotFound",
+                                value = """
+                                {
+                                  "success": false,
+                                  "data": null,
+                                  "error": {
+                                    "code": "CREDENTIALS_001",
+                                    "message": "인증 정보를 찾을 수 없습니다."
+                                  },
+                                  "timestamp": "2025-12-10T12:00:00Z"
+                                }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getMemberCredentials(
+        @AuthenticationPrincipal memberId: String,
+    ): ResponseEntity<CommonResponse<CredentialsResponse>>
+
+    @Operation(
+        summary = "사용자 인증 정보 업데이트",
+        description = "회원의 권한을 변경합니다. ADMIN 권한이 필요합니다.",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "인증 정보 업데이트 성공",
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "인증되지 않은 사용자",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "Unauthorized",
+                                value = """
+                                {
+                                  "success": false,
+                                  "data": null,
+                                  "error": {
+                                    "code": "AUTH_001",
+                                    "message": "인증에 실패했습니다."
+                                  },
+                                  "timestamp": "2025-12-10T12:00:00Z"
+                                }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 없음 (ADMIN 권한 필요)",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "Forbidden",
+                                value = """
+                                {
+                                  "success": false,
+                                  "data": null,
+                                  "error": {
+                                    "code": "AUTH_002",
+                                    "message": "접근 권한이 없습니다."
+                                  },
+                                  "timestamp": "2025-12-10T12:00:00Z"
+                                }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "인증 정보를 찾을 수 없음",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "CredentialsNotFound",
+                                value = """
+                                {
+                                  "success": false,
+                                  "data": null,
+                                  "error": {
+                                    "code": "CREDENTIALS_001",
+                                    "message": "인증 정보를 찾을 수 없습니다."
+                                  },
+                                  "timestamp": "2025-12-10T12:00:00Z"
+                                }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun updateCredentials(
+        @PathVariable memberId: String,
+        @RequestBody request: UpdateCredentialsRequest,
+    ): ResponseEntity<CommonResponse<Unit>>
+}

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/MemberCredentialsController.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/MemberCredentialsController.kt
@@ -1,0 +1,71 @@
+package cloud.luigi99.blog.auth.credentials.adapter.`in`.web
+
+import cloud.luigi99.blog.adapter.web.dto.CommonResponse
+import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.dto.CredentialsResponse
+import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.dto.UpdateCredentialsRequest
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.CredentialsCommandFacade
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.UpdateCredentialsUseCase
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.query.CredentialsQueryFacade
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.query.GetMemberCredentialsUseCase
+import mu.KotlinLogging
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+private val log = KotlinLogging.logger {}
+
+@RestController
+@RequestMapping("/api/v1/auth/credentials")
+class MemberCredentialsController(
+    private val credentialsQueryFacade: CredentialsQueryFacade,
+    private val credentialsCommandFacade: CredentialsCommandFacade,
+) : MemberCredentialsApi {
+    @GetMapping("/me")
+    override fun getMemberCredentials(
+        @AuthenticationPrincipal memberId: String,
+    ): ResponseEntity<CommonResponse<CredentialsResponse>> {
+        log.info { "Getting credentials for member: $memberId" }
+
+        val response =
+            credentialsQueryFacade.getMemberCredentials().execute(
+                GetMemberCredentialsUseCase.Query(memberId = memberId),
+            )
+
+        return ResponseEntity.ok(
+            CommonResponse.success(
+                CredentialsResponse(
+                    credentialsId = response.credentialsId,
+                    memberId = response.memberId,
+                    oauthProvider = response.oauthProvider,
+                    oauthProviderId = response.oauthProviderId,
+                    role = response.role,
+                    lastLoginAt = response.lastLoginAt,
+                ),
+            ),
+        )
+    }
+
+    @PutMapping("/{memberId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    override fun updateCredentials(
+        @PathVariable memberId: String,
+        @RequestBody request: UpdateCredentialsRequest,
+    ): ResponseEntity<CommonResponse<Unit>> {
+        log.info { "Updating credentials for member: $memberId to role: ${request.role}" }
+
+        credentialsCommandFacade.update().execute(
+            UpdateCredentialsUseCase.Command(
+                memberId = memberId,
+                role = request.role,
+            ),
+        )
+
+        return ResponseEntity.ok(CommonResponse.success(Unit))
+    }
+}

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/config/OAuth2Properties.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/config/OAuth2Properties.kt
@@ -1,0 +1,8 @@
+package cloud.luigi99.blog.auth.credentials.adapter.`in`.web.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "app.redirect")
+data class OAuth2Properties(val baseUrl: String, val endPoint: EndPoint) {
+    data class EndPoint(val success: String, val error: String)
+}

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/config/SecurityConfig.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/config/SecurityConfig.kt
@@ -1,0 +1,71 @@
+package cloud.luigi99.blog.auth.credentials.adapter.`in`.web.config
+
+import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.oauth2.OAuth2AuthenticationSuccessHandler
+import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.security.CustomAccessDeniedHandler
+import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.security.CustomAuthenticationEntryPoint
+import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.security.JwtAuthenticationFilter
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+class SecurityConfig {
+    @Bean
+    fun securityFilterChain(
+        http: HttpSecurity,
+        jwtAuthenticationFilter: JwtAuthenticationFilter,
+        oauth2SuccessHandler: OAuth2AuthenticationSuccessHandler,
+        customAuthenticationEntryPoint: CustomAuthenticationEntryPoint,
+        customAccessDeniedHandler: CustomAccessDeniedHandler,
+    ): SecurityFilterChain {
+        http
+            .csrf { it.disable() }
+            .cors { it.configurationSource(corsConfigurationSource()) }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .oauth2Login { oauth2 ->
+                oauth2.successHandler(oauth2SuccessHandler)
+            }.exceptionHandling { exceptions ->
+                exceptions
+                    .authenticationEntryPoint(customAuthenticationEntryPoint)
+                    .accessDeniedHandler(customAccessDeniedHandler)
+            }.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
+            .authorizeHttpRequests { auth ->
+                auth
+                    .requestMatchers(
+                        "/api-docs/**",
+                        "/swagger-ui/**",
+                        "/actuator/health",
+                        "/api/v1/auth/**",
+                        "/oauth2/**",
+                        "/login/oauth2/**",
+                    ).permitAll()
+                    .anyRequest()
+                    .authenticated()
+            }
+
+        return http.build()
+    }
+
+    @Bean
+    fun corsConfigurationSource(): CorsConfigurationSource {
+        val configuration = CorsConfiguration()
+        configuration.allowedOrigins = listOf("http://localhost:3000", "http://localhost:5173")
+        configuration.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+        configuration.allowedHeaders = listOf("*")
+        configuration.allowCredentials = true
+
+        val source = UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/**", configuration)
+        return source
+    }
+}

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/dto/CredentialsResponse.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/dto/CredentialsResponse.kt
@@ -1,0 +1,20 @@
+package cloud.luigi99.blog.auth.credentials.adapter.`in`.web.dto
+
+import cloud.luigi99.blog.auth.credentials.domain.enums.Role
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+data class CredentialsResponse(
+    @param:Schema(description = "인증 정보 ID", example = "123e4567-e89b-12d3-a456-426614174000")
+    val credentialsId: String,
+    @param:Schema(description = "회원 ID", example = "123e4567-e89b-12d3-a456-426614174000")
+    val memberId: String,
+    @param:Schema(description = "OAuth 제공자", example = "GITHUB")
+    val oauthProvider: String,
+    @param:Schema(description = "OAuth 제공자 ID", example = "12345678")
+    val oauthProviderId: String,
+    @param:Schema(description = "회원 권한", example = "USER")
+    val role: Role,
+    @param:Schema(description = "마지막 로그인 시간", example = "2025-12-10T12:00:00")
+    val lastLoginAt: LocalDateTime?,
+)

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/dto/GitHubOAuth2UserInfo.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/dto/GitHubOAuth2UserInfo.kt
@@ -1,0 +1,18 @@
+package cloud.luigi99.blog.auth.credentials.adapter.`in`.web.dto
+
+import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.oauth2.OAuth2UserInfo
+
+data class GitHubOAuth2UserInfo(private val attributes: Map<String, Any>) : OAuth2UserInfo {
+    override fun getEmail(): String =
+        attributes["email"] as? String
+            ?: throw IllegalStateException("GitHub 사용자 이메일을 찾을 수 없습니다")
+
+    override fun getUsername(): String =
+        (attributes["login"] as? String)
+            ?: (attributes["name"] as? String)
+            ?: "github_user"
+
+    override fun getProviderId(): String =
+        attributes["id"]?.toString()
+            ?: throw IllegalStateException("GitHub provider ID를 찾을 수 없습니다")
+}

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/dto/UpdateCredentialsRequest.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/dto/UpdateCredentialsRequest.kt
@@ -1,0 +1,9 @@
+package cloud.luigi99.blog.auth.credentials.adapter.`in`.web.dto
+
+import cloud.luigi99.blog.auth.credentials.domain.enums.Role
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class UpdateCredentialsRequest(
+    @param:Schema(description = "회원 권한", example = "ADMIN", required = true)
+    val role: Role,
+)

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/oauth2/OAuth2AuthenticationSuccessHandler.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/oauth2/OAuth2AuthenticationSuccessHandler.kt
@@ -1,0 +1,102 @@
+package cloud.luigi99.blog.auth.credentials.adapter.`in`.web.oauth2
+
+import cloud.luigi99.blog.adapter.web.util.CookieUtils
+import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.config.OAuth2Properties
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.CredentialsCommandFacade
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.LoginUseCase
+import cloud.luigi99.blog.auth.token.application.port.`in`.command.IssueTokenUseCase
+import cloud.luigi99.blog.auth.token.application.port.`in`.command.TokenCommandFacade
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import mu.KotlinLogging
+import org.springframework.http.HttpHeaders
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler
+import org.springframework.stereotype.Component
+import org.springframework.web.util.UriComponentsBuilder
+
+private val log = KotlinLogging.logger {}
+
+@Component
+class OAuth2AuthenticationSuccessHandler(
+    private val credentialsCommandFacade: CredentialsCommandFacade,
+    private val tokenCommandFacade: TokenCommandFacade,
+    private val cookieUtils: CookieUtils,
+    private val oAuth2Properties: OAuth2Properties,
+) : SimpleUrlAuthenticationSuccessHandler() {
+    override fun onAuthenticationSuccess(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authentication: Authentication,
+    ) {
+        log.info { "OAuth2 authentication successful" }
+
+        val oauth2Token = authentication as OAuth2AuthenticationToken
+        val oauth2User = oauth2Token.principal as OAuth2User
+        val provider = oauth2Token.authorizedClientRegistrationId
+
+        log.debug { "OAuth2 provider: $provider" }
+
+        try {
+            val userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(provider, oauth2User)
+
+            log.debug {
+                "Extracted user info - email: ${userInfo.getEmail()}, " +
+                    "username: ${userInfo.getUsername()}, providerId: ${userInfo.getProviderId()}"
+            }
+
+            val loginResponse =
+                credentialsCommandFacade.login().execute(
+                    LoginUseCase.Command(
+                        email = userInfo.getEmail(),
+                        username = userInfo.getUsername(),
+                        provider = provider,
+                        providerId = userInfo.getProviderId(),
+                    ),
+                )
+
+            log.info { "Member authenticated successfully: ${loginResponse.memberId}" }
+
+            val tokenResponse =
+                tokenCommandFacade.issue().execute(
+                    IssueTokenUseCase.Command(
+                        memberId = loginResponse.memberId,
+                    ),
+                )
+
+            val accessTokenCookie =
+                cookieUtils.createCookie(
+                    name = "accessToken",
+                    value = tokenResponse.accessToken,
+                    maxAge = tokenResponse.accessTokenExpiration,
+                )
+
+            val refreshTokenCookie =
+                cookieUtils.createCookie(
+                    name = "refreshToken",
+                    value = tokenResponse.refreshToken,
+                    maxAge = tokenResponse.refreshTokenExpiration,
+                )
+
+            response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
+            response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+
+            val successUrl = oAuth2Properties.baseUrl + oAuth2Properties.endPoint.success
+            log.debug { "Redirecting to: $successUrl" }
+            redirectStrategy.sendRedirect(request, response, successUrl)
+        } catch (e: Exception) {
+            log.error(e) { "Error processing OAuth2 authentication" }
+
+            val errorUrl =
+                UriComponentsBuilder
+                    .fromUriString(oAuth2Properties.baseUrl + oAuth2Properties.endPoint.error)
+                    .queryParam("error", "Authentication failed")
+                    .build()
+                    .toUriString()
+
+            redirectStrategy.sendRedirect(request, response, errorUrl)
+        }
+    }
+}

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/oauth2/OAuth2UserInfo.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/oauth2/OAuth2UserInfo.kt
@@ -1,0 +1,9 @@
+package cloud.luigi99.blog.auth.credentials.adapter.`in`.web.oauth2
+
+interface OAuth2UserInfo {
+    fun getEmail(): String
+
+    fun getUsername(): String
+
+    fun getProviderId(): String
+}

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/oauth2/OAuth2UserInfoFactory.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/oauth2/OAuth2UserInfoFactory.kt
@@ -1,0 +1,12 @@
+package cloud.luigi99.blog.auth.credentials.adapter.`in`.web.oauth2
+
+import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.dto.GitHubOAuth2UserInfo
+import org.springframework.security.oauth2.core.user.OAuth2User
+
+object OAuth2UserInfoFactory {
+    fun getOAuth2UserInfo(provider: String, oauth2User: OAuth2User): OAuth2UserInfo =
+        when (provider.lowercase()) {
+            "github" -> GitHubOAuth2UserInfo(oauth2User.attributes)
+            else -> throw IllegalStateException("지원하지 않는 OAuth2 프로바이더: $provider")
+        }
+}

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/security/CustomAccessDeniedHandler.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/security/CustomAccessDeniedHandler.kt
@@ -1,0 +1,34 @@
+package cloud.luigi99.blog.auth.credentials.adapter.`in`.web.security
+
+import cloud.luigi99.blog.adapter.web.dto.CommonResponse
+import cloud.luigi99.blog.common.exception.ErrorCode
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.stereotype.Component
+import tools.jackson.databind.json.JsonMapper
+import java.time.Instant
+
+@Component
+class CustomAccessDeniedHandler(private val jsonMapper: JsonMapper) : AccessDeniedHandler {
+    override fun handle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        accessDeniedException: AccessDeniedException,
+    ) {
+        val errorResponse =
+            CommonResponse
+                .error<Unit>(
+                    ErrorCode.ACCESS_DENIED.code,
+                    ErrorCode.ACCESS_DENIED.message,
+                ).copy(timestamp = Instant.now())
+
+        response.status = HttpStatus.FORBIDDEN.value()
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.characterEncoding = "UTF-8"
+        response.writer.write(jsonMapper.writeValueAsString(errorResponse))
+    }
+}

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/security/CustomAuthenticationEntryPoint.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/security/CustomAuthenticationEntryPoint.kt
@@ -1,0 +1,34 @@
+package cloud.luigi99.blog.auth.credentials.adapter.`in`.web.security
+
+import cloud.luigi99.blog.adapter.web.dto.CommonResponse
+import cloud.luigi99.blog.common.exception.ErrorCode
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+import tools.jackson.databind.json.JsonMapper
+import java.time.Instant
+
+@Component
+class CustomAuthenticationEntryPoint(private val jsonMapper: JsonMapper) : AuthenticationEntryPoint {
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException,
+    ) {
+        val errorResponse =
+            CommonResponse
+                .error<Unit>(
+                    ErrorCode.UNAUTHORIZED.code,
+                    ErrorCode.UNAUTHORIZED.message,
+                ).copy(timestamp = Instant.now())
+
+        response.status = HttpStatus.UNAUTHORIZED.value()
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.characterEncoding = "UTF-8"
+        response.writer.write(jsonMapper.writeValueAsString(errorResponse))
+    }
+}

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/security/JwtAuthenticationFilter.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/security/JwtAuthenticationFilter.kt
@@ -1,0 +1,78 @@
+package cloud.luigi99.blog.auth.credentials.adapter.`in`.web.security
+
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.query.CredentialsQueryFacade
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.query.GetMemberCredentialsUseCase
+import cloud.luigi99.blog.auth.token.application.port.`in`.query.TokenQueryFacade
+import cloud.luigi99.blog.auth.token.application.port.`in`.query.ValidateTokenUseCase
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import mu.KotlinLogging
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+private val log = KotlinLogging.logger {}
+
+@Component
+class JwtAuthenticationFilter(
+    private val credentialsQueryFacade: CredentialsQueryFacade,
+    private val tokenQueryFacade: TokenQueryFacade,
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        try {
+            extractTokenFromRequest(request)?.let { accessToken ->
+                val validationResult =
+                    tokenQueryFacade.validate().execute(
+                        ValidateTokenUseCase.Query(accessToken),
+                    )
+
+                if (validationResult.isValid) {
+                    validationResult.memberId?.let {
+                        log.debug { "Valid JWT token found for member: $it" }
+
+                        val credentials =
+                            credentialsQueryFacade.getMemberCredentials().execute(
+                                GetMemberCredentialsUseCase.Query(it),
+                            )
+
+                        val authentication =
+                            UsernamePasswordAuthenticationToken(
+                                credentials.memberId,
+                                null,
+                                listOf(SimpleGrantedAuthority(credentials.role.authority)),
+                            ).apply {
+                                details = WebAuthenticationDetailsSource().buildDetails(request)
+                            }
+
+                        SecurityContextHolder.getContext().authentication = authentication
+                        log.debug { "Set authentication for member: $it with role: ${credentials.role}" }
+                    }
+                } else {
+                    log.debug { "Invalid or expired JWT token" }
+                }
+            }
+        } catch (e: Exception) {
+            log.warn { "Authentication failed: ${e.message}" }
+            SecurityContextHolder.clearContext()
+        }
+
+        filterChain.doFilter(request, response)
+    }
+
+    private fun extractTokenFromRequest(request: HttpServletRequest): String? {
+        val bearerToken = request.getHeader("Authorization")
+        return if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            bearerToken.substring(7)
+        } else {
+            null
+        }
+    }
+}

--- a/modules/auth/credentials/adapter/out/client/member/build.gradle.kts
+++ b/modules/auth/credentials/adapter/out/client/member/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    springBootConventions
+}
+
+dependencies {
+    implementation(project(":libs:common"))
+    implementation(project(":modules:auth:credentials:domain"))
+    implementation(project(":modules:auth:credentials:application"))
+
+    implementation(project(":modules:member:application"))
+    implementation(project(":modules:member:domain"))
+}

--- a/modules/auth/credentials/adapter/out/client/member/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/client/member/MemberClientAdapter.kt
+++ b/modules/auth/credentials/adapter/out/client/member/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/client/member/MemberClientAdapter.kt
@@ -1,0 +1,26 @@
+package cloud.luigi99.blog.auth.credentials.adapter.out.client.member
+
+import cloud.luigi99.blog.auth.credentials.application.port.out.MemberClient
+import cloud.luigi99.blog.member.application.member.port.`in`.command.MemberCommandFacade
+import cloud.luigi99.blog.member.application.member.port.`in`.command.RegisterMemberUseCase
+import org.springframework.stereotype.Component
+
+@Component
+class MemberClientAdapter(private val memberCommandFacade: MemberCommandFacade) : MemberClient {
+    override fun execute(request: MemberClient.Request): MemberClient.Response {
+        val command =
+            RegisterMemberUseCase.Command(
+                email = request.email,
+                username = request.username,
+            )
+
+        // MSA 전환 시 실제 API 요청 전송 코드로 변경 필요
+        val response = memberCommandFacade.registerMember().execute(command)
+
+        return MemberClient.Response(
+            memberId = response.memberId,
+            email = response.email,
+            username = response.username,
+        )
+    }
+}

--- a/modules/auth/credentials/adapter/out/persistence/jpa/build.gradle.kts
+++ b/modules/auth/credentials/adapter/out/persistence/jpa/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    springBootConventions
+}
+
+dependencies {
+    implementation(project(":libs:common"))
+    implementation(project(":modules:auth:credentials:domain"))
+    implementation(project(":modules:auth:credentials:application"))
+    implementation(project(":modules:member:domain"))
+    implementation(project(":libs:adapter:persistence:jpa"))
+
+    implementation(libs.spring.boot.starter.data.jpa)
+
+    testImplementation(libs.bundles.kotlin.test)
+}

--- a/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/membercredentials/MemberCredentialsJpaEntity.kt
+++ b/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/membercredentials/MemberCredentialsJpaEntity.kt
@@ -1,0 +1,67 @@
+package cloud.luigi99.blog.auth.credentials.adapter.out.persistence.jpa.membercredentials
+
+import cloud.luigi99.blog.adapter.persistence.jpa.JpaAggregateRoot
+import cloud.luigi99.blog.auth.credentials.domain.enums.OAuthProvider
+import cloud.luigi99.blog.auth.credentials.domain.enums.Role
+import cloud.luigi99.blog.auth.credentials.domain.vo.CredentialsId
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.Embedded
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.DynamicUpdate
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "member_credentials")
+@DynamicUpdate
+class MemberCredentialsJpaEntity private constructor(
+    @Id
+    @Column(name = "id")
+    val id: UUID,
+    @Column(name = "member_id", nullable = false)
+    val memberId: UUID,
+    @Column(name = "last_login_at", nullable = false)
+    var lastLoginAt: LocalDateTime? = null,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 50)
+    val role: Role,
+    @Embedded
+    val oauthInfo: OAuthInfo,
+) : JpaAggregateRoot<CredentialsId>() {
+    override val entityId: CredentialsId
+        get() = CredentialsId(id)
+
+    companion object {
+        fun from(
+            id: UUID,
+            memberId: UUID,
+            role: Role,
+            provider: OAuthProvider,
+            providerId: String,
+        ): MemberCredentialsJpaEntity =
+            MemberCredentialsJpaEntity(
+                id = id,
+                memberId = memberId,
+                role = role,
+                oauthInfo =
+                    OAuthInfo(
+                        provider = provider,
+                        providerId = providerId,
+                    ),
+            )
+    }
+
+    @Embeddable
+    data class OAuthInfo(
+        @Enumerated(EnumType.STRING)
+        @Column(name = "provider", nullable = false, length = 50)
+        val provider: OAuthProvider,
+        @Column(name = "provider_id", nullable = false, length = 255)
+        val providerId: String,
+    )
+}

--- a/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/membercredentials/MemberCredentialsJpaRepository.kt
+++ b/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/membercredentials/MemberCredentialsJpaRepository.kt
@@ -1,0 +1,16 @@
+package cloud.luigi99.blog.auth.credentials.adapter.out.persistence.jpa.membercredentials
+
+import cloud.luigi99.blog.auth.credentials.domain.enums.OAuthProvider
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface MemberCredentialsJpaRepository : JpaRepository<MemberCredentialsJpaEntity, UUID> {
+    fun findByOauthInfoProviderAndOauthInfoProviderId(
+        provider: OAuthProvider,
+        providerId: String,
+    ): MemberCredentialsJpaEntity?
+
+    fun findByMemberId(memberId: UUID): MemberCredentialsJpaEntity?
+
+    fun deleteByMemberId(memberId: UUID)
+}

--- a/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/membercredentials/MemberCredentialsMapper.kt
+++ b/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/membercredentials/MemberCredentialsMapper.kt
@@ -1,0 +1,38 @@
+package cloud.luigi99.blog.auth.credentials.adapter.out.persistence.jpa.membercredentials
+
+import cloud.luigi99.blog.auth.credentials.domain.model.MemberCredentials
+import cloud.luigi99.blog.auth.credentials.domain.vo.CredentialsId
+import cloud.luigi99.blog.auth.credentials.domain.vo.LastLoginTime
+import cloud.luigi99.blog.auth.credentials.domain.vo.OAuthInfo
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+
+object MemberCredentialsMapper {
+    fun toDomain(entity: MemberCredentialsJpaEntity): MemberCredentials =
+        MemberCredentials.from(
+            entityId = CredentialsId(entity.id),
+            memberId = MemberId(entity.memberId),
+            oauthInfo =
+                OAuthInfo(
+                    provider = entity.oauthInfo.provider,
+                    providerId = entity.oauthInfo.providerId,
+                ),
+            role = entity.role,
+            lastLoginAt = entity.lastLoginAt?.let { LastLoginTime(it) },
+            createdAt = entity.createdAt,
+            updatedAt = entity.updatedAt,
+        )
+
+    fun toEntity(domain: MemberCredentials): MemberCredentialsJpaEntity =
+        MemberCredentialsJpaEntity
+            .from(
+                id = domain.entityId.value,
+                memberId = domain.memberId.value,
+                role = domain.role,
+                provider = domain.oauthInfo.provider,
+                providerId = domain.oauthInfo.providerId,
+            ).apply {
+                this.lastLoginAt = domain.lastLoginAt?.value
+                this.createdAt = domain.createdAt
+                this.updatedAt = domain.updatedAt
+            }
+}

--- a/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/membercredentials/MemberCredentialsRepositoryAdapter.kt
+++ b/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/membercredentials/MemberCredentialsRepositoryAdapter.kt
@@ -1,0 +1,33 @@
+package cloud.luigi99.blog.auth.credentials.adapter.out.persistence.jpa.membercredentials
+
+import cloud.luigi99.blog.auth.credentials.application.port.out.MemberCredentialsRepository
+import cloud.luigi99.blog.auth.credentials.domain.model.MemberCredentials
+import cloud.luigi99.blog.auth.credentials.domain.vo.OAuthInfo
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import org.springframework.stereotype.Repository
+
+@Repository
+class MemberCredentialsRepositoryAdapter(private val jpaRepository: MemberCredentialsJpaRepository) :
+    MemberCredentialsRepository {
+    override fun save(credentials: MemberCredentials): MemberCredentials {
+        val entity = MemberCredentialsMapper.toEntity(credentials)
+        val saved = jpaRepository.save(entity)
+        return MemberCredentialsMapper.toDomain(saved)
+    }
+
+    override fun findByOAuthInfo(oauthInfo: OAuthInfo): MemberCredentials? =
+        jpaRepository
+            .findByOauthInfoProviderAndOauthInfoProviderId(
+                oauthInfo.provider,
+                oauthInfo.providerId,
+            )?.let { MemberCredentialsMapper.toDomain(it) }
+
+    override fun findByMemberId(memberId: MemberId): MemberCredentials? =
+        jpaRepository.findByMemberId(memberId.value)?.let {
+            MemberCredentialsMapper.toDomain(it)
+        }
+
+    override fun deleteByMemberId(memberId: MemberId) {
+        jpaRepository.deleteByMemberId(memberId.value)
+    }
+}


### PR DESCRIPTION
## 📋 개요
<!-- 이 PR이 무엇을 해결하거나 추가하는지 간략하게 설명해주세요. -->
- 멤버 클라이언트 어댑터를 통해 회원 등록 요청을 처리하는 기능 추가
- JPA 기반 회원 인증 정보 저장소 구현
- 회원 삭제 시 인증 정보를 처리하는 이벤트 리스너 구현
- OAuth2 및 JWT 기반 인증을 포함한 시큐리티 설정 및 API 추가
- Gradle 설정 파일 업데이트로 모듈별 의존성 관리 및 빌드 설정

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 링크해주세요. ex) #123 -->
- Closes #31

## ☑️ 체크리스트
- [ ] 코딩 컨벤션을 준수했나요? (`./gradlew ktlintCheck`)
- [ ] 모든 테스트를 통과했나요? (`./gradlew test`)
- [ ] 불필요한 주석이나 로그는 제거했나요?