### PR TITLE
test: Member 어댑터 계층 테스트 코드 추가

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,7 +70,7 @@ jjwt-jackson = { module = "io.jsonwebtoken:jjwt-jackson", version.ref = "jjwt" }
 # Testing
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
-kotest-extensions-spring = { module = "io.kotest.extensions:kotest-extensions-spring", version.ref = "kotest" }
+kotest-extensions-spring = { module = "io.kotest:kotest-extensions-spring", version.ref = "kotest" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 
 # Documentation

--- a/modules/member/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/member/adapter/in/web/member/MemberControllerTest.kt
+++ b/modules/member/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/member/adapter/in/web/member/MemberControllerTest.kt
@@ -1,0 +1,121 @@
+package cloud.luigi99.blog.member.adapter.`in`.web.member
+
+import cloud.luigi99.blog.member.adapter.`in`.web.member.dto.MemberResponse
+import cloud.luigi99.blog.member.application.member.port.`in`.command.DeleteMemberUseCase
+import cloud.luigi99.blog.member.application.member.port.`in`.command.MemberCommandFacade
+import cloud.luigi99.blog.member.application.member.port.`in`.query.GetCurrentMemberUseCase
+import cloud.luigi99.blog.member.application.member.port.`in`.query.MemberQueryFacade
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import org.springframework.http.HttpStatus
+import java.util.UUID
+
+/**
+ * MemberController 테스트
+ *
+ * REST API 엔드포인트의 요청/응답 처리를 검증합니다.
+ */
+class MemberControllerTest :
+    BehaviorSpec({
+
+        val memberQueryFacade = mockk<MemberQueryFacade>()
+        val memberCommandFacade = mockk<MemberCommandFacade>()
+        val controller = MemberController(memberQueryFacade, memberCommandFacade)
+
+        Given("회원이 로그인한 상태에서") {
+            val memberId = UUID.randomUUID().toString()
+            val getCurrentMemberUseCase = mockk<GetCurrentMemberUseCase>()
+
+            every { memberQueryFacade.getCurrentMember() } returns getCurrentMemberUseCase
+
+            When("자신의 회원 정보 조회를 요청하면") {
+                val expectedResponse =
+                    GetCurrentMemberUseCase.Response(
+                        memberId = memberId,
+                        email = "test@example.com",
+                        username = "testuser",
+                    )
+
+                every { getCurrentMemberUseCase.execute(any()) } returns expectedResponse
+
+                val response = controller.getCurrentMember(memberId)
+
+                Then("성공 응답과 함께 회원 정보가 반환되어야 한다") {
+                    response.statusCode shouldBe HttpStatus.OK
+                    response.body shouldNotBe null
+                    response.body?.success shouldBe true
+                    response.body?.data shouldBe
+                        MemberResponse(
+                            memberId = memberId,
+                            email = "test@example.com",
+                            username = "testuser",
+                        )
+                }
+            }
+        }
+
+        Given("회원이 서비스를 탈퇴하려고 할 때") {
+            val memberId = UUID.randomUUID().toString()
+            val deleteMemberUseCase = mockk<DeleteMemberUseCase>()
+
+            every { memberCommandFacade.deleteMember() } returns deleteMemberUseCase
+
+            When("회원 탈퇴를 요청하면") {
+                justRun { deleteMemberUseCase.execute(any()) }
+
+                val response = controller.deleteMember(memberId)
+
+                Then("탈퇴가 완료되고 빈 응답이 반환되어야 한다") {
+                    response.statusCode shouldBe HttpStatus.NO_CONTENT
+                    response.body shouldBe null
+                }
+            }
+        }
+
+        Given("여러 회원이 각자 정보를 조회하려고 할 때") {
+            val getCurrentMemberUseCase = mockk<GetCurrentMemberUseCase>()
+            every { memberQueryFacade.getCurrentMember() } returns getCurrentMemberUseCase
+
+            When("서로 다른 회원이 자신의 정보 조회를 요청하면") {
+                val memberId1 = UUID.randomUUID().toString()
+                val memberId2 = UUID.randomUUID().toString()
+
+                every { getCurrentMemberUseCase.execute(GetCurrentMemberUseCase.Query(memberId1)) } returns
+                    GetCurrentMemberUseCase.Response(
+                        memberId = memberId1,
+                        email = "user1@example.com",
+                        username = "user1",
+                    )
+
+                every { getCurrentMemberUseCase.execute(GetCurrentMemberUseCase.Query(memberId2)) } returns
+                    GetCurrentMemberUseCase.Response(
+                        memberId = memberId2,
+                        email = "user2@example.com",
+                        username = "user2",
+                    )
+
+                val response1 = controller.getCurrentMember(memberId1)
+                val response2 = controller.getCurrentMember(memberId2)
+
+                Then("각 회원에게 맞는 정보가 정확히 반환되어야 한다") {
+                    response1.body
+                        ?.data
+                        ?.memberId shouldBe memberId1
+                    response1.body
+                        ?.data
+                        ?.email shouldBe "user1@example.com"
+
+                    response2.body
+                        ?.data
+                        ?.memberId shouldBe memberId2
+                    response2.body
+                        ?.data
+                        ?.email shouldBe "user2@example.com"
+                }
+            }
+        }
+    })

--- a/modules/member/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/member/adapter/in/web/profile/ProfileControllerTest.kt
+++ b/modules/member/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/member/adapter/in/web/profile/ProfileControllerTest.kt
@@ -1,0 +1,224 @@
+package cloud.luigi99.blog.member.adapter.`in`.web.profile
+
+import cloud.luigi99.blog.member.adapter.`in`.web.profile.dto.ProfileResponse
+import cloud.luigi99.blog.member.adapter.`in`.web.profile.dto.UpdateProfileRequest
+import cloud.luigi99.blog.member.application.member.port.`in`.command.MemberCommandFacade
+import cloud.luigi99.blog.member.application.member.port.`in`.command.UpdateMemberProfileUseCase
+import cloud.luigi99.blog.member.application.member.port.`in`.query.GetMemberProfileUseCase
+import cloud.luigi99.blog.member.application.member.port.`in`.query.MemberQueryFacade
+import cloud.luigi99.blog.member.domain.profile.exception.ProfileException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.http.HttpStatus
+import java.util.UUID
+
+/**
+ * ProfileController 테스트
+ *
+ * 프로필 REST API 엔드포인트의 요청/응답 처리를 검증합니다.
+ */
+class ProfileControllerTest :
+    BehaviorSpec({
+
+        val memberQueryFacade = mockk<MemberQueryFacade>()
+        val memberCommandFacade = mockk<MemberCommandFacade>()
+        val controller = ProfileController(memberQueryFacade, memberCommandFacade)
+
+        Given("회원이 프로필을 이미 등록한 상태에서") {
+            val memberId = UUID.randomUUID().toString()
+            val profileId = UUID.randomUUID().toString()
+            val getMemberProfileUseCase = mockk<GetMemberProfileUseCase>()
+
+            every { memberQueryFacade.getMemberProfile() } returns getMemberProfileUseCase
+
+            When("자신의 프로필 조회를 요청하면") {
+                val expectedResponse =
+                    GetMemberProfileUseCase.Response(
+                        memberId = memberId,
+                        email = "test@example.com",
+                        username = "testuser",
+                        profile =
+                            GetMemberProfileUseCase.ProfileResponse(
+                                profileId = profileId,
+                                nickname = "테스터",
+                                bio = "안녕하세요",
+                                profileImageUrl = "https://example.com/image.jpg",
+                                jobTitle = "Backend Developer",
+                                techStack = listOf("Kotlin", "Spring Boot"),
+                                githubUrl = "https://github.com/testuser",
+                                contactEmail = "contact@example.com",
+                                websiteUrl = "https://testuser.dev",
+                            ),
+                    )
+
+                every { getMemberProfileUseCase.execute(any()) } returns expectedResponse
+
+                val response = controller.getProfile(memberId)
+
+                Then("성공 응답과 함께 프로필 정보가 반환되어야 한다") {
+                    response.statusCode shouldBe HttpStatus.OK
+                    response.body shouldNotBe null
+                    response.body?.success shouldBe true
+                    response.body
+                        ?.data
+                        ?.profileId shouldBe profileId
+                    response.body
+                        ?.data
+                        ?.memberId shouldBe memberId
+                    response.body
+                        ?.data
+                        ?.nickname shouldBe "테스터"
+                    response.body
+                        ?.data
+                        ?.bio shouldBe "안녕하세요"
+                    response.body
+                        ?.data
+                        ?.techStack shouldBe listOf("Kotlin", "Spring Boot")
+                }
+            }
+        }
+
+        Given("회원이 아직 프로필을 등록하지 않은 상태에서") {
+            val memberId = UUID.randomUUID().toString()
+            val getMemberProfileUseCase = mockk<GetMemberProfileUseCase>()
+
+            every { memberQueryFacade.getMemberProfile() } returns getMemberProfileUseCase
+
+            When("프로필 조회를 요청하면") {
+                val expectedResponse =
+                    GetMemberProfileUseCase.Response(
+                        memberId = memberId,
+                        email = "noProfile@example.com",
+                        username = "noProfileUser",
+                        profile = null,
+                    )
+
+                every { getMemberProfileUseCase.execute(any()) } returns expectedResponse
+
+                Then("프로필을 찾을 수 없다는 예외가 발생해야 한다") {
+                    shouldThrow<ProfileException> {
+                        controller.getProfile(memberId)
+                    }
+                }
+            }
+        }
+
+        Given("회원이 프로필 정보를 변경하려고 할 때") {
+            val memberId = UUID.randomUUID().toString()
+            val profileId = UUID.randomUUID().toString()
+            val updateMemberProfileUseCase = mockk<UpdateMemberProfileUseCase>()
+
+            every { memberCommandFacade.updateProfile() } returns updateMemberProfileUseCase
+
+            When("새로운 프로필 정보로 업데이트를 요청하면") {
+                val request =
+                    UpdateProfileRequest(
+                        nickname = "새닉네임",
+                        bio = "업데이트된 소개",
+                        profileImageUrl = "https://example.com/new-image.jpg",
+                        jobTitle = "Senior Backend Developer",
+                        techStack = listOf("Kotlin", "Spring Boot", "DDD"),
+                        githubUrl = "https://github.com/newuser",
+                        contactEmail = "new@example.com",
+                        websiteUrl = "https://newuser.dev",
+                    )
+
+                val expectedResponse =
+                    UpdateMemberProfileUseCase.Response(
+                        profileId = profileId,
+                        nickname = "새닉네임",
+                        bio = "업데이트된 소개",
+                        profileImageUrl = "https://example.com/new-image.jpg",
+                        jobTitle = "Senior Backend Developer",
+                        techStack = listOf("Kotlin", "Spring Boot", "DDD"),
+                        githubUrl = "https://github.com/newuser",
+                        contactEmail = "new@example.com",
+                        websiteUrl = "https://newuser.dev",
+                    )
+
+                every { updateMemberProfileUseCase.execute(any()) } returns expectedResponse
+
+                val response = controller.updateProfile(memberId, request)
+
+                Then("성공 응답과 함께 변경된 프로필 정보가 반환되어야 한다") {
+                    response.statusCode shouldBe HttpStatus.OK
+                    response.body shouldNotBe null
+                    response.body?.success shouldBe true
+                    response.body
+                        ?.data
+                        ?.profileId shouldBe profileId
+                    response.body
+                        ?.data
+                        ?.nickname shouldBe "새닉네임"
+                    response.body
+                        ?.data
+                        ?.bio shouldBe "업데이트된 소개"
+                    response.body
+                        ?.data
+                        ?.jobTitle shouldBe "Senior Backend Developer"
+                    response.body
+                        ?.data
+                        ?.techStack shouldBe listOf("Kotlin", "Spring Boot", "DDD")
+                }
+            }
+        }
+
+        Given("회원이 닉네임만으로 간단하게 프로필을 구성하려고 할 때") {
+            val memberId = UUID.randomUUID().toString()
+            val profileId = UUID.randomUUID().toString()
+            val updateMemberProfileUseCase = mockk<UpdateMemberProfileUseCase>()
+
+            every { memberCommandFacade.updateProfile() } returns updateMemberProfileUseCase
+
+            When("필수 정보만 입력하고 선택 항목은 비워서 요청하면") {
+                val request =
+                    UpdateProfileRequest(
+                        nickname = "최소닉네임",
+                        bio = null,
+                        profileImageUrl = null,
+                        jobTitle = null,
+                        techStack = emptyList(),
+                        githubUrl = null,
+                        contactEmail = null,
+                        websiteUrl = null,
+                    )
+
+                val expectedResponse =
+                    UpdateMemberProfileUseCase.Response(
+                        profileId = profileId,
+                        nickname = "최소닉네임",
+                        bio = null,
+                        profileImageUrl = null,
+                        jobTitle = null,
+                        techStack = emptyList(),
+                        githubUrl = null,
+                        contactEmail = null,
+                        websiteUrl = null,
+                    )
+
+                every { updateMemberProfileUseCase.execute(any()) } returns expectedResponse
+
+                val response = controller.updateProfile(memberId, request)
+
+                Then("필수 정보만 포함된 프로필이 정상적으로 저장되어야 한다") {
+                    response.statusCode shouldBe HttpStatus.OK
+                    response.body
+                        ?.data
+                        ?.nickname shouldBe "최소닉네임"
+                    response.body
+                        ?.data
+                        ?.bio shouldBe null
+                    response.body
+                        ?.data
+                        ?.profileImageUrl shouldBe null
+                    response.body
+                        ?.data
+                        ?.techStack shouldBe emptyList()
+                }
+            }
+        }
+    })

--- a/modules/member/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/member/MemberMapperTest.kt
+++ b/modules/member/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/member/MemberMapperTest.kt
@@ -1,0 +1,167 @@
+package cloud.luigi99.blog.member.adapter.out.persistence.jpa.member
+
+import cloud.luigi99.blog.member.domain.member.model.Member
+import cloud.luigi99.blog.member.domain.member.vo.Email
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import cloud.luigi99.blog.member.domain.member.vo.Username
+import cloud.luigi99.blog.member.domain.profile.model.Profile
+import cloud.luigi99.blog.member.domain.profile.vo.Nickname
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * MemberMapper 테스트
+ *
+ * 도메인 모델과 JPA 엔티티 간의 변환 로직을 검증합니다.
+ */
+class MemberMapperTest :
+    BehaviorSpec({
+
+        Given("프로필이 없는 회원 도메인 모델이 주어졌을 때") {
+            val memberId = MemberId.generate()
+            val member =
+                Member.from(
+                    entityId = memberId,
+                    email = Email("test@example.com"),
+                    username = Username("testuser"),
+                    profile = null,
+                    createdAt = LocalDateTime.of(2025, 1, 1, 10, 0),
+                    updatedAt = LocalDateTime.of(2025, 1, 2, 15, 30),
+                )
+
+            When("JPA 엔티티로 변환하면") {
+                val entity = MemberMapper.toEntity(member)
+
+                Then("모든 필드가 정확하게 매핑되어야 한다") {
+                    entity.id shouldBe memberId.value
+                    entity.email shouldBe "test@example.com"
+                    entity.username shouldBe "testuser"
+                    entity.profile shouldBe null
+                    entity.createdAt shouldBe LocalDateTime.of(2025, 1, 1, 10, 0)
+                    entity.updatedAt shouldBe LocalDateTime.of(2025, 1, 2, 15, 30)
+                }
+            }
+        }
+
+        Given("프로필이 있는 회원 도메인 모델이 주어졌을 때") {
+            val memberId = MemberId.generate()
+            val profile =
+                Profile.create(
+                    nickname = Nickname("개발자"),
+                )
+            val member =
+                Member.from(
+                    entityId = memberId,
+                    email = Email("dev@example.com"),
+                    username = Username("developer"),
+                    profile = profile,
+                    createdAt = null,
+                    updatedAt = null,
+                )
+
+            When("JPA 엔티티로 변환하면") {
+                val entity = MemberMapper.toEntity(member)
+
+                Then("프로필 정보도 함께 매핑되어야 한다") {
+                    entity.id shouldBe memberId.value
+                    entity.email shouldBe "dev@example.com"
+                    entity.profile shouldNotBe null
+                    entity.profile?.nickname shouldBe "개발자"
+                }
+            }
+        }
+
+        Given("프로필이 없는 JPA 엔티티가 주어졌을 때") {
+            val entityId = UUID.randomUUID()
+            val jpaEntity =
+                MemberJpaEntity
+                    .from(
+                        entityId = entityId,
+                        email = "stored@example.com",
+                        username = "storeduser",
+                    ).apply {
+                        createdAt = LocalDateTime.of(2025, 1, 1, 12, 0)
+                        updatedAt = LocalDateTime.of(2025, 1, 3, 18, 0)
+                    }
+
+            When("도메인 모델로 변환하면") {
+                val domain = MemberMapper.toDomain(jpaEntity)
+
+                Then("모든 필드가 정확하게 매핑되어야 한다") {
+                    domain.entityId.value shouldBe entityId
+                    domain.email.value shouldBe "stored@example.com"
+                    domain.username.value shouldBe "storeduser"
+                    domain.profile shouldBe null
+                    domain.createdAt shouldBe LocalDateTime.of(2025, 1, 1, 12, 0)
+                    domain.updatedAt shouldBe LocalDateTime.of(2025, 1, 3, 18, 0)
+                }
+            }
+        }
+
+        Given("도메인 모델을 JPA 엔티티로 변환한 후") {
+            val memberId = MemberId.generate()
+            val member =
+                Member.from(
+                    entityId = memberId,
+                    email = Email("original@example.com"),
+                    username = Username("original"),
+                    profile = null,
+                    createdAt = null,
+                    updatedAt = null,
+                )
+            val entity = MemberMapper.toEntity(member)
+
+            When("다시 도메인 모델로 변환하면") {
+                val converted = MemberMapper.toDomain(entity)
+
+                Then("원본 데이터가 손실 없이 복원되어야 한다") {
+                    converted.entityId shouldBe member.entityId
+                    converted.email shouldBe member.email
+                    converted.username shouldBe member.username
+                    converted.profile shouldBe member.profile
+                }
+            }
+        }
+
+        Given("여러 회원 정보가 있을 때") {
+            val memberId1 = MemberId.generate()
+            val memberId2 = MemberId.generate()
+
+            val member1 =
+                Member.from(
+                    entityId = memberId1,
+                    email = Email("user1@example.com"),
+                    username = Username("user1"),
+                    profile = null,
+                    createdAt = null,
+                    updatedAt = null,
+                )
+            val member2 =
+                Member.from(
+                    entityId = memberId2,
+                    email = Email("user2@example.com"),
+                    username = Username("user2"),
+                    profile = null,
+                    createdAt = null,
+                    updatedAt = null,
+                )
+
+            When("각각 JPA 엔티티로 변환하면") {
+                val entity1 = MemberMapper.toEntity(member1)
+                val entity2 = MemberMapper.toEntity(member2)
+
+                Then("각 회원의 정보가 독립적으로 정확히 매핑되어야 한다") {
+                    entity1.id shouldBe member1.entityId.value
+                    entity1.email shouldBe "user1@example.com"
+
+                    entity2.id shouldBe member2.entityId.value
+                    entity2.email shouldBe "user2@example.com"
+
+                    entity1.id shouldNotBe entity2.id
+                }
+            }
+        }
+    })

--- a/modules/member/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/member/MemberRepositoryAdapterTest.kt
+++ b/modules/member/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/member/MemberRepositoryAdapterTest.kt
@@ -1,0 +1,212 @@
+package cloud.luigi99.blog.member.adapter.out.persistence.jpa.member
+
+import cloud.luigi99.blog.common.application.port.out.DomainEventPublisher
+import cloud.luigi99.blog.common.application.port.out.EventContextManager
+import cloud.luigi99.blog.member.domain.member.event.MemberRegisteredEvent
+import cloud.luigi99.blog.member.domain.member.model.Member
+import cloud.luigi99.blog.member.domain.member.vo.Email
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import cloud.luigi99.blog.member.domain.member.vo.Username
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.Optional
+import java.util.UUID
+
+/**
+ * MemberRepositoryAdapter 테스트
+ *
+ * JPA를 통한 회원 데이터 영속화 및 도메인 이벤트 발행을 검증합니다.
+ */
+class MemberRepositoryAdapterTest :
+    BehaviorSpec({
+
+        val jpaRepository = mockk<MemberJpaRepository>()
+        val eventContextManager = mockk<EventContextManager>()
+        val domainEventPublisher = mockk<DomainEventPublisher>()
+        val adapter = MemberRepositoryAdapter(jpaRepository, eventContextManager, domainEventPublisher)
+
+        Given("새로운 회원을 등록하려고 할 때") {
+            val memberId = MemberId.generate()
+            val member =
+                Member.from(
+                    entityId = memberId,
+                    email = Email("newuser@example.com"),
+                    username = Username("newuser"),
+                    profile = null,
+                    createdAt = null,
+                    updatedAt = null,
+                )
+
+            When("회원 정보를 저장하면") {
+                val jpaEntity = MemberMapper.toEntity(member)
+                val events = listOf(MemberRegisteredEvent(member.entityId, member.email))
+
+                every { jpaRepository.save(any()) } returns jpaEntity
+                every { eventContextManager.getDomainEventsAndClear() } returns events
+                justRun { domainEventPublisher.publish(any()) }
+
+                val saved = adapter.save(member)
+
+                Then("저장된 회원 정보가 반환되어야 한다") {
+                    saved shouldNotBe null
+                    saved.entityId shouldBe member.entityId
+                    saved.email shouldBe member.email
+                    saved.username shouldBe member.username
+                }
+
+                Then("도메인 이벤트가 발행되어야 한다") {
+                    verify(exactly = 1) {
+                        domainEventPublisher.publish(match { it is MemberRegisteredEvent })
+                    }
+                }
+            }
+        }
+
+        Given("기존 회원 정보를 수정하려고 할 때") {
+            val memberId = MemberId.generate()
+            val updatedMember =
+                Member.from(
+                    entityId = memberId,
+                    email = Email("existing@example.com"),
+                    username = Username("newname"),
+                    profile = null,
+                    createdAt = null,
+                    updatedAt = null,
+                )
+
+            When("변경된 정보로 저장하면") {
+                val jpaEntity = MemberMapper.toEntity(updatedMember)
+
+                every { jpaRepository.save(any()) } returns jpaEntity
+                every { eventContextManager.getDomainEventsAndClear() } returns emptyList()
+
+                val saved = adapter.save(updatedMember)
+
+                Then("업데이트된 회원 정보가 반환되어야 한다") {
+                    saved.entityId shouldBe memberId
+                    saved.username shouldBe Username("newname")
+                }
+            }
+        }
+
+        Given("데이터베이스에 회원이 존재할 때") {
+            val memberId = MemberId.generate()
+            val jpaEntity =
+                MemberJpaEntity.from(
+                    entityId = memberId.value,
+                    email = "stored@example.com",
+                    username = "storeduser",
+                )
+
+            When("회원 ID로 조회하면") {
+                every { jpaRepository.findById(memberId.value) } returns Optional.of(jpaEntity)
+
+                val found = adapter.findById(memberId)
+
+                Then("해당 회원 정보가 반환되어야 한다") {
+                    found shouldNotBe null
+                    found?.entityId shouldBe memberId
+                    found?.email shouldBe Email("stored@example.com")
+                    found?.username shouldBe Username("storeduser")
+                }
+            }
+        }
+
+        Given("데이터베이스에 존재하지 않는 회원 ID가 주어졌을 때") {
+            val nonExistentId = MemberId.generate()
+
+            When("회원 ID로 조회하면") {
+                every { jpaRepository.findById(nonExistentId.value) } returns Optional.empty()
+
+                val found = adapter.findById(nonExistentId)
+
+                Then("null이 반환되어야 한다") {
+                    found shouldBe null
+                }
+            }
+        }
+
+        Given("특정 이메일로 가입한 회원이 존재할 때") {
+            val email = Email("unique@example.com")
+            val jpaEntity =
+                MemberJpaEntity.from(
+                    entityId = UUID.randomUUID(),
+                    email = email.value,
+                    username = "uniqueuser",
+                )
+
+            When("이메일로 회원을 조회하면") {
+                every { jpaRepository.findByEmailValue(email.value) } returns jpaEntity
+
+                val found = adapter.findByEmail(email)
+
+                Then("해당 이메일의 회원 정보가 반환되어야 한다") {
+                    found shouldNotBe null
+                    found?.email shouldBe email
+                }
+            }
+        }
+
+        Given("특정 이메일로 가입한 회원이 없을 때") {
+            val email = Email("notfound@example.com")
+
+            When("이메일로 회원을 조회하면") {
+                every { jpaRepository.findByEmailValue(email.value) } returns null
+
+                val found = adapter.findByEmail(email)
+
+                Then("null이 반환되어야 한다") {
+                    found shouldBe null
+                }
+            }
+        }
+
+        Given("이미 사용 중인 이메일이 있을 때") {
+            val email = Email("duplicate@example.com")
+
+            When("이메일 중복 여부를 확인하면") {
+                every { jpaRepository.existsByEmailValue(email.value) } returns true
+
+                val exists = adapter.existsByEmail(email)
+
+                Then("중복되었다는 결과가 반환되어야 한다") {
+                    exists shouldBe true
+                }
+            }
+        }
+
+        Given("사용 가능한 이메일이 주어졌을 때") {
+            val email = Email("available@example.com")
+
+            When("이메일 중복 여부를 확인하면") {
+                every { jpaRepository.existsByEmailValue(email.value) } returns false
+
+                val exists = adapter.existsByEmail(email)
+
+                Then("사용 가능하다는 결과가 반환되어야 한다") {
+                    exists shouldBe false
+                }
+            }
+        }
+
+        Given("탈퇴하려는 회원이 존재할 때") {
+            val memberId = MemberId.generate()
+
+            When("회원 ID로 삭제를 요청하면") {
+                justRun { jpaRepository.deleteById(memberId.value) }
+
+                adapter.deleteById(memberId)
+
+                Then("데이터베이스에서 회원이 삭제되어야 한다") {
+                    verify(exactly = 1) {
+                        jpaRepository.deleteById(memberId.value)
+                    }
+                }
+            }
+        }
+    })

--- a/modules/member/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/profile/ProfileMapperTest.kt
+++ b/modules/member/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/profile/ProfileMapperTest.kt
@@ -1,0 +1,249 @@
+package cloud.luigi99.blog.member.adapter.out.persistence.jpa.profile
+
+import cloud.luigi99.blog.member.domain.profile.model.Profile
+import cloud.luigi99.blog.member.domain.profile.vo.Bio
+import cloud.luigi99.blog.member.domain.profile.vo.ContactEmail
+import cloud.luigi99.blog.member.domain.profile.vo.JobTitle
+import cloud.luigi99.blog.member.domain.profile.vo.Nickname
+import cloud.luigi99.blog.member.domain.profile.vo.ProfileId
+import cloud.luigi99.blog.member.domain.profile.vo.TechStack
+import cloud.luigi99.blog.member.domain.profile.vo.Url
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * ProfileMapper 테스트
+ *
+ * 프로필 도메인 모델과 JPA 엔티티 간의 변환 로직을 검증합니다.
+ */
+class ProfileMapperTest :
+    BehaviorSpec({
+
+        Given("최소 정보만 있는 프로필 도메인 모델이 주어졌을 때") {
+            val profileId = ProfileId.generate()
+            val profile =
+                Profile.from(
+                    entityId = profileId,
+                    nickname = Nickname("최소닉네임"),
+                    bio = null,
+                    profileImageUrl = null,
+                    jobTitle = null,
+                    techStack = TechStack(emptyList()),
+                    githubUrl = null,
+                    contactEmail = null,
+                    websiteUrl = null,
+                    createdAt = LocalDateTime.of(2025, 1, 1, 10, 0),
+                    updatedAt = LocalDateTime.of(2025, 1, 2, 15, 30),
+                )
+
+            When("JPA 엔티티로 변환하면") {
+                val entity = ProfileMapper.toEntity(profile)
+
+                Then("필수 필드와 선택 필드가 정확하게 매핑되어야 한다") {
+                    entity.id shouldBe profileId.value
+                    entity.nickname shouldBe "최소닉네임"
+                    entity.bio shouldBe null
+                    entity.profileImageUrl shouldBe null
+                    entity.jobTitle shouldBe null
+                    entity.techStack shouldBe emptyList()
+                    entity.githubUrl shouldBe null
+                    entity.contactEmail shouldBe null
+                    entity.websiteUrl shouldBe null
+                    entity.createdAt shouldBe LocalDateTime.of(2025, 1, 1, 10, 0)
+                    entity.updatedAt shouldBe LocalDateTime.of(2025, 1, 2, 15, 30)
+                }
+            }
+        }
+
+        Given("모든 정보가 있는 프로필 도메인 모델이 주어졌을 때") {
+            val profileId = ProfileId.generate()
+            val profile =
+                Profile.from(
+                    entityId = profileId,
+                    nickname = Nickname("풀스택개발자"),
+                    bio = Bio("안녕하세요, 백엔드 개발자입니다."),
+                    profileImageUrl = Url("https://example.com/profile.jpg"),
+                    jobTitle = JobTitle("Senior Backend Developer"),
+                    techStack = TechStack(listOf("Kotlin", "Spring Boot", "DDD", "TDD")),
+                    githubUrl = Url("https://github.com/developer"),
+                    contactEmail = ContactEmail("contact@developer.com"),
+                    websiteUrl = Url("https://developer.blog"),
+                    createdAt = LocalDateTime.of(2025, 1, 5, 9, 0),
+                    updatedAt = LocalDateTime.of(2025, 1, 10, 14, 0),
+                )
+
+            When("JPA 엔티티로 변환하면") {
+                val entity = ProfileMapper.toEntity(profile)
+
+                Then("모든 필드가 정확하게 매핑되어야 한다") {
+                    entity.id shouldBe profileId.value
+                    entity.nickname shouldBe "풀스택개발자"
+                    entity.bio shouldBe "안녕하세요, 백엔드 개발자입니다."
+                    entity.profileImageUrl shouldBe "https://example.com/profile.jpg"
+                    entity.jobTitle shouldBe "Senior Backend Developer"
+                    entity.techStack shouldBe listOf("Kotlin", "Spring Boot", "DDD", "TDD")
+                    entity.githubUrl shouldBe "https://github.com/developer"
+                    entity.contactEmail shouldBe "contact@developer.com"
+                    entity.websiteUrl shouldBe "https://developer.blog"
+                    entity.createdAt shouldBe LocalDateTime.of(2025, 1, 5, 9, 0)
+                    entity.updatedAt shouldBe LocalDateTime.of(2025, 1, 10, 14, 0)
+                }
+            }
+        }
+
+        Given("최소 정보만 있는 JPA 엔티티가 주어졌을 때") {
+            val entityId = UUID.randomUUID()
+            val jpaEntity =
+                ProfileJpaEntity
+                    .from(
+                        entityId = entityId,
+                        nickname = "간단닉네임",
+                        bio = null,
+                        profileImageUrl = null,
+                        jobTitle = null,
+                        techStack = emptyList(),
+                        githubUrl = null,
+                        contactEmail = null,
+                        websiteUrl = null,
+                    ).apply {
+                        createdAt = LocalDateTime.of(2025, 2, 1, 11, 0)
+                        updatedAt = LocalDateTime.of(2025, 2, 5, 16, 0)
+                    }
+
+            When("도메인 모델로 변환하면") {
+                val domain = ProfileMapper.toDomain(jpaEntity)
+
+                Then("필수 필드와 선택 필드가 정확하게 매핑되어야 한다") {
+                    domain.entityId.value shouldBe entityId
+                    domain.nickname.value shouldBe "간단닉네임"
+                    domain.bio shouldBe null
+                    domain.profileImageUrl shouldBe null
+                    domain.jobTitle shouldBe null
+                    domain.techStack.values shouldBe emptyList()
+                    domain.githubUrl shouldBe null
+                    domain.contactEmail shouldBe null
+                    domain.websiteUrl shouldBe null
+                    domain.createdAt shouldBe LocalDateTime.of(2025, 2, 1, 11, 0)
+                    domain.updatedAt shouldBe LocalDateTime.of(2025, 2, 5, 16, 0)
+                }
+            }
+        }
+
+        Given("모든 정보가 있는 JPA 엔티티가 주어졌을 때") {
+            val entityId = UUID.randomUUID()
+            val jpaEntity =
+                ProfileJpaEntity
+                    .from(
+                        entityId = entityId,
+                        nickname = "전문가",
+                        bio = "10년 경력의 개발자",
+                        profileImageUrl = "https://cdn.example.com/avatar.png",
+                        jobTitle = "Tech Lead",
+                        techStack = listOf("Java", "Kotlin", "AWS", "Kubernetes"),
+                        githubUrl = "https://github.com/expert",
+                        contactEmail = "expert@company.com",
+                        websiteUrl = "https://expert.tech",
+                    ).apply {
+                        createdAt = LocalDateTime.of(2025, 3, 1, 8, 0)
+                        updatedAt = LocalDateTime.of(2025, 3, 15, 20, 0)
+                    }
+
+            When("도메인 모델로 변환하면") {
+                val domain = ProfileMapper.toDomain(jpaEntity)
+
+                Then("모든 필드가 정확하게 매핑되어야 한다") {
+                    domain.entityId.value shouldBe entityId
+                    domain.nickname.value shouldBe "전문가"
+                    domain.bio?.value shouldBe "10년 경력의 개발자"
+                    domain.profileImageUrl?.value shouldBe "https://cdn.example.com/avatar.png"
+                    domain.jobTitle?.value shouldBe "Tech Lead"
+                    domain.techStack.values shouldBe listOf("Java", "Kotlin", "AWS", "Kubernetes")
+                    domain.githubUrl?.value shouldBe "https://github.com/expert"
+                    domain.contactEmail?.value shouldBe "expert@company.com"
+                    domain.websiteUrl?.value shouldBe "https://expert.tech"
+                    domain.createdAt shouldBe LocalDateTime.of(2025, 3, 1, 8, 0)
+                    domain.updatedAt shouldBe LocalDateTime.of(2025, 3, 15, 20, 0)
+                }
+            }
+        }
+
+        Given("도메인 모델을 JPA 엔티티로 변환한 후") {
+            val profile =
+                Profile.create(
+                    nickname = Nickname("원본닉네임"),
+                    bio = Bio("원본 소개"),
+                    techStack = TechStack(listOf("Spring", "Kotlin")),
+                )
+            val entity = ProfileMapper.toEntity(profile)
+
+            When("다시 도메인 모델로 변환하면") {
+                val converted = ProfileMapper.toDomain(entity)
+
+                Then("원본 데이터가 손실 없이 복원되어야 한다") {
+                    converted.entityId shouldBe profile.entityId
+                    converted.nickname shouldBe profile.nickname
+                    converted.bio shouldBe profile.bio
+                    converted.techStack.values shouldBe profile.techStack.values
+                }
+            }
+        }
+
+        Given("기술 스택이 여러 개인 프로필이 주어졌을 때") {
+            val techList = listOf("Kotlin", "Java", "Python", "Go", "Rust")
+            val profile =
+                Profile.create(
+                    nickname = Nickname("멀티언어개발자"),
+                    techStack = TechStack(techList),
+                )
+
+            When("JPA 엔티티로 변환하면") {
+                val entity = ProfileMapper.toEntity(profile)
+
+                Then("기술 스택 리스트가 순서대로 보존되어야 한다") {
+                    entity.techStack shouldBe techList
+                }
+            }
+
+            When("JPA 엔티티를 다시 도메인으로 변환하면") {
+                val entity = ProfileMapper.toEntity(profile)
+                val converted = ProfileMapper.toDomain(entity)
+
+                Then("기술 스택이 원본과 동일해야 한다") {
+                    converted.techStack.values shouldBe techList
+                }
+            }
+        }
+
+        Given("여러 프로필 정보가 있을 때") {
+            val profile1 =
+                Profile.create(
+                    nickname = Nickname("개발자1"),
+                    bio = Bio("첫 번째 개발자"),
+                )
+            val profile2 =
+                Profile.create(
+                    nickname = Nickname("개발자2"),
+                    bio = Bio("두 번째 개발자"),
+                )
+
+            When("각각 JPA 엔티티로 변환하면") {
+                val entity1 = ProfileMapper.toEntity(profile1)
+                val entity2 = ProfileMapper.toEntity(profile2)
+
+                Then("각 프로필의 정보가 독립적으로 정확히 매핑되어야 한다") {
+                    entity1.id shouldBe profile1.entityId.value
+                    entity1.nickname shouldBe "개발자1"
+                    entity1.bio shouldBe "첫 번째 개발자"
+
+                    entity2.id shouldBe profile2.entityId.value
+                    entity2.nickname shouldBe "개발자2"
+                    entity2.bio shouldBe "두 번째 개발자"
+
+                    entity1.id shouldNotBe entity2.id
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## 📋 개요
- 도메인 모델과 JPA 엔티티 간 매핑 로직 테스트를 위한 MemberMapper, ProfileMapper 테스트 추가
- 회원 데이터 영속화 및 도메인 이벤트 발행 동작 검증을 위한 MemberRepositoryAdapter 테스트 코드 추가
- 회원 조회/삭제 및 프로필 조회/업데이트 관련 MemberController, ProfileController 테스트 코드 작성

## 🔗 관련 이슈
- Closes #26

## ☑️ 체크리스트
- [ ] 코딩 컨벤션을 준수했나요? (`./gradlew ktlintCheck`)
- [ ] 모든 테스트를 통과했나요? (`./gradlew test`)
- [ ] 불필요한 주석이나 로그는 제거했나요?