### PR TITLE
feat: Content Post Application 모듈 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     implementation(project(":modules:auth:credentials:adapter:out:client:member"))
 
     implementation(project(":modules:content:domain"))
+    implementation(project(":modules:content:application"))
 
     implementation(libs.bundles.spring.boot.web)
     implementation(libs.bundles.spring.boot.data)

--- a/modules/content/application/build.gradle.kts
+++ b/modules/content/application/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    springBootConventions
+}
+
+dependencies {
+    implementation(project(":libs:common"))
+    api(project(":modules:content:domain"))
+
+    implementation(libs.spring.boot.starter.core)
+    implementation(libs.spring.boot.starter.security)
+    implementation(libs.spring.boot.starter.data.jpa)
+
+    testImplementation(libs.bundles.kotlin.test)
+}

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/command/CreatePostUseCase.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/command/CreatePostUseCase.kt
@@ -1,0 +1,62 @@
+package cloud.luigi99.blog.content.application.post.port.`in`.command
+
+/**
+ * Post 생성 UseCase
+ *
+ * 새로운 블로그 글을 DRAFT 상태로 생성합니다.
+ */
+interface CreatePostUseCase {
+    /**
+     * Post를 생성합니다.
+     *
+     * @param command 생성 명령
+     * @return 생성된 Post 정보
+     */
+    fun execute(command: Command): Response
+
+    /**
+     * Post 생성 명령
+     *
+     * @property memberId 작성자 Member ID
+     * @property title 제목
+     * @property slug URL slug
+     * @property body 본문 (Markdown)
+     * @property type 컨텐츠 타입 (BLOG, PORTFOLIO)
+     * @property tags 태그 목록
+     */
+    data class Command(
+        val memberId: String,
+        val title: String,
+        val slug: String,
+        val body: String,
+        val type: String,
+        val tags: List<String> = emptyList(),
+    )
+
+    /**
+     * Post 생성 응답
+     *
+     * @property postId Post ID
+     * @property memberId 작성자 Member ID
+     * @property title 제목
+     * @property slug URL slug
+     * @property body 본문
+     * @property type 컨텐츠 타입
+     * @property status 상태
+     * @property tags 태그 목록
+     * @property createdAt 생성 시간
+     * @property updatedAt 수정 시간
+     */
+    data class Response(
+        val postId: String,
+        val memberId: String,
+        val title: String,
+        val slug: String,
+        val body: String,
+        val type: String,
+        val status: String,
+        val tags: Set<String>,
+        val createdAt: java.time.LocalDateTime?,
+        val updatedAt: java.time.LocalDateTime?,
+    )
+}

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/command/PostCommandFacade.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/command/PostCommandFacade.kt
@@ -1,0 +1,18 @@
+package cloud.luigi99.blog.content.application.post.port.`in`.command
+
+/**
+ * Post Command Facade
+ *
+ * Post 관련 Command UseCase들을 그룹핑합니다.
+ */
+interface PostCommandFacade {
+    /**
+     * Post 생성 UseCase를 반환합니다.
+     */
+    fun createPost(): CreatePostUseCase
+
+    /**
+     * Post 수정 UseCase를 반환합니다.
+     */
+    fun updatePost(): UpdatePostUseCase
+}

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/command/UpdatePostUseCase.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/command/UpdatePostUseCase.kt
@@ -1,0 +1,60 @@
+package cloud.luigi99.blog.content.application.post.port.`in`.command
+
+/**
+ * Post 수정 UseCase
+ *
+ * Post의 제목, 본문, 상태를 수정합니다.
+ */
+interface UpdatePostUseCase {
+    /**
+     * Post를 수정합니다.
+     *
+     * @param command 수정 명령
+     * @return 수정된 Post 정보
+     */
+    fun execute(command: Command): Response
+
+    /**
+     * Post 수정 명령
+     *
+     * @property memberId 요청자 Member ID
+     * @property postId Post ID
+     * @property title 새로운 제목 (null이면 변경하지 않음)
+     * @property body 새로운 본문 (null이면 변경하지 않음)
+     * @property status 새로운 상태 (null이면 변경하지 않음, "PUBLISHED", "ARCHIVED", "DRAFT")
+     */
+    data class Command(
+        val memberId: String,
+        val postId: String,
+        val title: String?,
+        val body: String?,
+        val status: String? = null,
+    )
+
+    /**
+     * Post 수정 응답
+     *
+     * @property postId Post ID
+     * @property memberId 작성자 Member ID
+     * @property title 수정된 제목
+     * @property slug URL slug
+     * @property body 수정된 본문
+     * @property type 컨텐츠 타입
+     * @property status 상태
+     * @property tags 태그 목록
+     * @property createdAt 생성 시간
+     * @property updatedAt 수정 시간
+     */
+    data class Response(
+        val postId: String,
+        val memberId: String,
+        val title: String,
+        val slug: String,
+        val body: String,
+        val type: String,
+        val status: String,
+        val tags: Set<String>,
+        val createdAt: java.time.LocalDateTime?,
+        val updatedAt: java.time.LocalDateTime?,
+    )
+}

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/query/GetPostByIdUseCase.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/query/GetPostByIdUseCase.kt
@@ -1,0 +1,50 @@
+package cloud.luigi99.blog.content.application.post.port.`in`.query
+
+/**
+ * ID로 Post 조회 UseCase
+ *
+ * Post ID를 사용하여 Post를 조회합니다.
+ */
+interface GetPostByIdUseCase {
+    /**
+     * ID로 Post를 조회합니다.
+     *
+     * @param query 조회 쿼리
+     * @return Post 정보
+     */
+    fun execute(query: Query): Response
+
+    /**
+     * Post 조회 쿼리
+     *
+     * @property postId Post ID
+     */
+    data class Query(val postId: String)
+
+    /**
+     * Post 조회 응답
+     *
+     * @property postId Post ID
+     * @property memberId 작성자 Member ID
+     * @property title 제목
+     * @property slug URL slug
+     * @property body 본문
+     * @property type 컨텐츠 타입
+     * @property status 상태
+     * @property tags 태그 목록
+     * @property createdAt 생성 시간
+     * @property updatedAt 수정 시간
+     */
+    data class Response(
+        val postId: String,
+        val memberId: String,
+        val title: String,
+        val slug: String,
+        val body: String,
+        val type: String,
+        val status: String,
+        val tags: Set<String>,
+        val createdAt: java.time.LocalDateTime?,
+        val updatedAt: java.time.LocalDateTime?,
+    )
+}

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/query/GetPostBySlugUseCase.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/query/GetPostBySlugUseCase.kt
@@ -1,0 +1,51 @@
+package cloud.luigi99.blog.content.application.post.port.`in`.query
+
+/**
+ * Slug로 Post 조회 UseCase
+ *
+ * URL slug를 사용하여 Post를 조회합니다.
+ */
+interface GetPostBySlugUseCase {
+    /**
+     * Slug로 Post를 조회합니다.
+     *
+     * @param query 조회 쿼리
+     * @return Post 정보
+     */
+    fun execute(query: Query): Response
+
+    /**
+     * Post 조회 쿼리
+     *
+     * @property username 사용자 이름
+     * @property slug URL slug
+     */
+    data class Query(val username: String, val slug: String)
+
+    /**
+     * Post 조회 응답
+     *
+     * @property postId Post ID
+     * @property memberId 작성자 Member ID
+     * @property title 제목
+     * @property slug URL slug
+     * @property body 본문
+     * @property type 컨텐츠 타입
+     * @property status 상태
+     * @property tags 태그 목록
+     * @property createdAt 생성 시간
+     * @property updatedAt 수정 시간
+     */
+    data class Response(
+        val postId: String,
+        val memberId: String,
+        val title: String,
+        val slug: String,
+        val body: String,
+        val type: String,
+        val status: String,
+        val tags: Set<String>,
+        val createdAt: java.time.LocalDateTime?,
+        val updatedAt: java.time.LocalDateTime?,
+    )
+}

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/query/GetPostsUseCase.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/query/GetPostsUseCase.kt
@@ -1,0 +1,54 @@
+package cloud.luigi99.blog.content.application.post.port.`in`.query
+
+/**
+ * Post 목록 조회 UseCase
+ *
+ * 필터링 조건에 따라 Post 목록을 조회합니다.
+ */
+interface GetPostsUseCase {
+    /**
+     * Post 목록을 조회합니다.
+     *
+     * @param query 조회 쿼리
+     * @return Post 목록
+     */
+    fun execute(query: Query): Response
+
+    /**
+     * Post 목록 조회 쿼리
+     *
+     * @property status 상태 필터 (null이면 전체)
+     * @property type 컨텐츠 타입 필터 (null이면 전체)
+     */
+    data class Query(val status: String? = null, val type: String? = null)
+
+    /**
+     * Post 목록 조회 응답
+     *
+     * @property posts Post 목록
+     */
+    data class Response(val posts: List<PostSummary>)
+
+    /**
+     * Post 요약 정보
+     *
+     * @property postId Post ID
+     * @property memberId 작성자 Member ID
+     * @property title 제목
+     * @property slug URL slug
+     * @property type 컨텐츠 타입
+     * @property status 상태
+     * @property tags 태그 목록
+     * @property createdAt 생성 시간
+     */
+    data class PostSummary(
+        val postId: String,
+        val memberId: String,
+        val title: String,
+        val slug: String,
+        val type: String,
+        val status: String,
+        val tags: Set<String>,
+        val createdAt: java.time.LocalDateTime?,
+    )
+}

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/query/PostQueryFacade.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/query/PostQueryFacade.kt
@@ -1,0 +1,23 @@
+package cloud.luigi99.blog.content.application.post.port.`in`.query
+
+/**
+ * Post Query Facade
+ *
+ * Post 관련 Query UseCase들을 그룹핑합니다.
+ */
+interface PostQueryFacade {
+    /**
+     * Slug로 Post 조회 UseCase를 반환합니다.
+     */
+    fun getPostBySlug(): GetPostBySlugUseCase
+
+    /**
+     * ID로 Post 조회 UseCase를 반환합니다.
+     */
+    fun getPostById(): GetPostByIdUseCase
+
+    /**
+     * Post 목록 조회 UseCase를 반환합니다.
+     */
+    fun getPosts(): GetPostsUseCase
+}

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/out/PostRepository.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/out/PostRepository.kt
@@ -1,0 +1,82 @@
+package cloud.luigi99.blog.content.application.post.port.out
+
+import cloud.luigi99.blog.common.application.port.out.Repository
+import cloud.luigi99.blog.content.domain.post.model.Post
+import cloud.luigi99.blog.content.domain.post.vo.ContentType
+import cloud.luigi99.blog.content.domain.post.vo.PostId
+import cloud.luigi99.blog.content.domain.post.vo.PostStatus
+import cloud.luigi99.blog.content.domain.post.vo.Slug
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+
+/**
+ * Post Repository Port
+ *
+ * Post Aggregate의 영속성 작업을 추상화합니다.
+ */
+interface PostRepository : Repository<Post, PostId> {
+    /**
+     * Slug로 Post를 조회합니다.
+     *
+     * @param slug Post의 slug
+     * @return Post 또는 null (존재하지 않을 경우)
+     */
+    fun findBySlug(slug: Slug): Post?
+
+    /**
+     * Slug가 이미 존재하는지 확인합니다.
+     *
+     * @param slug 확인할 slug
+     * @return 존재 여부
+     */
+    fun existsBySlug(slug: Slug): Boolean
+
+    /**
+     * 특정 사용자가 해당 slug를 사용하는 Post를 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @param slug Post의 slug
+     * @return Post 또는 null (존재하지 않을 경우)
+     */
+    fun findByMemberIdAndSlug(memberId: MemberId, slug: Slug): Post?
+
+    /**
+     * Username과 Slug로 Post를 조회합니다.
+     *
+     * @param username 사용자 이름
+     * @param slug Post의 slug
+     * @return Post 또는 null (존재하지 않을 경우)
+     */
+    fun findByUsernameAndSlug(username: String, slug: Slug): Post?
+
+    /**
+     * 특정 사용자가 해당 slug를 이미 사용 중인지 확인합니다.
+     *
+     * @param memberId 회원 ID
+     * @param slug 확인할 slug
+     * @return 존재 여부
+     */
+    fun existsByMemberIdAndSlug(memberId: MemberId, slug: Slug): Boolean
+
+    /**
+     * 상태별로 Post 목록을 조회합니다.
+     *
+     * @param status Post 상태
+     * @return Post 목록
+     */
+    fun findAllByStatus(status: PostStatus): List<Post>
+
+    /**
+     * 컨텐츠 타입별로 Post 목록을 조회합니다.
+     *
+     * @param type 컨텐츠 타입
+     * @return Post 목록
+     */
+    fun findAllByContentType(type: ContentType): List<Post>
+
+    /**
+     * 모든 Post를 조회합니다.
+     *
+     * @return Post 목록
+     */
+    fun findAll(): List<Post>
+}

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/service/command/CreatePostService.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/service/command/CreatePostService.kt
@@ -1,0 +1,79 @@
+package cloud.luigi99.blog.content.application.post.service.command
+
+import cloud.luigi99.blog.content.application.post.port.`in`.command.CreatePostUseCase
+import cloud.luigi99.blog.content.application.post.port.out.PostRepository
+import cloud.luigi99.blog.content.domain.post.exception.DuplicateSlugException
+import cloud.luigi99.blog.content.domain.post.model.Post
+import cloud.luigi99.blog.content.domain.post.vo.Body
+import cloud.luigi99.blog.content.domain.post.vo.ContentType
+import cloud.luigi99.blog.content.domain.post.vo.Slug
+import cloud.luigi99.blog.content.domain.post.vo.Title
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Post 생성 유스케이스 구현체
+ *
+ * 새로운 블로그 글을 DRAFT 상태로 생성합니다.
+ * Slug 중복 검증을 수행합니다.
+ */
+@Service
+class CreatePostService(private val postRepository: PostRepository) : CreatePostUseCase {
+    @Transactional
+    override fun execute(command: CreatePostUseCase.Command): CreatePostUseCase.Response {
+        log.info { "Creating new post with slug: ${command.slug} by member: ${command.memberId}" }
+
+        val memberId = MemberId.from(command.memberId)
+        val slug = Slug(command.slug)
+
+        // Slug 중복 검증 (사용자별)
+        if (postRepository.existsByMemberIdAndSlug(memberId, slug)) {
+            throw DuplicateSlugException("슬러그 '${command.slug}'는 이미 사용 중입니다")
+        }
+
+        val title = Title(command.title)
+        val body = Body(command.body)
+        val type = ContentType.valueOf(command.type)
+
+        // Post 생성
+        var newPost =
+            Post.create(
+                memberId = memberId,
+                title = title,
+                slug = slug,
+                body = body,
+                type = type,
+            )
+
+        // 태그 추가
+        command.tags.forEach { tagName ->
+            newPost = newPost.addTag(tagName)
+        }
+
+        // Post 저장
+        val savedPost = postRepository.save(newPost)
+
+        log.info { "Successfully created post: ${savedPost.entityId}" }
+
+        return CreatePostUseCase.Response(
+            postId =
+                savedPost.entityId.value
+                    .toString(),
+            memberId =
+                savedPost.memberId.value
+                    .toString(),
+            title = savedPost.title.value,
+            slug = savedPost.slug.value,
+            body = savedPost.body.value,
+            type = savedPost.type.name,
+            status = savedPost.status.name,
+            tags = savedPost.tags,
+            createdAt = savedPost.createdAt,
+            updatedAt = savedPost.updatedAt,
+        )
+    }
+}

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/service/command/PostCommandService.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/service/command/PostCommandService.kt
@@ -1,0 +1,21 @@
+package cloud.luigi99.blog.content.application.post.service.command
+
+import cloud.luigi99.blog.content.application.post.port.`in`.command.CreatePostUseCase
+import cloud.luigi99.blog.content.application.post.port.`in`.command.PostCommandFacade
+import cloud.luigi99.blog.content.application.post.port.`in`.command.UpdatePostUseCase
+import org.springframework.stereotype.Service
+
+/**
+ * Post Command Facade 구현체
+ *
+ * Post 생성/수정 관련 UseCase들을 그룹핑하여 제공합니다 (RESTful 설계).
+ */
+@Service
+class PostCommandService(
+    private val createPostUseCase: CreatePostUseCase,
+    private val updatePostUseCase: UpdatePostUseCase,
+) : PostCommandFacade {
+    override fun createPost(): CreatePostUseCase = createPostUseCase
+
+    override fun updatePost(): UpdatePostUseCase = updatePostUseCase
+}

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/service/command/UpdatePostService.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/service/command/UpdatePostService.kt
@@ -1,0 +1,85 @@
+package cloud.luigi99.blog.content.application.post.service.command
+
+import cloud.luigi99.blog.content.application.post.port.`in`.command.UpdatePostUseCase
+import cloud.luigi99.blog.content.application.post.port.out.PostRepository
+import cloud.luigi99.blog.content.domain.post.exception.PostNotFoundException
+import cloud.luigi99.blog.content.domain.post.exception.UnauthorizedPostAccessException
+import cloud.luigi99.blog.content.domain.post.vo.Body
+import cloud.luigi99.blog.content.domain.post.vo.PostId
+import cloud.luigi99.blog.content.domain.post.vo.Title
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Post 수정 유스케이스 구현체
+ *
+ * Post의 제목, 본문, 상태를 선택적으로 수정합니다.
+ */
+@Service
+class UpdatePostService(private val postRepository: PostRepository) : UpdatePostUseCase {
+    @Transactional
+    override fun execute(command: UpdatePostUseCase.Command): UpdatePostUseCase.Response {
+        log.info {
+            "Updating post: ${command.postId} by member: ${command.memberId} (title=${command.title != null}, body=${command.body != null}, status=${command.status})"
+        }
+
+        val memberId = MemberId.from(command.memberId)
+        val postId = PostId(UUID.fromString(command.postId))
+        var post =
+            postRepository.findById(postId)
+                ?: throw PostNotFoundException("Post ID ${command.postId}를 찾을 수 없습니다")
+
+        // 권한 검증
+        if (!post.isOwner(memberId)) {
+            throw UnauthorizedPostAccessException("게시글 ${command.postId}에 대한 수정 권한이 없습니다")
+        }
+
+        // 1. 제목/본문 수정 (둘 중 하나라도 있으면)
+        if (command.title != null || command.body != null) {
+            val newTitle = command.title?.let { Title(it) } ?: post.title
+            val newBody = command.body?.let { Body(it) } ?: post.body
+            post = post.update(newTitle, newBody)
+        }
+
+        // 2. 상태 변경 (status가 있으면)
+        if (command.status != null) {
+            post =
+                when (command.status.uppercase()) {
+                    "PUBLISHED" -> post.publish()
+
+                    "ARCHIVED" -> post.archive()
+
+                    "DRAFT" -> post
+
+                    // DRAFT는 초기 상태이므로 변경 불필요 (필요하면 도메인에 toDraft() 메서드 추가)
+                    else -> throw IllegalArgumentException("Invalid status: ${command.status}")
+                }
+        }
+
+        val savedPost = postRepository.save(post)
+
+        log.info { "Successfully updated post: ${savedPost.entityId}, status=${savedPost.status}" }
+
+        return UpdatePostUseCase.Response(
+            postId =
+                savedPost.entityId.value
+                    .toString(),
+            memberId =
+                savedPost.memberId.value
+                    .toString(),
+            title = savedPost.title.value,
+            slug = savedPost.slug.value,
+            body = savedPost.body.value,
+            type = savedPost.type.name,
+            status = savedPost.status.name,
+            tags = savedPost.tags,
+            createdAt = savedPost.createdAt,
+            updatedAt = savedPost.updatedAt,
+        )
+    }
+}

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/service/query/GetPostByIdService.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/service/query/GetPostByIdService.kt
@@ -1,0 +1,47 @@
+package cloud.luigi99.blog.content.application.post.service.query
+
+import cloud.luigi99.blog.content.application.post.port.`in`.query.GetPostByIdUseCase
+import cloud.luigi99.blog.content.application.post.port.out.PostRepository
+import cloud.luigi99.blog.content.domain.post.exception.PostNotFoundException
+import cloud.luigi99.blog.content.domain.post.vo.PostId
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * ID로 Post 조회 유스케이스 구현체
+ *
+ * Post ID를 사용하여 Post를 조회합니다.
+ */
+@Service
+class GetPostByIdService(private val postRepository: PostRepository) : GetPostByIdUseCase {
+    @Transactional(readOnly = true)
+    override fun execute(query: GetPostByIdUseCase.Query): GetPostByIdUseCase.Response {
+        log.info { "Getting post by id: ${query.postId}" }
+
+        val postId = PostId(UUID.fromString(query.postId))
+        val post =
+            postRepository.findById(postId)
+                ?: throw PostNotFoundException("Post ID ${query.postId}를 찾을 수 없습니다")
+
+        return GetPostByIdUseCase.Response(
+            postId =
+                post.entityId.value
+                    .toString(),
+            memberId =
+                post.memberId.value
+                    .toString(),
+            title = post.title.value,
+            slug = post.slug.value,
+            body = post.body.value,
+            type = post.type.name,
+            status = post.status.name,
+            tags = post.tags,
+            createdAt = post.createdAt,
+            updatedAt = post.updatedAt,
+        )
+    }
+}

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/service/query/GetPostBySlugService.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/service/query/GetPostBySlugService.kt
@@ -1,0 +1,48 @@
+package cloud.luigi99.blog.content.application.post.service.query
+
+import cloud.luigi99.blog.content.application.post.port.`in`.query.GetPostBySlugUseCase
+import cloud.luigi99.blog.content.application.post.port.out.PostRepository
+import cloud.luigi99.blog.content.domain.post.exception.PostNotFoundException
+import cloud.luigi99.blog.content.domain.post.vo.Slug
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Username과 Slug로 Post 조회 유스케이스 구현체
+ *
+ * 사용자 이름과 URL slug를 사용하여 Post를 조회합니다.
+ */
+@Service
+class GetPostBySlugService(private val postRepository: PostRepository) : GetPostBySlugUseCase {
+    @Transactional(readOnly = true)
+    override fun execute(query: GetPostBySlugUseCase.Query): GetPostBySlugUseCase.Response {
+        log.info { "Getting post by username: ${query.username}, slug: ${query.slug}" }
+
+        val slug = Slug(query.slug)
+        val post =
+            postRepository.findByUsernameAndSlug(query.username, slug)
+                ?: throw PostNotFoundException(
+                    "사용자 '${query.username}'의 Slug '${query.slug}'에 해당하는 Post를 찾을 수 없습니다",
+                )
+
+        return GetPostBySlugUseCase.Response(
+            postId =
+                post.entityId.value
+                    .toString(),
+            memberId =
+                post.memberId.value
+                    .toString(),
+            title = post.title.value,
+            slug = post.slug.value,
+            body = post.body.value,
+            type = post.type.name,
+            status = post.status.name,
+            tags = post.tags,
+            createdAt = post.createdAt,
+            updatedAt = post.updatedAt,
+        )
+    }
+}

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/service/query/GetPostsService.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/service/query/GetPostsService.kt
@@ -1,0 +1,71 @@
+package cloud.luigi99.blog.content.application.post.service.query
+
+import cloud.luigi99.blog.content.application.post.port.`in`.query.GetPostsUseCase
+import cloud.luigi99.blog.content.application.post.port.out.PostRepository
+import cloud.luigi99.blog.content.domain.post.vo.ContentType
+import cloud.luigi99.blog.content.domain.post.vo.PostStatus
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Post 목록 조회 유스케이스 구현체
+ *
+ * 필터링 조건에 따라 Post 목록을 조회합니다.
+ */
+@Service
+class GetPostsService(private val postRepository: PostRepository) : GetPostsUseCase {
+    @Transactional(readOnly = true)
+    override fun execute(query: GetPostsUseCase.Query): GetPostsUseCase.Response {
+        log.info { "Listing posts with filters - status: ${query.status}, type: ${query.type}" }
+
+        val posts =
+            when {
+                query.status != null && query.type != null -> {
+                    val status = PostStatus.valueOf(query.status)
+                    val type = ContentType.valueOf(query.type)
+                    postRepository
+                        .findAllByStatus(status)
+                        .filter { it.type == type }
+                }
+
+                query.status != null -> {
+                    val status = PostStatus.valueOf(query.status)
+                    postRepository.findAllByStatus(status)
+                }
+
+                query.type != null -> {
+                    val type = ContentType.valueOf(query.type)
+                    postRepository.findAllByContentType(type)
+                }
+
+                else -> {
+                    postRepository.findAll()
+                }
+            }
+
+        val summaries =
+            posts.map { post ->
+                GetPostsUseCase.PostSummary(
+                    postId =
+                        post.entityId.value
+                            .toString(),
+                    memberId =
+                        post.memberId.value
+                            .toString(),
+                    title = post.title.value,
+                    slug = post.slug.value,
+                    type = post.type.name,
+                    status = post.status.name,
+                    tags = post.tags,
+                    createdAt = post.createdAt,
+                )
+            }
+
+        log.info { "Found ${summaries.size} posts" }
+
+        return GetPostsUseCase.Response(posts = summaries)
+    }
+}

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/service/query/PostQueryService.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/service/query/PostQueryService.kt
@@ -1,0 +1,25 @@
+package cloud.luigi99.blog.content.application.post.service.query
+
+import cloud.luigi99.blog.content.application.post.port.`in`.query.GetPostByIdUseCase
+import cloud.luigi99.blog.content.application.post.port.`in`.query.GetPostBySlugUseCase
+import cloud.luigi99.blog.content.application.post.port.`in`.query.GetPostsUseCase
+import cloud.luigi99.blog.content.application.post.port.`in`.query.PostQueryFacade
+import org.springframework.stereotype.Service
+
+/**
+ * Post Query Facade 구현체
+ *
+ * Post 조회 관련 UseCase들을 그룹핑하여 제공합니다.
+ */
+@Service
+class PostQueryService(
+    private val getPostBySlugUseCase: GetPostBySlugUseCase,
+    private val getPostByIdUseCase: GetPostByIdUseCase,
+    private val getPostsUseCase: GetPostsUseCase,
+) : PostQueryFacade {
+    override fun getPostBySlug(): GetPostBySlugUseCase = getPostBySlugUseCase
+
+    override fun getPostById(): GetPostByIdUseCase = getPostByIdUseCase
+
+    override fun getPosts(): GetPostsUseCase = getPostsUseCase
+}

--- a/modules/content/application/src/test/kotlin/cloud/luigi99/blog/content/application/post/service/command/CreatePostServiceTest.kt
+++ b/modules/content/application/src/test/kotlin/cloud/luigi99/blog/content/application/post/service/command/CreatePostServiceTest.kt
@@ -1,0 +1,301 @@
+package cloud.luigi99.blog.content.application.post.service.command
+
+import cloud.luigi99.blog.common.domain.event.EventManager
+import cloud.luigi99.blog.content.application.post.port.`in`.command.CreatePostUseCase
+import cloud.luigi99.blog.content.application.post.port.out.PostRepository
+import cloud.luigi99.blog.content.domain.post.exception.DuplicateSlugException
+import cloud.luigi99.blog.content.domain.post.model.Post
+import cloud.luigi99.blog.content.domain.post.vo.Body
+import cloud.luigi99.blog.content.domain.post.vo.ContentType
+import cloud.luigi99.blog.content.domain.post.vo.PostId
+import cloud.luigi99.blog.content.domain.post.vo.PostStatus
+import cloud.luigi99.blog.content.domain.post.vo.Slug
+import cloud.luigi99.blog.content.domain.post.vo.Title
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.verify
+import java.util.UUID
+
+/**
+ * CreatePostService 테스트
+ */
+class CreatePostServiceTest :
+    BehaviorSpec({
+
+        beforeTest {
+            mockkObject(EventManager)
+            every { EventManager.eventContextManager } returns mockk(relaxed = true)
+        }
+
+        Given("블로그 글을 생성할 때") {
+            val postRepository = mockk<PostRepository>()
+            val service = CreatePostService(postRepository)
+            val memberId = UUID.randomUUID().toString()
+
+            When("유효한 memberId, 제목, slug로 생성하면") {
+                val command =
+                    CreatePostUseCase.Command(
+                        memberId = memberId,
+                        title = "테스트 블로그 글",
+                        slug = "test-blog-post",
+                        body = "# 제목\n본문 내용",
+                        type = "BLOG",
+                    )
+
+                val savedPostSlot = slot<Post>()
+                val savedPost =
+                    Post.from(
+                        entityId = PostId.generate(),
+                        memberId = MemberId.from(memberId),
+                        title = Title("테스트 블로그 글"),
+                        slug = Slug("test-blog-post"),
+                        body = Body("# 제목\n본문 내용"),
+                        type = ContentType.BLOG,
+                        status = PostStatus.DRAFT,
+                        tags = emptySet(),
+                        createdAt = null,
+                        updatedAt = null,
+                    )
+
+                every {
+                    postRepository.existsByMemberIdAndSlug(
+                        MemberId.from(memberId),
+                        Slug("test-blog-post"),
+                    )
+                } returns false
+                every { postRepository.save(capture(savedPostSlot)) } returns savedPost
+
+                val response = service.execute(command)
+
+                Then("Post ID가 반환된다") {
+                    response.postId shouldNotBe null
+                }
+
+                Then("memberId가 반환된다") {
+                    response.memberId shouldBe memberId
+                }
+
+                Then("제목이 반환된다") {
+                    response.title shouldBe "테스트 블로그 글"
+                }
+
+                Then("본문이 반환된다") {
+                    response.body shouldBe "# 제목\n본문 내용"
+                }
+
+                Then("타입이 반환된다") {
+                    response.type shouldBe "BLOG"
+                }
+
+                Then("DRAFT 상태로 생성된다") {
+                    response.status shouldBe "DRAFT"
+                }
+
+                Then("태그가 빈 Set으로 반환된다") {
+                    response.tags shouldBe emptySet()
+                }
+
+                Then("Repository save가 호출된다") {
+                    verify(exactly = 1) { postRepository.save(any()) }
+                }
+            }
+        }
+
+        Given("같은 사용자가 중복된 slug로 글을 생성하려고 할 때") {
+            val postRepository = mockk<PostRepository>()
+            val service = CreatePostService(postRepository)
+            val memberId = UUID.randomUUID().toString()
+
+            When("이미 자신이 사용 중인 slug를 사용하면") {
+                val command =
+                    CreatePostUseCase.Command(
+                        memberId = memberId,
+                        title = "중복 테스트",
+                        slug = "duplicate-slug",
+                        body = "내용",
+                        type = "BLOG",
+                    )
+
+                every {
+                    postRepository.existsByMemberIdAndSlug(
+                        MemberId.from(memberId),
+                        Slug("duplicate-slug"),
+                    )
+                } returns true
+
+                Then("DuplicateSlugException이 발생한다") {
+                    shouldThrow<DuplicateSlugException> {
+                        service.execute(command)
+                    }
+                }
+            }
+        }
+
+        Given("다른 사용자가 동일한 slug를 사용할 때") {
+            val postRepository = mockk<PostRepository>()
+            val service = CreatePostService(postRepository)
+            val member1Id = UUID.randomUUID().toString()
+            val member2Id = UUID.randomUUID().toString()
+
+            When("다른 사용자가 이미 사용 중인 slug로 글을 생성하면") {
+                val command =
+                    CreatePostUseCase.Command(
+                        memberId = member2Id,
+                        title = "다른 사용자의 글",
+                        slug = "same-slug",
+                        body = "내용",
+                        type = "BLOG",
+                    )
+
+                val savedPost =
+                    Post
+                        .from(
+                            entityId = PostId.generate(),
+                            memberId = MemberId.from(member2Id),
+                            title = Title("다른 사용자의 글"),
+                            slug = Slug("same-slug"),
+                            body = Body("내용"),
+                            type = ContentType.BLOG,
+                            status = PostStatus.DRAFT,
+                            tags = emptySet(),
+                            createdAt = null,
+                            updatedAt = null,
+                        )
+
+                // member2는 same-slug를 사용하지 않았음
+                every {
+                    postRepository.existsByMemberIdAndSlug(
+                        MemberId.from(member2Id),
+                        Slug("same-slug"),
+                    )
+                } returns false
+                every { postRepository.save(any()) } returns savedPost
+
+                val response = service.execute(command)
+
+                Then("글이 정상적으로 생성된다") {
+                    response.postId shouldNotBe null
+                    response.slug shouldBe "same-slug"
+                }
+            }
+        }
+
+        Given("태그와 함께 글을 생성할 때") {
+            val postRepository = mockk<PostRepository>()
+            val service = CreatePostService(postRepository)
+            val memberId = UUID.randomUUID().toString()
+
+            When("여러 태그를 포함하여 생성하면") {
+                val command =
+                    CreatePostUseCase.Command(
+                        memberId = memberId,
+                        title = "태그 테스트",
+                        slug = "tagged-post",
+                        body = "태그가 있는 글",
+                        type = "BLOG",
+                        tags = listOf("Kotlin", "Spring", "DDD"),
+                    )
+
+                val savedPost =
+                    Post
+                        .from(
+                            entityId = PostId.generate(),
+                            memberId = MemberId.from(memberId),
+                            title = Title("태그 테스트"),
+                            slug = Slug("tagged-post"),
+                            body = Body("태그가 있는 글"),
+                            type = ContentType.BLOG,
+                            status = PostStatus.DRAFT,
+                            tags = setOf("Kotlin", "Spring", "DDD"),
+                            createdAt = null,
+                            updatedAt = null,
+                        )
+
+                every {
+                    postRepository.existsByMemberIdAndSlug(
+                        MemberId.from(memberId),
+                        Slug("tagged-post"),
+                    )
+                } returns false
+                every { postRepository.save(any()) } returns savedPost
+
+                val response = service.execute(command)
+
+                Then("태그가 모두 반환된다") {
+                    response.tags shouldBe setOf("Kotlin", "Spring", "DDD")
+                }
+            }
+        }
+
+        Given("여러 타입의 글을 생성할 때") {
+            val postRepository = mockk<PostRepository>()
+            val service = CreatePostService(postRepository)
+            val memberId = UUID.randomUUID().toString()
+
+            When("BLOG 타입으로 생성하면") {
+                val command =
+                    CreatePostUseCase.Command(
+                        memberId = memberId,
+                        title = "블로그 글",
+                        slug = "blog-post",
+                        body = "블로그 내용",
+                        type = "BLOG",
+                    )
+
+                val postSlot = slot<Post>()
+                every {
+                    postRepository.existsByMemberIdAndSlug(
+                        MemberId.from(memberId),
+                        Slug("blog-post"),
+                    )
+                } returns false
+                every { postRepository.save(capture(postSlot)) } answers { firstArg() }
+
+                service.execute(command)
+
+                Then("BLOG 타입으로 저장된다") {
+                    val post = postSlot.captured
+                    post.type shouldBe ContentType.BLOG
+                }
+
+                Then("memberId가 설정된다") {
+                    val post = postSlot.captured
+                    post.memberId shouldBe MemberId.from(memberId)
+                }
+            }
+
+            When("PORTFOLIO 타입으로 생성하면") {
+                val command =
+                    CreatePostUseCase.Command(
+                        memberId = memberId,
+                        title = "포트폴리오",
+                        slug = "portfolio",
+                        body = "프로젝트 설명",
+                        type = "PORTFOLIO",
+                    )
+
+                val postSlot = slot<Post>()
+                every {
+                    postRepository.existsByMemberIdAndSlug(
+                        MemberId.from(memberId),
+                        Slug("portfolio"),
+                    )
+                } returns false
+                every { postRepository.save(capture(postSlot)) } answers { firstArg() }
+
+                service.execute(command)
+
+                Then("PORTFOLIO 타입으로 저장된다") {
+                    val post = postSlot.captured
+                    post.type shouldBe ContentType.PORTFOLIO
+                }
+            }
+        }
+    })

--- a/modules/content/application/src/test/kotlin/cloud/luigi99/blog/content/application/post/service/command/UpdatePostServiceTest.kt
+++ b/modules/content/application/src/test/kotlin/cloud/luigi99/blog/content/application/post/service/command/UpdatePostServiceTest.kt
@@ -1,0 +1,274 @@
+package cloud.luigi99.blog.content.application.post.service.command
+
+import cloud.luigi99.blog.common.domain.event.EventManager
+import cloud.luigi99.blog.content.application.post.port.`in`.command.UpdatePostUseCase
+import cloud.luigi99.blog.content.application.post.port.out.PostRepository
+import cloud.luigi99.blog.content.domain.post.exception.PostNotFoundException
+import cloud.luigi99.blog.content.domain.post.exception.UnauthorizedPostAccessException
+import cloud.luigi99.blog.content.domain.post.model.Post
+import cloud.luigi99.blog.content.domain.post.vo.Body
+import cloud.luigi99.blog.content.domain.post.vo.ContentType
+import cloud.luigi99.blog.content.domain.post.vo.PostId
+import cloud.luigi99.blog.content.domain.post.vo.Slug
+import cloud.luigi99.blog.content.domain.post.vo.Title
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verify
+import java.util.UUID
+
+/**
+ * UpdatePostService 테스트
+ */
+class UpdatePostServiceTest :
+    BehaviorSpec({
+
+        beforeTest {
+            mockkObject(EventManager)
+            every { EventManager.eventContextManager } returns mockk(relaxed = true)
+        }
+
+        Given("글을 수정할 때") {
+            val postRepository = mockk<PostRepository>()
+            val service = UpdatePostService(postRepository)
+            val memberId = MemberId.generate()
+
+            When("작성자가 제목과 본문을 수정하면") {
+                val postId = PostId.generate()
+                val command =
+                    UpdatePostUseCase.Command(
+                        memberId = memberId.value.toString(),
+                        postId = postId.value.toString(),
+                        title = "수정된 제목",
+                        body = "수정된 본문",
+                    )
+
+                val originalPost =
+                    Post.create(
+                        memberId = memberId,
+                        title = Title("원본 제목"),
+                        slug = Slug("original-post"),
+                        body = Body("원본 본문"),
+                        type = ContentType.BLOG,
+                    )
+
+                val updatedPost = originalPost.update(Title("수정된 제목"), Body("수정된 본문"))
+
+                every { postRepository.findById(postId) } returns originalPost
+                every { postRepository.save(any()) } returns updatedPost
+
+                val response = service.execute(command)
+
+                Then("수정된 제목이 반환된다") {
+                    response.title shouldBe "수정된 제목"
+                }
+
+                Then("수정된 본문이 반환된다") {
+                    response.body shouldBe "수정된 본문"
+                }
+
+                Then("Repository save가 호출된다") {
+                    verify(exactly = 1) { postRepository.save(any()) }
+                }
+            }
+        }
+
+        Given("글의 상태를 PUBLISHED로 변경할 때") {
+            val postRepository = mockk<PostRepository>()
+            val service = UpdatePostService(postRepository)
+            val memberId = MemberId.generate()
+
+            When("작성자가 status를 PUBLISHED로 수정하면") {
+                val postId = PostId.generate()
+                val command =
+                    UpdatePostUseCase.Command(
+                        memberId = memberId.value.toString(),
+                        postId = postId.value.toString(),
+                        title = null,
+                        body = null,
+                        status = "PUBLISHED",
+                    )
+
+                val originalPost =
+                    Post.create(
+                        memberId = memberId,
+                        title = Title("원본 제목"),
+                        slug = Slug("original-post"),
+                        body = Body("원본 본문"),
+                        type = ContentType.BLOG,
+                    )
+
+                val publishedPost = originalPost.publish()
+
+                every { postRepository.findById(postId) } returns originalPost
+                every { postRepository.save(any()) } returns publishedPost
+
+                val response = service.execute(command)
+
+                Then("상태가 PUBLISHED로 변경된다") {
+                    response.status shouldBe "PUBLISHED"
+                }
+
+                Then("Repository save가 호출된다") {
+                    verify(exactly = 1) { postRepository.save(any()) }
+                }
+            }
+        }
+
+        Given("글의 상태를 ARCHIVED로 변경할 때") {
+            val postRepository = mockk<PostRepository>()
+            val service = UpdatePostService(postRepository)
+            val memberId = MemberId.generate()
+
+            When("작성자가 status를 ARCHIVED로 수정하면") {
+                val postId = PostId.generate()
+                val command =
+                    UpdatePostUseCase.Command(
+                        memberId = memberId.value.toString(),
+                        postId = postId.value.toString(),
+                        title = null,
+                        body = null,
+                        status = "ARCHIVED",
+                    )
+
+                val originalPost =
+                    Post.create(
+                        memberId = memberId,
+                        title = Title("원본 제목"),
+                        slug = Slug("original-post"),
+                        body = Body("원본 본문"),
+                        type = ContentType.BLOG,
+                    )
+
+                val archivedPost = originalPost.archive()
+
+                every { postRepository.findById(postId) } returns originalPost
+                every { postRepository.save(any()) } returns archivedPost
+
+                val response = service.execute(command)
+
+                Then("상태가 ARCHIVED로 변경된다") {
+                    response.status shouldBe "ARCHIVED"
+                }
+
+                Then("Repository save가 호출된다") {
+                    verify(exactly = 1) { postRepository.save(any()) }
+                }
+            }
+        }
+
+        Given("제목, 본문, 상태를 동시에 수정할 때") {
+            val postRepository = mockk<PostRepository>()
+            val service = UpdatePostService(postRepository)
+            val memberId = MemberId.generate()
+
+            When("작성자가 모든 필드를 수정하면") {
+                val postId = PostId.generate()
+                val command =
+                    UpdatePostUseCase.Command(
+                        memberId = memberId.value.toString(),
+                        postId = postId.value.toString(),
+                        title = "수정된 제목",
+                        body = "수정된 본문",
+                        status = "PUBLISHED",
+                    )
+
+                val originalPost =
+                    Post.create(
+                        memberId = memberId,
+                        title = Title("원본 제목"),
+                        slug = Slug("original-post"),
+                        body = Body("원본 본문"),
+                        type = ContentType.BLOG,
+                    )
+
+                val updatedPost = originalPost.update(Title("수정된 제목"), Body("수정된 본문"))
+                val publishedPost = updatedPost.publish()
+
+                every { postRepository.findById(postId) } returns originalPost
+                every { postRepository.save(any()) } returns publishedPost
+
+                val response = service.execute(command)
+
+                Then("제목이 변경된다") {
+                    response.title shouldBe "수정된 제목"
+                }
+
+                Then("본문이 변경된다") {
+                    response.body shouldBe "수정된 본문"
+                }
+
+                Then("상태가 PUBLISHED로 변경된다") {
+                    response.status shouldBe "PUBLISHED"
+                }
+
+                Then("Repository save가 호출된다") {
+                    verify(exactly = 1) { postRepository.save(any()) }
+                }
+            }
+        }
+
+        Given("존재하지 않는 글을 수정하려고 할 때") {
+            val postRepository = mockk<PostRepository>()
+            val service = UpdatePostService(postRepository)
+            val memberId = MemberId.generate()
+
+            When("없는 Post ID로 수정하면") {
+                val postId = UUID.randomUUID()
+                val command =
+                    UpdatePostUseCase.Command(
+                        memberId = memberId.value.toString(),
+                        postId = postId.toString(),
+                        title = "수정된 제목",
+                        body = "수정된 본문",
+                    )
+
+                every { postRepository.findById(PostId(postId)) } returns null
+
+                Then("PostNotFoundException이 발생한다") {
+                    shouldThrow<PostNotFoundException> {
+                        service.execute(command)
+                    }
+                }
+            }
+        }
+
+        Given("다른 사용자의 글을 수정하려고 할 때") {
+            val postRepository = mockk<PostRepository>()
+            val service = UpdatePostService(postRepository)
+            val authorId = MemberId.generate()
+            val otherMemberId = MemberId.generate()
+
+            When("작성자가 아닌 사용자가 수정하려고 하면") {
+                val postId = PostId.generate()
+                val command =
+                    UpdatePostUseCase.Command(
+                        memberId = otherMemberId.value.toString(),
+                        postId = postId.value.toString(),
+                        title = "수정 시도",
+                        body = "수정 시도",
+                    )
+
+                val originalPost =
+                    Post.create(
+                        memberId = authorId,
+                        title = Title("원본 제목"),
+                        slug = Slug("original-post"),
+                        body = Body("원본 본문"),
+                        type = ContentType.BLOG,
+                    )
+
+                every { postRepository.findById(postId) } returns originalPost
+
+                Then("UnauthorizedPostAccessException이 발생한다") {
+                    shouldThrow<UnauthorizedPostAccessException> {
+                        service.execute(command)
+                    }
+                }
+            }
+        }
+    })

--- a/modules/content/application/src/test/kotlin/cloud/luigi99/blog/content/application/post/service/query/GetPostByIdServiceTest.kt
+++ b/modules/content/application/src/test/kotlin/cloud/luigi99/blog/content/application/post/service/query/GetPostByIdServiceTest.kt
@@ -1,0 +1,81 @@
+package cloud.luigi99.blog.content.application.post.service.query
+
+import cloud.luigi99.blog.common.domain.event.EventManager
+import cloud.luigi99.blog.content.application.post.port.`in`.query.GetPostByIdUseCase
+import cloud.luigi99.blog.content.application.post.port.out.PostRepository
+import cloud.luigi99.blog.content.domain.post.exception.PostNotFoundException
+import cloud.luigi99.blog.content.domain.post.model.Post
+import cloud.luigi99.blog.content.domain.post.vo.Body
+import cloud.luigi99.blog.content.domain.post.vo.ContentType
+import cloud.luigi99.blog.content.domain.post.vo.PostId
+import cloud.luigi99.blog.content.domain.post.vo.Slug
+import cloud.luigi99.blog.content.domain.post.vo.Title
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import java.util.UUID
+
+/**
+ * GetPostByIdService 테스트
+ */
+class GetPostByIdServiceTest :
+    BehaviorSpec({
+
+        beforeTest {
+            mockkObject(EventManager)
+            every { EventManager.eventContextManager } returns mockk(relaxed = true)
+        }
+
+        Given("ID로 글을 조회할 때") {
+            val postRepository = mockk<PostRepository>()
+            val service = GetPostByIdService(postRepository)
+
+            When("존재하는 Post ID로 조회하면") {
+                val postId = PostId.generate()
+                val query = GetPostByIdUseCase.Query(postId = postId.value.toString())
+
+                val post =
+                    Post.create(
+                        memberId = MemberId.generate(),
+                        title = Title("테스트 글"),
+                        slug = Slug("test-post"),
+                        body = Body("테스트 내용"),
+                        type = ContentType.BLOG,
+                    )
+
+                every { postRepository.findById(postId) } returns post
+
+                val response = service.execute(query)
+
+                Then("제목이 반환된다") {
+                    response.title shouldBe "테스트 글"
+                }
+
+                Then("본문이 반환된다") {
+                    response.body shouldBe "테스트 내용"
+                }
+            }
+        }
+
+        Given("존재하지 않는 ID로 조회할 때") {
+            val postRepository = mockk<PostRepository>()
+            val service = GetPostByIdService(postRepository)
+
+            When("없는 Post ID로 조회하면") {
+                val postId = UUID.randomUUID()
+                val query = GetPostByIdUseCase.Query(postId = postId.toString())
+
+                every { postRepository.findById(PostId(postId)) } returns null
+
+                Then("PostNotFoundException이 발생한다") {
+                    shouldThrow<PostNotFoundException> {
+                        service.execute(query)
+                    }
+                }
+            }
+        }
+    })

--- a/modules/content/application/src/test/kotlin/cloud/luigi99/blog/content/application/post/service/query/GetPostBySlugServiceTest.kt
+++ b/modules/content/application/src/test/kotlin/cloud/luigi99/blog/content/application/post/service/query/GetPostBySlugServiceTest.kt
@@ -1,0 +1,102 @@
+package cloud.luigi99.blog.content.application.post.service.query
+
+import cloud.luigi99.blog.common.domain.event.EventManager
+import cloud.luigi99.blog.content.application.post.port.`in`.query.GetPostBySlugUseCase
+import cloud.luigi99.blog.content.application.post.port.out.PostRepository
+import cloud.luigi99.blog.content.domain.post.exception.PostNotFoundException
+import cloud.luigi99.blog.content.domain.post.model.Post
+import cloud.luigi99.blog.content.domain.post.vo.Body
+import cloud.luigi99.blog.content.domain.post.vo.ContentType
+import cloud.luigi99.blog.content.domain.post.vo.Slug
+import cloud.luigi99.blog.content.domain.post.vo.Title
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+
+/**
+ * GetPostBySlugService 테스트
+ */
+class GetPostBySlugServiceTest :
+    BehaviorSpec({
+
+        beforeTest {
+            mockkObject(EventManager)
+            every { EventManager.eventContextManager } returns mockk(relaxed = true)
+        }
+
+        Given("Username과 Slug로 글을 조회할 때") {
+            val postRepository = mockk<PostRepository>()
+            // MemberClient 제거됨
+            val service = GetPostBySlugService(postRepository)
+
+            When("존재하는 Username과 Slug로 조회하면") {
+                val memberId = MemberId.generate()
+                val query = GetPostBySlugUseCase.Query(username = "testuser", slug = "test-post")
+
+                val post =
+                    Post.create(
+                        memberId = memberId,
+                        title = Title("테스트 글"),
+                        slug = Slug("test-post"),
+                        body = Body("테스트 내용"),
+                        type = ContentType.BLOG,
+                    )
+
+                // MemberClient 호출 모킹 제거
+                // findByUsernameAndSlug 모킹 추가
+                every { postRepository.findByUsernameAndSlug("testuser", Slug("test-post")) } returns post
+
+                val response = service.execute(query)
+
+                Then("제목이 반환된다") {
+                    response.title shouldBe "테스트 글"
+                }
+
+                Then("Slug가 반환된다") {
+                    response.slug shouldBe "test-post"
+                }
+
+                Then("본문이 반환된다") {
+                    response.body shouldBe "테스트 내용"
+                }
+            }
+        }
+
+        Given("존재하지 않는 Username으로 조회할 때") {
+            val postRepository = mockk<PostRepository>()
+            val service = GetPostBySlugService(postRepository)
+
+            When("존재하지 않는 Username으로 조회하면") {
+                val query = GetPostBySlugUseCase.Query(username = "nonexistent", slug = "test-post")
+
+                every { postRepository.findByUsernameAndSlug("nonexistent", Slug("test-post")) } returns null
+
+                Then("PostNotFoundException이 발생한다") {
+                    shouldThrow<PostNotFoundException> {
+                        service.execute(query)
+                    }
+                }
+            }
+        }
+
+        Given("존재하지 않는 Slug로 조회할 때") {
+            val postRepository = mockk<PostRepository>()
+            val service = GetPostBySlugService(postRepository)
+
+            When("존재하는 Username이지만 없는 Slug로 조회하면") {
+                val query = GetPostBySlugUseCase.Query(username = "testuser", slug = "non-existent")
+
+                every { postRepository.findByUsernameAndSlug("testuser", Slug("non-existent")) } returns null
+
+                Then("PostNotFoundException이 발생한다") {
+                    shouldThrow<PostNotFoundException> {
+                        service.execute(query)
+                    }
+                }
+            }
+        }
+    })

--- a/modules/content/application/src/test/kotlin/cloud/luigi99/blog/content/application/post/service/query/GetPostsServiceTest.kt
+++ b/modules/content/application/src/test/kotlin/cloud/luigi99/blog/content/application/post/service/query/GetPostsServiceTest.kt
@@ -1,0 +1,121 @@
+package cloud.luigi99.blog.content.application.post.service.query
+
+import cloud.luigi99.blog.common.domain.event.EventManager
+import cloud.luigi99.blog.content.application.post.port.`in`.query.GetPostsUseCase
+import cloud.luigi99.blog.content.application.post.port.out.PostRepository
+import cloud.luigi99.blog.content.domain.post.model.Post
+import cloud.luigi99.blog.content.domain.post.vo.Body
+import cloud.luigi99.blog.content.domain.post.vo.ContentType
+import cloud.luigi99.blog.content.domain.post.vo.PostStatus
+import cloud.luigi99.blog.content.domain.post.vo.Slug
+import cloud.luigi99.blog.content.domain.post.vo.Title
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+
+/**
+ * GetPostsService 테스트
+ */
+class GetPostsServiceTest :
+    BehaviorSpec({
+
+        beforeTest {
+            mockkObject(EventManager)
+            every { EventManager.eventContextManager } returns mockk(relaxed = true)
+        }
+
+        Given("전체 글 목록을 조회할 때") {
+            val postRepository = mockk<PostRepository>()
+            val service = GetPostsService(postRepository)
+
+            When("필터 없이 조회하면") {
+                val query = GetPostsUseCase.Query()
+
+                val posts =
+                    listOf(
+                        Post.create(
+                            memberId = MemberId.generate(),
+                            title = Title("글1"),
+                            slug = Slug("post-1"),
+                            body = Body("내용1"),
+                            type = ContentType.BLOG,
+                        ),
+                        Post.create(
+                            memberId = MemberId.generate(),
+                            title = Title("글2"),
+                            slug = Slug("post-2"),
+                            body = Body("내용2"),
+                            type = ContentType.PORTFOLIO,
+                        ),
+                    )
+
+                every { postRepository.findAll() } returns posts
+
+                val response = service.execute(query)
+
+                Then("모든 글이 반환된다") {
+                    response.posts.size shouldBe 2
+                }
+            }
+        }
+
+        Given("상태별로 글 목록을 조회할 때") {
+            val postRepository = mockk<PostRepository>()
+            val service = GetPostsService(postRepository)
+
+            When("PUBLISHED 상태로 필터링하면") {
+                val query = GetPostsUseCase.Query(status = "PUBLISHED")
+
+                val publishedPosts =
+                    listOf(
+                        Post
+                            .create(
+                                memberId = MemberId.generate(),
+                                title = Title("발행 글"),
+                                slug = Slug("published"),
+                                body = Body("발행 내용"),
+                                type = ContentType.BLOG,
+                            ).publish(),
+                    )
+
+                every { postRepository.findAllByStatus(PostStatus.PUBLISHED) } returns publishedPosts
+
+                val response = service.execute(query)
+
+                Then("PUBLISHED 글만 반환된다") {
+                    response.posts.size shouldBe 1
+                }
+            }
+        }
+
+        Given("타입별로 글 목록을 조회할 때") {
+            val postRepository = mockk<PostRepository>()
+            val service = GetPostsService(postRepository)
+
+            When("PORTFOLIO 타입으로 필터링하면") {
+                val query = GetPostsUseCase.Query(type = "PORTFOLIO")
+
+                val portfolioPosts =
+                    listOf(
+                        Post.create(
+                            memberId = MemberId.generate(),
+                            title = Title("포트폴리오"),
+                            slug = Slug("portfolio"),
+                            body = Body("프로젝트"),
+                            type = ContentType.PORTFOLIO,
+                        ),
+                    )
+
+                every { postRepository.findAllByContentType(ContentType.PORTFOLIO) } returns portfolioPosts
+
+                val response = service.execute(query)
+
+                Then("PORTFOLIO 글만 반환된다") {
+                    response.posts.size shouldBe 1
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## 📋 개요
<!-- 이 PR이 무엇을 해결하거나 추가하는지 간략하게 설명해주세요. -->
- Post 관련 서비스, 유스케이스, 레포지토리 구현 및 테스트 추가
- 블로그 글 생성, 수정, 상태 변경, 단일 조회 및 목록 조회 기능 지원
- Slug 중복 검증 및 권한 검증 로직 포함
- content 모듈의 빌드 스크립트와 의존성 설정 추가

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 링크해주세요. ex) #123 -->
- Closes #49

## ☑️ 체크리스트
- [ ] 코딩 컨벤션을 준수했나요? (`./gradlew ktlintCheck`)
- [ ] 모든 테스트를 통과했나요? (`./gradlew test`)
- [ ] 불필요한 주석이나 로그는 제거했나요?