### PR TITLE
feat: Content Post Adapter 모듈 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,6 +24,8 @@ dependencies {
 
     implementation(project(":modules:content:domain"))
     implementation(project(":modules:content:application"))
+    implementation(project(":modules:content:adapter:in:web"))
+    implementation(project(":modules:content:adapter:out:persistence:jpa"))
 
     implementation(libs.bundles.spring.boot.web)
     implementation(libs.bundles.spring.boot.data)

--- a/modules/content/adapter/in/web/build.gradle.kts
+++ b/modules/content/adapter/in/web/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    springBootConventions
+}
+
+dependencies {
+    implementation(project(":libs:common"))
+    implementation(project(":modules:content:domain"))
+    implementation(project(":modules:content:application"))
+    implementation(project(":libs:adapter:web"))
+
+    implementation(libs.bundles.spring.boot.web)
+    implementation(libs.bundles.spring.boot.security)
+
+    testImplementation(libs.bundles.kotlin.test)
+}

--- a/modules/content/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/PostApi.kt
+++ b/modules/content/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/PostApi.kt
@@ -1,0 +1,358 @@
+package cloud.luigi99.blog.content.adapter.`in`.web.post
+
+import cloud.luigi99.blog.adapter.web.dto.CommonResponse
+import cloud.luigi99.blog.content.adapter.`in`.web.post.dto.CreatePostRequest
+import cloud.luigi99.blog.content.adapter.`in`.web.post.dto.PostListResponse
+import cloud.luigi99.blog.content.adapter.`in`.web.post.dto.PostResponse
+import cloud.luigi99.blog.content.adapter.`in`.web.post.dto.UpdatePostRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
+
+/**
+ * Post API 인터페이스
+ *
+ * 블로그 글 관련 API를 정의합니다.
+ */
+@Tag(name = "Post", description = "블로그 글 관리 API")
+interface PostApi {
+    @Operation(
+        summary = "블로그 글 생성",
+        description = "새로운 블로그 글 또는 포트폴리오를 생성합니다. 초기 상태는 DRAFT입니다.",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "201",
+                description = "글 생성 성공",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "CreatePostSuccess",
+                                value = """
+                                {
+                                  "success": true,
+                                  "data": {
+                                    "postId": "550e8400-e29b-41d4-a716-446655440000",
+                                    "memberId": "987e6543-e21b-98d7-a654-426614174111",
+                                    "title": "Kotlin으로 DDD 구현하기",
+                                    "slug": "kotlin-ddd-implementation",
+                                    "body": "# 시작하기\n\nKotlin과 DDD를 결합하면...",
+                                    "type": "BLOG",
+                                    "status": "DRAFT",
+                                    "tags": ["Kotlin", "DDD"],
+                                    "createdAt": "2025-12-31T12:00:00",
+                                    "updatedAt": "2025-12-31T12:00:00"
+                                  },
+                                  "error": null,
+                                  "timestamp": "2025-12-31T12:00:00"
+                                }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (Slug 중복 등)",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "SlugDuplicate",
+                                value = """
+                                {
+                                  "success": false,
+                                  "data": null,
+                                  "error": {
+                                    "code": "CONTENT_002",
+                                    "message": "이미 존재하는 slug입니다."
+                                  },
+                                  "timestamp": "2025-12-31T12:00:00"
+                                }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "인증되지 않은 사용자",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "Unauthorized",
+                                value = """
+                                {
+                                  "success": false,
+                                  "data": null,
+                                  "error": {
+                                    "code": "AUTH_001",
+                                    "message": "인증에 실패했습니다."
+                                  },
+                                  "timestamp": "2025-12-31T12:00:00"
+                                }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun createPost(
+        @AuthenticationPrincipal memberId: String,
+        @RequestBody request: CreatePostRequest,
+    ): ResponseEntity<CommonResponse<PostResponse>>
+
+    @Operation(
+        summary = "블로그 글 수정",
+        description = "기존 블로그 글의 제목, 본문, 상태를 선택적으로 수정합니다. null인 필드는 변경되지 않습니다.",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "글 수정 성공",
+                content = [Content(schema = Schema(implementation = CommonResponse::class))],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "인증되지 않은 사용자",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "Unauthorized",
+                                value = """
+                                {
+                                  "success": false,
+                                  "data": null,
+                                  "error": {
+                                    "code": "AUTH_001",
+                                    "message": "인증에 실패했습니다."
+                                  },
+                                  "timestamp": "2025-12-31T12:00:00"
+                                }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "글을 찾을 수 없음",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "PostNotFound",
+                                value = """
+                                {
+                                  "success": false,
+                                  "data": null,
+                                  "error": {
+                                    "code": "CONTENT_001",
+                                    "message": "글을 찾을 수 없습니다."
+                                  },
+                                  "timestamp": "2025-12-31T12:00:00"
+                                }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun updatePost(
+        @AuthenticationPrincipal memberId: String,
+        @Parameter(description = "Post ID") @PathVariable postId: String,
+        @RequestBody request: UpdatePostRequest,
+    ): ResponseEntity<CommonResponse<PostResponse>>
+
+    @Operation(
+        summary = "ID로 블로그 글 조회",
+        description = "Post ID로 단일 블로그 글을 조회합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "글 조회 성공",
+                content = [Content(schema = Schema(implementation = CommonResponse::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "글을 찾을 수 없음",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "PostNotFound",
+                                value = """
+                                {
+                                  "success": false,
+                                  "data": null,
+                                  "error": {
+                                    "code": "CONTENT_001",
+                                    "message": "글을 찾을 수 없습니다."
+                                  },
+                                  "timestamp": "2025-12-31T12:00:00"
+                                }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getPostById(
+        @Parameter(description = "Post ID") @PathVariable postId: String,
+    ): ResponseEntity<CommonResponse<PostResponse>>
+
+    @Operation(
+        summary = "사용자의 특정 Slug 블로그 글 조회",
+        description = "사용자 이름과 URL Slug로 단일 블로그 글을 조회합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "글 조회 성공",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "GetPostSuccess",
+                                value = """
+                                {
+                                  "success": true,
+                                  "data": {
+                                    "postId": "550e8400-e29b-41d4-a716-446655440000",
+                                    "memberId": "987e6543-e21b-98d7-a654-426614174111",
+                                    "title": "Kotlin으로 DDD 구현하기",
+                                    "slug": "kotlin-ddd-implementation",
+                                    "body": "# 시작하기\n\nKotlin과 DDD를 결합하면...",
+                                    "type": "BLOG",
+                                    "status": "PUBLISHED",
+                                    "tags": ["Kotlin", "DDD"],
+                                    "createdAt": "2025-12-31T12:00:00",
+                                    "updatedAt": "2025-12-31T12:00:00"
+                                  },
+                                  "error": null,
+                                  "timestamp": "2025-12-31T12:00:00"
+                                }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "글을 찾을 수 없음",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "PostNotFound",
+                                value = """
+                                {
+                                  "success": false,
+                                  "data": null,
+                                  "error": {
+                                    "code": "CONTENT_001",
+                                    "message": "글을 찾을 수 없습니다."
+                                  },
+                                  "timestamp": "2025-12-31T12:00:00"
+                                }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getPostByUsernameAndSlug(
+        @Parameter(description = "사용자 이름") @PathVariable username: String,
+        @Parameter(description = "URL Slug") @PathVariable slug: String,
+    ): ResponseEntity<CommonResponse<PostResponse>>
+
+    @Operation(
+        summary = "블로그 글 목록 조회",
+        description = "블로그 글 목록을 조회합니다. 상태 및 타입 필터링이 가능합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "목록 조회 성공",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "ListPostsSuccess",
+                                value = """
+                                {
+                                  "success": true,
+                                  "data": {
+                                    "posts": [
+                                      {
+                                        "postId": "550e8400-e29b-41d4-a716-446655440000",
+                                        "memberId": "987e6543-e21b-98d7-a654-426614174111",
+                                        "title": "Kotlin으로 DDD 구현하기",
+                                        "slug": "kotlin-ddd-implementation",
+                                        "type": "BLOG",
+                                        "status": "PUBLISHED",
+                                        "tags": ["Kotlin", "DDD"],
+                                        "createdAt": "2025-12-31T12:00:00"
+                                      }
+                                    ],
+                                    "total": 1
+                                  },
+                                  "error": null,
+                                  "timestamp": "2025-12-31T12:00:00"
+                                }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getPosts(
+        @Parameter(description = "상태 필터 (DRAFT, PUBLISHED, ARCHIVED)") @RequestParam(required = false) status: String?,
+        @Parameter(description = "타입 필터 (BLOG, PORTFOLIO)") @RequestParam(required = false) type: String?,
+    ): ResponseEntity<CommonResponse<PostListResponse>>
+}

--- a/modules/content/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/PostController.kt
+++ b/modules/content/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/PostController.kt
@@ -1,0 +1,207 @@
+package cloud.luigi99.blog.content.adapter.`in`.web.post
+
+import cloud.luigi99.blog.adapter.web.dto.CommonResponse
+import cloud.luigi99.blog.content.adapter.`in`.web.post.dto.CreatePostRequest
+import cloud.luigi99.blog.content.adapter.`in`.web.post.dto.PostListResponse
+import cloud.luigi99.blog.content.adapter.`in`.web.post.dto.PostResponse
+import cloud.luigi99.blog.content.adapter.`in`.web.post.dto.PostSummaryResponse
+import cloud.luigi99.blog.content.adapter.`in`.web.post.dto.UpdatePostRequest
+import cloud.luigi99.blog.content.application.post.port.`in`.command.CreatePostUseCase
+import cloud.luigi99.blog.content.application.post.port.`in`.command.PostCommandFacade
+import cloud.luigi99.blog.content.application.post.port.`in`.command.UpdatePostUseCase
+import cloud.luigi99.blog.content.application.post.port.`in`.query.GetPostByIdUseCase
+import cloud.luigi99.blog.content.application.post.port.`in`.query.GetPostBySlugUseCase
+import cloud.luigi99.blog.content.application.post.port.`in`.query.GetPostsUseCase
+import cloud.luigi99.blog.content.application.post.port.`in`.query.PostQueryFacade
+import mu.KotlinLogging
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Post 컨트롤러
+ *
+ * 블로그 글 생성, 조회, 수정, 발행, 아카이빙 등 Post 관련 요청을 처리합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/posts")
+class PostController(private val postQueryFacade: PostQueryFacade, private val postCommandFacade: PostCommandFacade) :
+    PostApi {
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
+    @PostMapping
+    override fun createPost(
+        @AuthenticationPrincipal memberId: String,
+        @RequestBody request: CreatePostRequest,
+    ): ResponseEntity<CommonResponse<PostResponse>> {
+        log.info { "Creating post with slug: ${request.slug}" }
+
+        val command =
+            CreatePostUseCase.Command(
+                memberId = memberId,
+                title = request.title,
+                slug = request.slug,
+                body = request.body,
+                type = request.type,
+                tags = request.tags ?: emptyList(),
+            )
+
+        val response = postCommandFacade.createPost().execute(command)
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+            CommonResponse.success(
+                PostResponse(
+                    postId = response.postId,
+                    memberId = response.memberId,
+                    title = response.title,
+                    slug = response.slug,
+                    body = response.body,
+                    type = response.type,
+                    status = response.status,
+                    tags = response.tags,
+                    createdAt = response.createdAt,
+                    updatedAt = response.updatedAt,
+                ),
+            ),
+        )
+    }
+
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
+    @PutMapping("/{postId}")
+    override fun updatePost(
+        @AuthenticationPrincipal memberId: String,
+        @PathVariable postId: String,
+        @RequestBody request: UpdatePostRequest,
+    ): ResponseEntity<CommonResponse<PostResponse>> {
+        log.info {
+            "Updating post: $postId (title=${request.title != null}, body=${request.body != null}, status=${request.status})"
+        }
+
+        val command =
+            UpdatePostUseCase.Command(
+                memberId = memberId,
+                postId = postId,
+                title = request.title,
+                body = request.body,
+                status = request.status,
+            )
+
+        val response = postCommandFacade.updatePost().execute(command)
+
+        return ResponseEntity.ok(
+            CommonResponse.success(
+                PostResponse(
+                    postId = response.postId,
+                    memberId = response.memberId,
+                    title = response.title,
+                    slug = response.slug,
+                    body = response.body,
+                    type = response.type,
+                    status = response.status,
+                    tags = response.tags,
+                    createdAt = response.createdAt,
+                    updatedAt = response.updatedAt,
+                ),
+            ),
+        )
+    }
+
+    @GetMapping("/{postId}")
+    override fun getPostById(
+        @PathVariable postId: String,
+    ): ResponseEntity<CommonResponse<PostResponse>> {
+        log.info { "Getting post by ID: $postId" }
+
+        val query = GetPostByIdUseCase.Query(postId = postId)
+        val response = postQueryFacade.getPostById().execute(query)
+
+        return ResponseEntity.ok(
+            CommonResponse.success(
+                PostResponse(
+                    postId = response.postId,
+                    memberId = response.memberId,
+                    title = response.title,
+                    slug = response.slug,
+                    body = response.body,
+                    type = response.type,
+                    status = response.status,
+                    tags = response.tags,
+                    createdAt = response.createdAt,
+                    updatedAt = response.updatedAt,
+                ),
+            ),
+        )
+    }
+
+    @GetMapping("/@{username}/{slug}")
+    override fun getPostByUsernameAndSlug(
+        @PathVariable username: String,
+        @PathVariable slug: String,
+    ): ResponseEntity<CommonResponse<PostResponse>> {
+        log.info { "Getting post by username: $username, slug: $slug" }
+
+        val query = GetPostBySlugUseCase.Query(username = username, slug = slug)
+        val response = postQueryFacade.getPostBySlug().execute(query)
+
+        return ResponseEntity.ok(
+            CommonResponse.success(
+                PostResponse(
+                    postId = response.postId,
+                    memberId = response.memberId,
+                    title = response.title,
+                    slug = response.slug,
+                    body = response.body,
+                    type = response.type,
+                    status = response.status,
+                    tags = response.tags,
+                    createdAt = response.createdAt,
+                    updatedAt = response.updatedAt,
+                ),
+            ),
+        )
+    }
+
+    @GetMapping
+    override fun getPosts(
+        @RequestParam(required = false) status: String?,
+        @RequestParam(required = false) type: String?,
+    ): ResponseEntity<CommonResponse<PostListResponse>> {
+        log.info { "Listing posts with filters - status: $status, type: $type" }
+
+        val query = GetPostsUseCase.Query(status = status, type = type)
+        val response = postQueryFacade.getPosts().execute(query)
+
+        val summaries =
+            response.posts.map { post ->
+                PostSummaryResponse(
+                    postId = post.postId,
+                    memberId = post.memberId,
+                    title = post.title,
+                    slug = post.slug,
+                    type = post.type,
+                    status = post.status,
+                    tags = post.tags,
+                    createdAt = post.createdAt,
+                )
+            }
+
+        return ResponseEntity.ok(
+            CommonResponse.success(
+                PostListResponse(
+                    posts = summaries,
+                    total = summaries.size,
+                ),
+            ),
+        )
+    }
+}

--- a/modules/content/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/dto/CreatePostRequest.kt
+++ b/modules/content/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/dto/CreatePostRequest.kt
@@ -1,0 +1,19 @@
+package cloud.luigi99.blog.content.adapter.`in`.web.post.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 블로그 글 생성 요청 DTO
+ */
+data class CreatePostRequest(
+    @field:Schema(description = "제목", example = "Kotlin으로 DDD 구현하기")
+    val title: String,
+    @field:Schema(description = "URL slug", example = "kotlin-ddd-implementation")
+    val slug: String,
+    @field:Schema(description = "본문 (Markdown)", example = "# 시작하기\n\nKotlin과 DDD를 결합하면...")
+    val body: String,
+    @field:Schema(description = "콘텐츠 타입", example = "BLOG", allowableValues = ["BLOG", "PORTFOLIO"])
+    val type: String,
+    @field:Schema(description = "태그 목록", example = "[\"Kotlin\", \"DDD\", \"Spring\"]")
+    val tags: List<String>? = null,
+)

--- a/modules/content/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/dto/PostListResponse.kt
+++ b/modules/content/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/dto/PostListResponse.kt
@@ -1,0 +1,13 @@
+package cloud.luigi99.blog.content.adapter.`in`.web.post.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 블로그 글 목록 응답 DTO
+ */
+data class PostListResponse(
+    @field:Schema(description = "글 목록")
+    val posts: List<PostSummaryResponse>,
+    @field:Schema(description = "총 개수", example = "42")
+    val total: Int,
+)

--- a/modules/content/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/dto/PostResponse.kt
+++ b/modules/content/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/dto/PostResponse.kt
@@ -1,0 +1,30 @@
+package cloud.luigi99.blog.content.adapter.`in`.web.post.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+/**
+ * 블로그 글 상세 응답 DTO
+ */
+data class PostResponse(
+    @field:Schema(description = "Post ID", example = "123e4567-e89b-12d3-a456-426614174000")
+    val postId: String,
+    @field:Schema(description = "작성자 Member ID", example = "987e6543-e21b-98d7-a654-426614174111")
+    val memberId: String,
+    @field:Schema(description = "제목", example = "Kotlin으로 DDD 구현하기")
+    val title: String,
+    @field:Schema(description = "URL slug", example = "kotlin-ddd-implementation")
+    val slug: String,
+    @field:Schema(description = "본문 (Markdown)", example = "# 시작하기\n\nKotlin과 DDD를 결합하면...")
+    val body: String,
+    @field:Schema(description = "콘텐츠 타입", example = "BLOG")
+    val type: String,
+    @field:Schema(description = "상태", example = "DRAFT")
+    val status: String,
+    @field:Schema(description = "태그 목록", example = "[\"Kotlin\", \"DDD\"]")
+    val tags: Set<String>,
+    @field:Schema(description = "생성 시간", example = "2025-01-01T12:00:00")
+    val createdAt: LocalDateTime?,
+    @field:Schema(description = "수정 시간", example = "2025-01-01T13:00:00")
+    val updatedAt: LocalDateTime?,
+)

--- a/modules/content/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/dto/PostSummaryResponse.kt
+++ b/modules/content/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/dto/PostSummaryResponse.kt
@@ -1,0 +1,26 @@
+package cloud.luigi99.blog.content.adapter.`in`.web.post.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+/**
+ * 블로그 글 목록 조회 응답 DTO
+ */
+data class PostSummaryResponse(
+    @field:Schema(description = "Post ID", example = "123e4567-e89b-12d3-a456-426614174000")
+    val postId: String,
+    @field:Schema(description = "작성자 Member ID", example = "987e6543-e21b-98d7-a654-426614174111")
+    val memberId: String,
+    @field:Schema(description = "제목", example = "Kotlin으로 DDD 구현하기")
+    val title: String,
+    @field:Schema(description = "URL slug", example = "kotlin-ddd-implementation")
+    val slug: String,
+    @field:Schema(description = "콘텐츠 타입", example = "BLOG")
+    val type: String,
+    @field:Schema(description = "상태", example = "PUBLISHED")
+    val status: String,
+    @field:Schema(description = "태그 목록", example = "[\"Kotlin\", \"DDD\"]")
+    val tags: Set<String>,
+    @field:Schema(description = "생성 시간", example = "2025-01-01T12:00:00")
+    val createdAt: LocalDateTime?,
+)

--- a/modules/content/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/dto/UpdatePostRequest.kt
+++ b/modules/content/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/dto/UpdatePostRequest.kt
@@ -1,0 +1,21 @@
+package cloud.luigi99.blog.content.adapter.`in`.web.post.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 블로그 글 수정 요청 DTO
+ *
+ * 모든 필드가 선택적입니다. null인 필드는 변경되지 않습니다.
+ */
+data class UpdatePostRequest(
+    @field:Schema(description = "제목 (null이면 변경하지 않음)", example = "수정된 제목")
+    val title: String? = null,
+    @field:Schema(description = "본문 (null이면 변경하지 않음)", example = "# 수정된 본문\n\n...")
+    val body: String? = null,
+    @field:Schema(
+        description = "상태 (null이면 변경하지 않음)",
+        example = "PUBLISHED",
+        allowableValues = ["DRAFT", "PUBLISHED", "ARCHIVED"],
+    )
+    val status: String? = null,
+)

--- a/modules/content/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/PostControllerTest.kt
+++ b/modules/content/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/PostControllerTest.kt
@@ -1,0 +1,302 @@
+package cloud.luigi99.blog.content.adapter.`in`.web.post
+
+import cloud.luigi99.blog.content.adapter.`in`.web.post.dto.CreatePostRequest
+import cloud.luigi99.blog.content.adapter.`in`.web.post.dto.UpdatePostRequest
+import cloud.luigi99.blog.content.application.post.port.`in`.command.CreatePostUseCase
+import cloud.luigi99.blog.content.application.post.port.`in`.command.PostCommandFacade
+import cloud.luigi99.blog.content.application.post.port.`in`.command.UpdatePostUseCase
+import cloud.luigi99.blog.content.application.post.port.`in`.query.GetPostByIdUseCase
+import cloud.luigi99.blog.content.application.post.port.`in`.query.GetPostBySlugUseCase
+import cloud.luigi99.blog.content.application.post.port.`in`.query.PostQueryFacade
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.http.HttpStatus
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * PostController 테스트
+ *
+ * REST API 엔드포인트의 요청/응답 처리를 검증합니다.
+ */
+class PostControllerTest :
+    BehaviorSpec({
+
+        val postQueryFacade = mockk<PostQueryFacade>()
+        val postCommandFacade = mockk<PostCommandFacade>()
+        val controller = PostController(postQueryFacade, postCommandFacade)
+
+        Given("블로그 글을 생성할 때") {
+            val createPostUseCase = mockk<CreatePostUseCase>()
+            every { postCommandFacade.createPost() } returns createPostUseCase
+
+            When("유효한 요청으로 글을 생성하면") {
+                val request =
+                    CreatePostRequest(
+                        title = "Kotlin DDD",
+                        slug = "kotlin-ddd",
+                        body = "# Content",
+                        type = "BLOG",
+                        tags = listOf("Kotlin", "DDD"),
+                    )
+
+                val expectedResponse =
+                    CreatePostUseCase.Response(
+                        postId = UUID.randomUUID().toString(),
+                        memberId = "member-id",
+                        title = "Kotlin DDD",
+                        slug = "kotlin-ddd",
+                        body = "# Content",
+                        type = "BLOG",
+                        status = "DRAFT",
+                        tags = setOf("Kotlin", "DDD"),
+                        createdAt = LocalDateTime.now(),
+                        updatedAt = LocalDateTime.now(),
+                    )
+
+                every { createPostUseCase.execute(any()) } returns expectedResponse
+
+                val response = controller.createPost("member-id", request)
+
+                Then("201 Created 응답이 반환되어야 한다") {
+                    response.statusCode shouldBe HttpStatus.CREATED
+                }
+
+                Then("생성된 글 정보가 반환되어야 한다") {
+                    response.body shouldNotBe null
+                    response.body?.success shouldBe true
+                    response.body
+                        ?.data
+                        ?.title shouldBe "Kotlin DDD"
+                    response.body
+                        ?.data
+                        ?.status shouldBe "DRAFT"
+                }
+            }
+        }
+
+        Given("글의 제목만 수정할 때") {
+            val updatePostUseCase = mockk<UpdatePostUseCase>()
+            every { postCommandFacade.updatePost() } returns updatePostUseCase
+
+            When("title만 포함된 요청을 보내면") {
+                val postId = UUID.randomUUID().toString()
+                val request = UpdatePostRequest(title = "수정된 제목", body = null, status = null)
+
+                val expectedResponse =
+                    UpdatePostUseCase.Response(
+                        postId = postId,
+                        memberId = "member-id",
+                        title = "수정된 제목",
+                        slug = "original-slug",
+                        body = "원본 본문",
+                        type = "BLOG",
+                        status = "DRAFT",
+                        tags = emptySet(),
+                        createdAt = LocalDateTime.now(),
+                        updatedAt = LocalDateTime.now(),
+                    )
+
+                every { updatePostUseCase.execute(any()) } returns expectedResponse
+
+                val response = controller.updatePost("member-id", postId, request)
+
+                Then("200 OK 응답이 반환되어야 한다") {
+                    response.statusCode shouldBe HttpStatus.OK
+                }
+
+                Then("제목만 변경된 글이 반환되어야 한다") {
+                    response.body shouldNotBe null
+                    response.body?.success shouldBe true
+                    response.body
+                        ?.data
+                        ?.title shouldBe "수정된 제목"
+                    response.body
+                        ?.data
+                        ?.body shouldBe "원본 본문"
+                }
+            }
+        }
+
+        Given("글의 상태만 PUBLISHED로 변경할 때") {
+            val updatePostUseCase = mockk<UpdatePostUseCase>()
+            every { postCommandFacade.updatePost() } returns updatePostUseCase
+
+            When("status만 포함된 요청을 보내면") {
+                val postId = UUID.randomUUID().toString()
+                val request = UpdatePostRequest(title = null, body = null, status = "PUBLISHED")
+
+                val expectedResponse =
+                    UpdatePostUseCase.Response(
+                        postId = postId,
+                        memberId = "member-id",
+                        title = "원본 제목",
+                        slug = "original-slug",
+                        body = "원본 본문",
+                        type = "BLOG",
+                        status = "PUBLISHED",
+                        tags = emptySet(),
+                        createdAt = LocalDateTime.now(),
+                        updatedAt = LocalDateTime.now(),
+                    )
+
+                every { updatePostUseCase.execute(any()) } returns expectedResponse
+
+                val response = controller.updatePost("member-id", postId, request)
+
+                Then("200 OK 응답이 반환되어야 한다") {
+                    response.statusCode shouldBe HttpStatus.OK
+                }
+
+                Then("상태만 PUBLISHED로 변경된 글이 반환되어야 한다") {
+                    response.body shouldNotBe null
+                    response.body?.success shouldBe true
+                    response.body
+                        ?.data
+                        ?.status shouldBe "PUBLISHED"
+                    response.body
+                        ?.data
+                        ?.title shouldBe "원본 제목"
+                }
+            }
+        }
+
+        Given("글의 제목, 본문, 상태를 모두 수정할 때") {
+            val updatePostUseCase = mockk<UpdatePostUseCase>()
+            every { postCommandFacade.updatePost() } returns updatePostUseCase
+
+            When("모든 필드가 포함된 요청을 보내면") {
+                val postId = UUID.randomUUID().toString()
+                val request =
+                    UpdatePostRequest(
+                        title = "완전히 수정된 제목",
+                        body = "완전히 수정된 본문",
+                        status = "PUBLISHED",
+                    )
+
+                val expectedResponse =
+                    UpdatePostUseCase.Response(
+                        postId = postId,
+                        memberId = "member-id",
+                        title = "완전히 수정된 제목",
+                        slug = "original-slug",
+                        body = "완전히 수정된 본문",
+                        type = "BLOG",
+                        status = "PUBLISHED",
+                        tags = emptySet(),
+                        createdAt = LocalDateTime.now(),
+                        updatedAt = LocalDateTime.now(),
+                    )
+
+                every { updatePostUseCase.execute(any()) } returns expectedResponse
+
+                val response = controller.updatePost("member-id", postId, request)
+
+                Then("200 OK 응답이 반환되어야 한다") {
+                    response.statusCode shouldBe HttpStatus.OK
+                }
+
+                Then("모든 필드가 변경된 글이 반환되어야 한다") {
+                    response.body shouldNotBe null
+                    response.body?.success shouldBe true
+                    response.body
+                        ?.data
+                        ?.title shouldBe "완전히 수정된 제목"
+                    response.body
+                        ?.data
+                        ?.body shouldBe "완전히 수정된 본문"
+                    response.body
+                        ?.data
+                        ?.status shouldBe "PUBLISHED"
+                }
+            }
+        }
+
+        Given("글을 ID로 조회할 때") {
+            val getPostByIdUseCase = mockk<GetPostByIdUseCase>()
+            every { postQueryFacade.getPostById() } returns getPostByIdUseCase
+
+            When("유효한 Post ID로 조회하면") {
+                val postId = UUID.randomUUID().toString()
+
+                val expectedResponse =
+                    GetPostByIdUseCase.Response(
+                        postId = postId,
+                        memberId = "member-id",
+                        title = "조회된 글",
+                        slug = "retrieved-post",
+                        body = "본문 내용",
+                        type = "BLOG",
+                        status = "PUBLISHED",
+                        tags = setOf("Tag1"),
+                        createdAt = LocalDateTime.now(),
+                        updatedAt = LocalDateTime.now(),
+                    )
+
+                every { getPostByIdUseCase.execute(any()) } returns expectedResponse
+
+                val response = controller.getPostById(postId)
+
+                Then("200 OK 응답이 반환되어야 한다") {
+                    response.statusCode shouldBe HttpStatus.OK
+                }
+
+                Then("조회된 글 정보가 반환되어야 한다") {
+                    response.body shouldNotBe null
+                    response.body?.success shouldBe true
+                    response.body
+                        ?.data
+                        ?.postId shouldBe postId
+                    response.body
+                        ?.data
+                        ?.title shouldBe "조회된 글"
+                }
+            }
+        }
+
+        Given("Username과 Slug로 글을 조회할 때") {
+            val getPostBySlugUseCase = mockk<GetPostBySlugUseCase>()
+            every { postQueryFacade.getPostBySlug() } returns getPostBySlugUseCase
+
+            When("유효한 Username과 Slug로 조회하면") {
+                val username = "testuser"
+                val slug = "test-post"
+
+                val expectedResponse =
+                    GetPostBySlugUseCase.Response(
+                        postId = UUID.randomUUID().toString(),
+                        memberId = "member-id",
+                        title = "테스트 글",
+                        slug = slug,
+                        body = "본문 내용",
+                        type = "BLOG",
+                        status = "PUBLISHED",
+                        tags = setOf("Tag1"),
+                        createdAt = LocalDateTime.now(),
+                        updatedAt = LocalDateTime.now(),
+                    )
+
+                every { getPostBySlugUseCase.execute(any()) } returns expectedResponse
+
+                val response = controller.getPostByUsernameAndSlug(username, slug)
+
+                Then("200 OK 응답이 반환되어야 한다") {
+                    response.statusCode shouldBe HttpStatus.OK
+                }
+
+                Then("조회된 글 정보가 반환되어야 한다") {
+                    response.body shouldNotBe null
+                    response.body?.success shouldBe true
+                    response.body
+                        ?.data
+                        ?.slug shouldBe slug
+                    response.body
+                        ?.data
+                        ?.title shouldBe "테스트 글"
+                }
+            }
+        }
+    })

--- a/modules/content/adapter/out/persistence/jpa/build.gradle.kts
+++ b/modules/content/adapter/out/persistence/jpa/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    springBootConventions
+}
+
+dependencies {
+    implementation(project(":libs:common"))
+    implementation(project(":modules:content:domain"))
+    implementation(project(":modules:content:application"))
+    implementation(project(":libs:adapter:persistence:jpa"))
+    implementation(project(":libs:adapter:message:spring"))
+
+    implementation(libs.spring.boot.starter.data.jpa)
+
+    testImplementation(libs.bundles.kotlin.test)
+}

--- a/modules/content/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/adapter/out/persistence/jpa/post/PostJpaEntity.kt
+++ b/modules/content/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/adapter/out/persistence/jpa/post/PostJpaEntity.kt
@@ -1,0 +1,79 @@
+package cloud.luigi99.blog.content.adapter.out.persistence.jpa.post
+
+import cloud.luigi99.blog.adapter.persistence.jpa.JpaAggregateRoot
+import cloud.luigi99.blog.content.domain.post.vo.ContentType
+import cloud.luigi99.blog.content.domain.post.vo.PostId
+import cloud.luigi99.blog.content.domain.post.vo.PostStatus
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.Table
+import org.hibernate.annotations.DynamicUpdate
+import java.util.UUID
+
+/**
+ * Post JPA 엔티티
+ *
+ * 블로그 글의 영속성 모델을 정의합니다.
+ */
+@Entity
+@Table(name = "post")
+@DynamicUpdate
+class PostJpaEntity private constructor(
+    @Id
+    @Column(name = "id")
+    val id: UUID,
+    @Column(name = "member_id", nullable = false)
+    val memberId: UUID,
+    @Column(name = "title", nullable = false, length = 200)
+    val title: String,
+    @Column(name = "slug", nullable = false, unique = true, length = 200)
+    val slug: String,
+    @Column(name = "body", nullable = false, columnDefinition = "TEXT")
+    val body: String,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 50)
+    val type: ContentType,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 50)
+    var status: PostStatus,
+    @ElementCollection
+    @CollectionTable(
+        name = "post_tag",
+        joinColumns = [JoinColumn(name = "post_id")],
+    )
+    @Column(name = "tag_name", length = 50)
+    val tags: MutableSet<String> = mutableSetOf(),
+) : JpaAggregateRoot<PostId>() {
+    override val entityId: PostId
+        get() = PostId(id)
+
+    companion object {
+        /**
+         * JPA 엔티티를 생성합니다.
+         */
+        fun from(
+            entityId: UUID,
+            memberId: UUID,
+            title: String,
+            slug: String,
+            body: String,
+            type: ContentType,
+            status: PostStatus,
+        ): PostJpaEntity =
+            PostJpaEntity(
+                id = entityId,
+                memberId = memberId,
+                title = title,
+                slug = slug,
+                body = body,
+                type = type,
+                status = status,
+            )
+    }
+}

--- a/modules/content/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/adapter/out/persistence/jpa/post/PostJpaRepository.kt
+++ b/modules/content/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/adapter/out/persistence/jpa/post/PostJpaRepository.kt
@@ -1,0 +1,80 @@
+package cloud.luigi99.blog.content.adapter.out.persistence.jpa.post
+
+import cloud.luigi99.blog.content.domain.post.vo.ContentType
+import cloud.luigi99.blog.content.domain.post.vo.PostStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+/**
+ * Post JPA Repository
+ *
+ * Spring Data JPA를 사용한 Post 저장소입니다.
+ */
+@Repository
+interface PostJpaRepository : JpaRepository<PostJpaEntity, UUID> {
+    /**
+     * Slug 값으로 Post를 조회합니다.
+     */
+    @Query("SELECT p FROM PostJpaEntity p WHERE p.slug = :slug")
+    fun findBySlugValue(
+        @Param("slug") slug: String,
+    ): PostJpaEntity?
+
+    /**
+     * Slug 값으로 Post 존재 여부를 확인합니다.
+     */
+    @Query("SELECT COUNT(p) > 0 FROM PostJpaEntity p WHERE p.slug = :slug")
+    fun existsBySlugValue(
+        @Param("slug") slug: String,
+    ): Boolean
+
+    /**
+     * 특정 사용자의 Slug로 Post를 조회합니다.
+     */
+    @Query("SELECT p FROM PostJpaEntity p WHERE p.memberId = :memberId AND p.slug = :slug")
+    fun findByMemberIdAndSlugValue(
+        @Param("memberId") memberId: UUID,
+        @Param("slug") slug: String,
+    ): PostJpaEntity?
+
+    /**
+     * 특정 사용자가 해당 Slug를 사용 중인지 확인합니다.
+     */
+    @Query("SELECT COUNT(p) > 0 FROM PostJpaEntity p WHERE p.memberId = :memberId AND p.slug = :slug")
+    fun existsByMemberIdAndSlugValue(
+        @Param("memberId") memberId: UUID,
+        @Param("slug") slug: String,
+    ): Boolean
+
+    /**
+     * 상태별로 Post 목록을 조회합니다.
+     */
+    @Query("SELECT p FROM PostJpaEntity p WHERE p.status = :status")
+    fun findAllByStatus(
+        @Param("status") status: PostStatus,
+    ): List<PostJpaEntity>
+
+    /**
+     * 콘텐츠 타입별로 Post 목록을 조회합니다.
+     */
+    @Query("SELECT p FROM PostJpaEntity p WHERE p.type = :type")
+    fun findAllByType(
+        @Param("type") type: ContentType,
+    ): List<PostJpaEntity>
+
+    @Query(
+        """
+        SELECT p.* FROM post p
+        INNER JOIN member m ON p.member_id = m.id
+        WHERE m.username = :username AND p.slug = :slug
+        """,
+        nativeQuery = true,
+    )
+    fun findByUsernameAndSlug(
+        @Param("username") username: String,
+        @Param("slug") slug: String,
+    ): PostJpaEntity?
+}

--- a/modules/content/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/adapter/out/persistence/jpa/post/PostMapper.kt
+++ b/modules/content/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/adapter/out/persistence/jpa/post/PostMapper.kt
@@ -1,0 +1,57 @@
+package cloud.luigi99.blog.content.adapter.out.persistence.jpa.post
+
+import cloud.luigi99.blog.content.domain.post.model.Post
+import cloud.luigi99.blog.content.domain.post.vo.Body
+import cloud.luigi99.blog.content.domain.post.vo.PostId
+import cloud.luigi99.blog.content.domain.post.vo.Slug
+import cloud.luigi99.blog.content.domain.post.vo.Title
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+
+/**
+ * Post Mapper
+ *
+ * Post 도메인 모델과 JPA 엔티티 간의 변환을 담당합니다.
+ */
+object PostMapper {
+    /**
+     * JPA 엔티티를 도메인 모델로 변환합니다.
+     */
+    fun toDomain(entity: PostJpaEntity): Post =
+        Post.from(
+            entityId = PostId(entity.id),
+            memberId = MemberId(entity.memberId),
+            title = Title(entity.title),
+            slug = Slug(entity.slug),
+            body = Body(entity.body),
+            type = entity.type,
+            status = entity.status,
+            tags = entity.tags.toSet(),
+            createdAt = entity.createdAt,
+            updatedAt = entity.updatedAt,
+        )
+
+    /**
+     * 도메인 모델을 JPA 엔티티로 변환합니다.
+     */
+    fun toEntity(post: Post): PostJpaEntity {
+        val postJpaEntity =
+            PostJpaEntity
+                .from(
+                    entityId = post.entityId.value,
+                    memberId = post.memberId.value,
+                    title = post.title.value,
+                    slug = post.slug.value,
+                    body = post.body.value,
+                    type = post.type,
+                    status = post.status,
+                ).apply {
+                    createdAt = post.createdAt
+                    updatedAt = post.updatedAt
+                }
+
+        // tags 복사
+        postJpaEntity.tags.addAll(post.tags)
+
+        return postJpaEntity
+    }
+}

--- a/modules/content/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/adapter/out/persistence/jpa/post/PostRepositoryAdapter.kt
+++ b/modules/content/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/adapter/out/persistence/jpa/post/PostRepositoryAdapter.kt
@@ -1,0 +1,136 @@
+package cloud.luigi99.blog.content.adapter.out.persistence.jpa.post
+
+import cloud.luigi99.blog.common.application.port.out.DomainEventPublisher
+import cloud.luigi99.blog.common.application.port.out.EventContextManager
+import cloud.luigi99.blog.content.application.post.port.out.PostRepository
+import cloud.luigi99.blog.content.domain.post.model.Post
+import cloud.luigi99.blog.content.domain.post.vo.ContentType
+import cloud.luigi99.blog.content.domain.post.vo.PostId
+import cloud.luigi99.blog.content.domain.post.vo.PostStatus
+import cloud.luigi99.blog.content.domain.post.vo.Slug
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import mu.KotlinLogging
+import org.springframework.stereotype.Repository
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Post 저장소 어댑터 구현체
+ *
+ * JPA 리포지토리를 사용하여 Post 데이터를 영속화하고, 도메인 이벤트를 발행합니다.
+ */
+@Repository
+class PostRepositoryAdapter(
+    private val jpaRepository: PostJpaRepository,
+    private val eventContextManager: EventContextManager,
+    private val domainEventPublisher: DomainEventPublisher,
+) : PostRepository {
+    /**
+     * Post 엔티티를 저장합니다.
+     * 저장 후 누적된 도메인 이벤트를 발행합니다.
+     *
+     * @param entity 저장할 Post 엔티티
+     * @return 저장된 Post 엔티티
+     */
+    override fun save(entity: Post): Post {
+        log.debug { "Saving post: ${entity.entityId}" }
+
+        val postJpaEntity = PostMapper.toEntity(entity)
+        val saved = jpaRepository.save(postJpaEntity)
+
+        val events = eventContextManager.getDomainEventsAndClear()
+        events.forEach { domainEventPublisher.publish(it) }
+
+        log.debug { "Successfully saved post: ${saved.entityId}" }
+        return PostMapper.toDomain(saved)
+    }
+
+    /**
+     * ID로 Post를 조회합니다.
+     */
+    override fun findById(id: PostId): Post? {
+        log.debug { "Finding post by ID: $id" }
+
+        return jpaRepository
+            .findById(id.value)
+            .map { PostMapper.toDomain(it) }
+            .orElse(null)
+    }
+
+    /**
+     * Slug로 Post를 조회합니다.
+     */
+    override fun findBySlug(slug: Slug): Post? {
+        log.debug { "Finding post by slug: $slug" }
+        return jpaRepository.findBySlugValue(slug.value)?.let { PostMapper.toDomain(it) }
+    }
+
+    /**
+     * Slug 존재 여부를 확인합니다.
+     */
+    override fun existsBySlug(slug: Slug): Boolean {
+        log.debug { "Checking if post exists with slug: $slug" }
+        return jpaRepository.existsBySlugValue(slug.value)
+    }
+
+    /**
+     * 특정 사용자의 Slug로 Post를 조회합니다.
+     */
+    override fun findByMemberIdAndSlug(memberId: MemberId, slug: Slug): Post? {
+        log.debug { "Finding post by memberId: $memberId and slug: $slug" }
+        return jpaRepository
+            .findByMemberIdAndSlugValue(memberId.value, slug.value)
+            ?.let { PostMapper.toDomain(it) }
+    }
+
+    /**
+     * Username과 Slug로 Post를 조회합니다.
+     */
+    override fun findByUsernameAndSlug(username: String, slug: Slug): Post? {
+        log.debug { "Finding post by username: $username and slug: $slug" }
+        return jpaRepository
+            .findByUsernameAndSlug(username, slug.value)
+            ?.let { PostMapper.toDomain(it) }
+    }
+
+    /**
+     * 특정 사용자가 해당 Slug를 사용 중인지 확인합니다.
+     */
+    override fun existsByMemberIdAndSlug(memberId: MemberId, slug: Slug): Boolean {
+        log.debug { "Checking if post exists with memberId: $memberId and slug: $slug" }
+        return jpaRepository.existsByMemberIdAndSlugValue(memberId.value, slug.value)
+    }
+
+    /**
+     * 상태별로 Post 목록을 조회합니다.
+     */
+    override fun findAllByStatus(status: PostStatus): List<Post> {
+        log.debug { "Finding posts by status: $status" }
+        return jpaRepository.findAllByStatus(status).map { PostMapper.toDomain(it) }
+    }
+
+    /**
+     * 콘텐츠 타입별로 Post 목록을 조회합니다.
+     */
+    override fun findAllByContentType(type: ContentType): List<Post> {
+        log.debug { "Finding posts by content type: $type" }
+        return jpaRepository.findAllByType(type).map { PostMapper.toDomain(it) }
+    }
+
+    /**
+     * 모든 Post를 조회합니다.
+     */
+    override fun findAll(): List<Post> {
+        log.debug { "Finding all posts" }
+        return jpaRepository.findAll().map { PostMapper.toDomain(it) }
+    }
+
+    /**
+     * ID로 Post를 삭제합니다.
+     */
+    override fun deleteById(id: PostId) {
+        log.debug { "Deleting post by ID: $id" }
+        jpaRepository.deleteById(id.value)
+        log.info { "Deleted post: $id" }
+    }
+}

--- a/modules/content/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/content/adapter/out/persistence/jpa/post/PostMapperTest.kt
+++ b/modules/content/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/content/adapter/out/persistence/jpa/post/PostMapperTest.kt
@@ -1,0 +1,141 @@
+package cloud.luigi99.blog.content.adapter.out.persistence.jpa.post
+
+import cloud.luigi99.blog.common.domain.event.EventManager
+import cloud.luigi99.blog.content.domain.post.model.Post
+import cloud.luigi99.blog.content.domain.post.vo.Body
+import cloud.luigi99.blog.content.domain.post.vo.ContentType
+import cloud.luigi99.blog.content.domain.post.vo.Slug
+import cloud.luigi99.blog.content.domain.post.vo.Title
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+
+/**
+ * PostMapper 테스트
+ */
+class PostMapperTest :
+    BehaviorSpec({
+
+        beforeTest {
+            mockkObject(EventManager)
+            every { EventManager.eventContextManager } returns mockk(relaxed = true)
+        }
+
+        Given("Post 도메인 모델이 주어졌을 때") {
+            val post =
+                Post.create(
+                    memberId = MemberId.generate(),
+                    title = Title("테스트 제목"),
+                    slug = Slug("test-post"),
+                    body = Body("테스트 본문"),
+                    type = ContentType.BLOG,
+                )
+
+            When("JPA 엔티티로 변환하면") {
+                val entity = PostMapper.toEntity(post)
+
+                Then("모든 필드가 정확하게 매핑되어야 한다") {
+                    entity.id shouldBe post.entityId.value
+                    entity.title shouldBe post.title.value
+                    entity.slug shouldBe post.slug.value
+                    entity.body shouldBe post.body.value
+                    entity.type shouldBe post.type
+                    entity.status shouldBe post.status
+                }
+
+                Then("tags가 빈 Set으로 초기화되어야 한다") {
+                    entity.tags shouldBe emptySet()
+                }
+            }
+        }
+
+        Given("tags가 있는 Post 도메인 모델이 주어졌을 때") {
+            val post =
+                Post
+                    .create(
+                        memberId = MemberId.generate(),
+                        title = Title("태그 테스트"),
+                        slug = Slug("tag-test"),
+                        body = Body("태그 본문"),
+                        type = ContentType.BLOG,
+                    ).addTag("Kotlin")
+                    .addTag("Spring")
+
+            When("JPA 엔티티로 변환하면") {
+                val entity = PostMapper.toEntity(post)
+
+                Then("tags가 정확하게 매핑되어야 한다") {
+                    entity.tags shouldBe setOf("Kotlin", "Spring")
+                }
+            }
+        }
+
+        Given("Post 도메인 모델을 JPA 엔티티로 변환한 후") {
+            val originalPost =
+                Post
+                    .create(
+                        memberId = MemberId.generate(),
+                        title = Title("원본 제목"),
+                        slug = Slug("original-post"),
+                        body = Body("원본 본문"),
+                        type = ContentType.PORTFOLIO,
+                    ).addTag("DDD")
+                    .addTag("Hexagonal")
+
+            When("다시 도메인 모델로 변환하면") {
+                val entity = PostMapper.toEntity(originalPost)
+                val converted = PostMapper.toDomain(entity)
+
+                Then("원본 데이터가 손실 없이 복원되어야 한다") {
+                    converted.entityId shouldBe originalPost.entityId
+                    converted.title shouldBe originalPost.title
+                    converted.slug shouldBe originalPost.slug
+                    converted.body shouldBe originalPost.body
+                    converted.type shouldBe originalPost.type
+                    converted.status shouldBe originalPost.status
+                }
+
+                Then("tags도 손실 없이 복원되어야 한다") {
+                    converted.tags shouldBe setOf("DDD", "Hexagonal")
+                }
+            }
+        }
+
+        Given("JPA 엔티티가 주어졌을 때") {
+            val entity =
+                PostJpaEntity.from(
+                    entityId =
+                        java.util.UUID
+                            .randomUUID(),
+                    memberId =
+                        java.util.UUID
+                            .randomUUID(),
+                    title = "JPA 제목",
+                    slug = "jpa-post",
+                    body = "JPA 본문",
+                    type = ContentType.BLOG,
+                    status = cloud.luigi99.blog.content.domain.post.vo.PostStatus.DRAFT,
+                )
+
+            entity.tags.addAll(setOf("JPA", "Hibernate"))
+
+            When("도메인 모델로 변환하면") {
+                val domain = PostMapper.toDomain(entity)
+
+                Then("모든 필드가 정확하게 매핑되어야 한다") {
+                    domain.title.value shouldBe "JPA 제목"
+                    domain.slug.value shouldBe "jpa-post"
+                    domain.body.value shouldBe "JPA 본문"
+                    domain.type shouldBe ContentType.BLOG
+                    domain.status shouldBe cloud.luigi99.blog.content.domain.post.vo.PostStatus.DRAFT
+                }
+
+                Then("tags가 정확하게 매핑되어야 한다") {
+                    domain.tags shouldBe setOf("JPA", "Hibernate")
+                }
+            }
+        }
+    })

--- a/modules/content/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/content/adapter/out/persistence/jpa/post/PostRepositoryAdapterTest.kt
+++ b/modules/content/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/content/adapter/out/persistence/jpa/post/PostRepositoryAdapterTest.kt
@@ -1,0 +1,331 @@
+package cloud.luigi99.blog.content.adapter.out.persistence.jpa.post
+
+import cloud.luigi99.blog.common.application.port.out.DomainEventPublisher
+import cloud.luigi99.blog.common.application.port.out.EventContextManager
+import cloud.luigi99.blog.common.domain.event.EventManager
+import cloud.luigi99.blog.content.domain.post.event.PostCreatedEvent
+import cloud.luigi99.blog.content.domain.post.model.Post
+import cloud.luigi99.blog.content.domain.post.vo.Body
+import cloud.luigi99.blog.content.domain.post.vo.ContentType
+import cloud.luigi99.blog.content.domain.post.vo.PostId
+import cloud.luigi99.blog.content.domain.post.vo.PostStatus
+import cloud.luigi99.blog.content.domain.post.vo.Slug
+import cloud.luigi99.blog.content.domain.post.vo.Title
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verify
+import java.util.Optional
+import java.util.UUID
+
+/**
+ * PostRepositoryAdapter 테스트
+ */
+class PostRepositoryAdapterTest :
+    BehaviorSpec({
+
+        beforeTest {
+            mockkObject(EventManager)
+            every { EventManager.eventContextManager } returns mockk(relaxed = true)
+        }
+
+        Given("새로운 Post를 저장하려고 할 때") {
+            val jpaRepository = mockk<PostJpaRepository>()
+            val eventContextManager = mockk<EventContextManager>()
+            val domainEventPublisher = mockk<DomainEventPublisher>()
+
+            val adapter =
+                PostRepositoryAdapter(
+                    jpaRepository,
+                    eventContextManager,
+                    domainEventPublisher,
+                )
+
+            val post =
+                Post.create(
+                    memberId = MemberId.generate(),
+                    title = Title("테스트 글"),
+                    slug = Slug("test-post"),
+                    body = Body("테스트 본문"),
+                    type = ContentType.BLOG,
+                )
+
+            When("Post를 저장하면") {
+                val savedEntity = PostMapper.toEntity(post)
+                every { jpaRepository.save(any()) } returns savedEntity
+                every { eventContextManager.getDomainEventsAndClear() } returns
+                    listOf(
+                        PostCreatedEvent(post.entityId, post.slug),
+                    )
+                every { domainEventPublisher.publish(any()) } just Runs
+
+                val saved = adapter.save(post)
+
+                Then("저장된 Post가 반환되어야 한다") {
+                    saved.entityId shouldBe post.entityId
+                    saved.title shouldBe post.title
+                    saved.slug shouldBe post.slug
+                }
+
+                Then("도메인 이벤트가 발행되어야 한다") {
+                    verify(exactly = 1) {
+                        domainEventPublisher.publish(match { it is PostCreatedEvent })
+                    }
+                }
+            }
+        }
+
+        Given("ID로 Post를 조회할 때") {
+            val jpaRepository = mockk<PostJpaRepository>()
+            val eventContextManager = mockk<EventContextManager>()
+            val domainEventPublisher = mockk<DomainEventPublisher>()
+
+            val adapter =
+                PostRepositoryAdapter(
+                    jpaRepository,
+                    eventContextManager,
+                    domainEventPublisher,
+                )
+
+            val postId = PostId.generate()
+            val entity =
+                PostJpaEntity.from(
+                    entityId = postId.value,
+                    memberId = UUID.randomUUID(),
+                    title = "찾을 글",
+                    slug = "find-post",
+                    body = "본문",
+                    type = ContentType.BLOG,
+                    status = PostStatus.DRAFT,
+                )
+
+            When("존재하는 ID로 조회하면") {
+                every { jpaRepository.findById(postId.value) } returns Optional.of(entity)
+
+                val found = adapter.findById(postId)
+
+                Then("Post가 반환되어야 한다") {
+                    found shouldNotBe null
+                    found?.entityId shouldBe postId
+                    found?.title?.value shouldBe "찾을 글"
+                }
+            }
+
+            When("존재하지 않는 ID로 조회하면") {
+                every { jpaRepository.findById(postId.value) } returns Optional.empty()
+
+                val found = adapter.findById(postId)
+
+                Then("null이 반환되어야 한다") {
+                    found shouldBe null
+                }
+            }
+        }
+
+        Given("Slug로 Post를 조회할 때") {
+            val jpaRepository = mockk<PostJpaRepository>()
+            val eventContextManager = mockk<EventContextManager>()
+            val domainEventPublisher = mockk<DomainEventPublisher>()
+
+            val adapter =
+                PostRepositoryAdapter(
+                    jpaRepository,
+                    eventContextManager,
+                    domainEventPublisher,
+                )
+
+            val slug = Slug("my-post")
+            val entity =
+                PostJpaEntity.from(
+                    entityId = UUID.randomUUID(),
+                    memberId = UUID.randomUUID(),
+                    title = "내 글",
+                    slug = "my-post",
+                    body = "본문",
+                    type = ContentType.BLOG,
+                    status = PostStatus.DRAFT,
+                )
+
+            When("존재하는 Slug로 조회하면") {
+                every { jpaRepository.findBySlugValue("my-post") } returns entity
+
+                val found = adapter.findBySlug(slug)
+
+                Then("Post가 반환되어야 한다") {
+                    found shouldNotBe null
+                    found?.slug shouldBe slug
+                }
+            }
+
+            When("존재하지 않는 Slug로 조회하면") {
+                every { jpaRepository.findBySlugValue("non-existent") } returns null
+
+                val found = adapter.findBySlug(Slug("non-existent"))
+
+                Then("null이 반환되어야 한다") {
+                    found shouldBe null
+                }
+            }
+        }
+
+        Given("Slug 존재 여부를 확인할 때") {
+            val jpaRepository = mockk<PostJpaRepository>()
+            val eventContextManager = mockk<EventContextManager>()
+            val domainEventPublisher = mockk<DomainEventPublisher>()
+
+            val adapter =
+                PostRepositoryAdapter(
+                    jpaRepository,
+                    eventContextManager,
+                    domainEventPublisher,
+                )
+
+            val slug = Slug("existing-post")
+
+            When("존재하는 Slug를 확인하면") {
+                every { jpaRepository.existsBySlugValue("existing-post") } returns true
+
+                val exists = adapter.existsBySlug(slug)
+
+                Then("true가 반환되어야 한다") {
+                    exists shouldBe true
+                }
+            }
+
+            When("존재하지 않는 Slug를 확인하면") {
+                every { jpaRepository.existsBySlugValue("non-existent") } returns false
+
+                val exists = adapter.existsBySlug(Slug("non-existent"))
+
+                Then("false가 반환되어야 한다") {
+                    exists shouldBe false
+                }
+            }
+        }
+
+        Given("상태별로 Post 목록을 조회할 때") {
+            val jpaRepository = mockk<PostJpaRepository>()
+            val eventContextManager = mockk<EventContextManager>()
+            val domainEventPublisher = mockk<DomainEventPublisher>()
+
+            val adapter =
+                PostRepositoryAdapter(
+                    jpaRepository,
+                    eventContextManager,
+                    domainEventPublisher,
+                )
+
+            val publishedEntities =
+                listOf(
+                    PostJpaEntity.from(
+                        entityId = UUID.randomUUID(),
+                        memberId = UUID.randomUUID(),
+                        title = "발행글 1",
+                        slug = "published-1",
+                        body = "본문1",
+                        type = ContentType.BLOG,
+                        status = PostStatus.PUBLISHED,
+                    ),
+                    PostJpaEntity.from(
+                        entityId = UUID.randomUUID(),
+                        memberId = UUID.randomUUID(),
+                        title = "발행글 2",
+                        slug = "published-2",
+                        body = "본문2",
+                        type = ContentType.BLOG,
+                        status = PostStatus.PUBLISHED,
+                    ),
+                )
+
+            When("PUBLISHED 상태로 조회하면") {
+                every { jpaRepository.findAllByStatus(PostStatus.PUBLISHED) } returns publishedEntities
+
+                val posts = adapter.findAllByStatus(PostStatus.PUBLISHED)
+
+                Then("PUBLISHED 상태의 Post 목록이 반환되어야 한다") {
+                    posts.size shouldBe 2
+                    posts.all { it.status == PostStatus.PUBLISHED } shouldBe true
+                }
+            }
+        }
+
+        Given("타입별로 Post 목록을 조회할 때") {
+            val jpaRepository = mockk<PostJpaRepository>()
+            val eventContextManager = mockk<EventContextManager>()
+            val domainEventPublisher = mockk<DomainEventPublisher>()
+
+            val adapter =
+                PostRepositoryAdapter(
+                    jpaRepository,
+                    eventContextManager,
+                    domainEventPublisher,
+                )
+
+            val portfolioEntities =
+                listOf(
+                    PostJpaEntity.from(
+                        entityId = UUID.randomUUID(),
+                        memberId = UUID.randomUUID(),
+                        title = "프로젝트 1",
+                        slug = "project-1",
+                        body = "설명1",
+                        type = ContentType.PORTFOLIO,
+                        status = PostStatus.DRAFT,
+                    ),
+                )
+
+            When("PORTFOLIO 타입으로 조회하면") {
+                every { jpaRepository.findAllByType(ContentType.PORTFOLIO) } returns portfolioEntities
+
+                val posts = adapter.findAllByContentType(ContentType.PORTFOLIO)
+
+                Then("PORTFOLIO 타입의 Post 목록이 반환되어야 한다") {
+                    posts.size shouldBe 1
+                    posts.all { it.type == ContentType.PORTFOLIO } shouldBe true
+                }
+            }
+        }
+
+        Given("사용자 이름과 Slug로 글을 조회할 때") {
+            val jpaRepository = mockk<PostJpaRepository>()
+            val eventContextManager = mockk<EventContextManager>()
+            val domainEventPublisher = mockk<DomainEventPublisher>()
+
+            val adapter =
+                PostRepositoryAdapter(
+                    jpaRepository,
+                    eventContextManager,
+                    domainEventPublisher,
+                )
+
+            val username = "testuser"
+            val slug = Slug("test-post")
+            val entity =
+                PostJpaEntity.from(
+                    entityId = UUID.randomUUID(),
+                    memberId = UUID.randomUUID(),
+                    title = "조회된 글",
+                    slug = "test-post",
+                    body = "본문",
+                    type = ContentType.BLOG,
+                    status = PostStatus.PUBLISHED,
+                )
+
+            When("사용자 이름과 Slug가 일치하는 글이 존재하면") {
+                every { jpaRepository.findByUsernameAndSlug(username, slug.value) } returns entity
+
+                val found = adapter.findByUsernameAndSlug(username, slug)
+
+                Then("해당 게시글이 반환된다") {
+                    found shouldNotBe null
+                    found?.slug shouldBe slug
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## 📋 개요
- Post API를 위한 인터페이스, 컨트롤러, DTO와 관련 기능 추가
- Post JPA 영속성 어댑터 및 저장소 구현
- PostMapper 및 Repository와 Controller에 대한 단위 테스트 작성
- content 레이어의 Gradle 종속성 및 빌드 파일 설정 추가

## 🔗 관련 이슈
- Closes #50

## ☑️ 체크리스트
- [ ] 코딩 컨벤션을 준수했나요? (`./gradlew ktlintCheck`)
- [ ] 모든 테스트를 통과했나요? (`./gradlew test`)
- [ ] 불필요한 주석이나 로그는 제거했나요?