### PR TITLE
feat: Media Adapter 모듈 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,6 +29,8 @@ dependencies {
 
     implementation(project(":modules:media:domain"))
     implementation(project(":modules:media:application"))
+    implementation(project(":modules:media:adapter:in:web"))
+    implementation(project(":modules:media:adapter:out:persistence:jpa"))
 
     implementation(libs.bundles.spring.boot.web)
     implementation(libs.bundles.spring.boot.data)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation(project(":modules:media:application"))
     implementation(project(":modules:media:adapter:in:web"))
     implementation(project(":modules:media:adapter:out:persistence:jpa"))
+    implementation(project(":modules:media:adapter:out:storage:r2"))
 
     implementation(libs.bundles.spring.boot.web)
     implementation(libs.bundles.spring.boot.data)

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -20,6 +20,20 @@ spring:
     locations: classpath:db/migration
     validate-on-migrate: true
 
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 50MB
+      max-request-size: 50MB
+
+cloudflare:
+  r2:
+    account-id: ${CLOUDFLARE_R2_ACCOUNT_ID}
+    access-key-id: ${CLOUDFLARE_R2_ACCESS_KEY_ID}
+    secret-access-key: ${CLOUDFLARE_R2_SECRET_ACCESS_KEY}
+    bucket-name: ${CLOUDFLARE_R2_BUCKET_NAME}
+    public-url: ${CLOUDFLARE_R2_PUBLIC_URL}
+
 app:
   cookie:
     secure: ${APP_COOKIE_SECURE:true}

--- a/app/src/main/resources/db/migration/V11__create_media_file_table.sql
+++ b/app/src/main/resources/db/migration/V11__create_media_file_table.sql
@@ -1,0 +1,27 @@
+-- Media File 테이블 생성
+CREATE TABLE media_file
+(
+    id                 UUID PRIMARY KEY,
+    original_file_name VARCHAR(255)  NOT NULL,
+    mime_type          VARCHAR(50)   NOT NULL,
+    file_size          BIGINT        NOT NULL,
+    storage_key        VARCHAR(500)  NOT NULL UNIQUE,
+    public_url         VARCHAR(1000) NOT NULL,
+    created_at         TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at         TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 인덱스 생성
+CREATE INDEX idx_media_file_storage_key ON media_file (storage_key);
+CREATE INDEX idx_media_file_created_at ON media_file (created_at);
+
+-- 테이블 코멘트
+COMMENT ON TABLE media_file IS '미디어 파일 메타데이터';
+COMMENT ON COLUMN media_file.id IS '파일 ID (UUID)';
+COMMENT ON COLUMN media_file.original_file_name IS '원본 파일명';
+COMMENT ON COLUMN media_file.mime_type IS 'MIME 타입';
+COMMENT ON COLUMN media_file.file_size IS '파일 크기 (bytes)';
+COMMENT ON COLUMN media_file.storage_key IS '저장소 키 (Cloudflare R2)';
+COMMENT ON COLUMN media_file.public_url IS 'Public URL';
+COMMENT ON COLUMN media_file.created_at IS '생성 시간';
+COMMENT ON COLUMN media_file.updated_at IS '수정 시간';

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,9 @@ flyway = "11.13.2"
 # Security
 jjwt = "0.13.0"
 
+# AWS SDK
+awsSdk = "2.21.0"
+
 # Documentation
 springdoc = "2.8.14"
 
@@ -76,6 +79,10 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 # Documentation
 springdoc-openapi = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui", version.ref = "springdoc" }
 
+# AWS SDK for S3 (R2 compatible)
+aws-s3 = { module = "software.amazon.awssdk:s3", version.ref = "awsSdk" }
+aws-core = { module = "software.amazon.awssdk:aws-core", version.ref = "awsSdk" }
+
 [bundles]
 kotlin-dependencies = ["kotlin-reflect", "kotlin-logging"]
 kotlin-test = ["kotest-runner-junit5", "kotest-assertions-core", "mockk"]
@@ -87,4 +94,5 @@ spring-ai = ["spring-ai-openai-spring-boot-starter", "spring-ai-pgvector-store-s
 
 jwt = ["jjwt-api", "jjwt-impl", "jjwt-jackson"]
 redis = ["spring-boot-starter-data-redis"]
+aws-s3 = ["aws-s3", "aws-core"]
 

--- a/modules/media/adapter/in/web/build.gradle.kts
+++ b/modules/media/adapter/in/web/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    springBootConventions
+}
+
+dependencies {
+    implementation(project(":libs:common"))
+    implementation(project(":libs:adapter:web"))
+    implementation(project(":modules:media:domain"))
+    implementation(project(":modules:media:application"))
+
+    implementation(libs.bundles.spring.boot.web)
+    implementation(libs.bundles.spring.boot.security)
+
+    testImplementation(libs.bundles.kotlin.test)
+}

--- a/modules/media/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/media/adapter/in/web/MediaApi.kt
+++ b/modules/media/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/media/adapter/in/web/MediaApi.kt
@@ -1,0 +1,205 @@
+package cloud.luigi99.blog.media.adapter.`in`.web
+
+import cloud.luigi99.blog.adapter.web.dto.CommonResponse
+import cloud.luigi99.blog.media.adapter.`in`.web.dto.FileListResponse
+import cloud.luigi99.blog.media.adapter.`in`.web.dto.FileResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.multipart.MultipartFile
+
+@Tag(name = "Media", description = "미디어 파일 관리 API")
+interface MediaApi {
+    @Operation(
+        summary = "파일 업로드",
+        description = "이미지 등 파일을 업로드합니다. 최대 10MB까지 업로드 가능합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "201",
+                description = "파일 업로드 성공",
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 파일 형식 또는 크기 초과",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "InvalidFileType",
+                                value = """
+                                {
+                                  "success": false,
+                                  "data": null,
+                                  "error": {
+                                    "code": "MEDIA_002",
+                                    "message": "지원하지 않는 파일 형식입니다."
+                                  },
+                                  "timestamp": "2026-01-03T10:00:00Z"
+                                }
+                                """,
+                            ),
+                            ExampleObject(
+                                name = "FileSizeExceeded",
+                                value = """
+                                {
+                                  "success": false,
+                                  "data": null,
+                                  "error": {
+                                    "code": "MEDIA_003",
+                                    "message": "파일 크기가 제한을 초과했습니다."
+                                  },
+                                  "timestamp": "2026-01-03T10:00:00Z"
+                                }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "500",
+                description = "업로드 실패 (서버 오류)",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "UploadFailed",
+                                value = """
+                                {
+                                  "success": false,
+                                  "data": null,
+                                  "error": {
+                                    "code": "MEDIA_001",
+                                    "message": "파일 업로드에 실패했습니다."
+                                  },
+                                  "timestamp": "2026-01-03T10:00:00Z"
+                                }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun uploadFile(
+        @Parameter(
+            description = "업로드할 파일",
+            required = true,
+            content = [Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)],
+        )
+        @RequestPart
+        file: MultipartFile,
+    ): ResponseEntity<CommonResponse<FileResponse>>
+
+    @Operation(
+        summary = "파일 상세 조회",
+        description = "파일 ID를 통해 파일의 메타데이터와 Public URL을 조회합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "파일 조회 성공",
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "파일을 찾을 수 없음",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "FileNotFound",
+                                value = """
+                                {
+                                  "success": false,
+                                  "data": null,
+                                  "error": {
+                                    "code": "MEDIA_004",
+                                    "message": "파일을 찾을 수 없습니다."
+                                  },
+                                  "timestamp": "2026-01-03T10:00:00Z"
+                                }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getFile(
+        @Parameter(description = "파일 ID", required = true)
+        fileId: String,
+    ): ResponseEntity<CommonResponse<FileResponse>>
+
+    @Operation(
+        summary = "파일 목록 조회",
+        description = "업로드된 모든 파일의 목록을 조회합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "파일 목록 조회 성공",
+            ),
+        ],
+    )
+    fun getFileList(): ResponseEntity<CommonResponse<FileListResponse>>
+
+    @Operation(
+        summary = "파일 삭제",
+        description = "파일 ID에 해당하는 파일을 삭제합니다. Storage와 DB에서 모두 제거됩니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "204",
+                description = "파일 삭제 성공",
+                content = [Content(schema = Schema(hidden = true))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "파일을 찾을 수 없음",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "FileNotFound",
+                                value = """
+                                {
+                                  "success": false,
+                                  "data": null,
+                                  "error": {
+                                    "code": "MEDIA_004",
+                                    "message": "파일을 찾을 수 없습니다."
+                                  },
+                                  "timestamp": "2026-01-03T10:00:00Z"
+                                }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun deleteFile(
+        @Parameter(description = "파일 ID", required = true)
+        fileId: String,
+    ): ResponseEntity<Unit>
+}

--- a/modules/media/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/media/adapter/in/web/MediaController.kt
+++ b/modules/media/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/media/adapter/in/web/MediaController.kt
@@ -1,0 +1,135 @@
+package cloud.luigi99.blog.media.adapter.`in`.web
+
+import cloud.luigi99.blog.adapter.web.dto.CommonResponse
+import cloud.luigi99.blog.media.adapter.`in`.web.dto.FileListResponse
+import cloud.luigi99.blog.media.adapter.`in`.web.dto.FileResponse
+import cloud.luigi99.blog.media.application.media.port.`in`.command.DeleteFileUseCase
+import cloud.luigi99.blog.media.application.media.port.`in`.command.MediaCommandFacade
+import cloud.luigi99.blog.media.application.media.port.`in`.command.UploadFileUseCase
+import cloud.luigi99.blog.media.application.media.port.`in`.query.GetFileListUseCase
+import cloud.luigi99.blog.media.application.media.port.`in`.query.GetFileUseCase
+import cloud.luigi99.blog.media.application.media.port.`in`.query.MediaQueryFacade
+import mu.KotlinLogging
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 미디어 파일 컨트롤러
+ *
+ * 파일 업로드/조회/삭제 등 미디어 파일 관련 요청을 처리합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/files")
+class MediaController(
+    private val mediaCommandFacade: MediaCommandFacade,
+    private val mediaQueryFacade: MediaQueryFacade,
+) : MediaApi {
+    @PreAuthorize("hasAnyRole('ADMIN')")
+    @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    override fun uploadFile(
+        @RequestPart("file") file: MultipartFile,
+    ): ResponseEntity<CommonResponse<FileResponse>> {
+        log.info { "Uploading file: ${file.originalFilename}" }
+
+        val response =
+            mediaCommandFacade.uploadFile().execute(
+                UploadFileUseCase.Command(
+                    originalFileName = file.originalFilename ?: "unknown",
+                    mimeType = file.contentType ?: "application/octet-stream",
+                    fileSize = file.size,
+                    fileData = file.bytes,
+                ),
+            )
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(
+                CommonResponse.success(
+                    FileResponse(
+                        fileId = response.fileId,
+                        originalFileName = response.originalFileName,
+                        mimeType = response.mimeType,
+                        fileSize = response.fileSize,
+                        publicUrl = response.publicUrl,
+                    ),
+                ),
+            )
+    }
+
+    @GetMapping("/{fileId}")
+    override fun getFile(
+        @PathVariable fileId: String,
+    ): ResponseEntity<CommonResponse<FileResponse>> {
+        log.info { "Getting file: $fileId" }
+
+        val response =
+            mediaQueryFacade.getFile().execute(
+                GetFileUseCase.Query(fileId = fileId),
+            )
+
+        return ResponseEntity.ok(
+            CommonResponse.success(
+                FileResponse(
+                    fileId = response.fileId,
+                    originalFileName = response.originalFileName,
+                    mimeType = response.mimeType,
+                    fileSize = response.fileSize,
+                    publicUrl = response.publicUrl,
+                ),
+            ),
+        )
+    }
+
+    @GetMapping
+    override fun getFileList(): ResponseEntity<CommonResponse<FileListResponse>> {
+        log.info { "Getting file list" }
+
+        val response =
+            mediaQueryFacade.getFileList().execute(
+                GetFileListUseCase.Query(),
+            )
+
+        return ResponseEntity.ok(
+            CommonResponse.success(
+                FileListResponse(
+                    files =
+                        response.files.map {
+                            FileListResponse.FileSummary(
+                                fileId = it.fileId,
+                                originalFileName = it.originalFileName,
+                                mimeType = it.mimeType,
+                                fileSize = it.fileSize,
+                                publicUrl = it.publicUrl,
+                            )
+                        },
+                ),
+            ),
+        )
+    }
+
+    @PreAuthorize("hasAnyRole('ADMIN')")
+    @DeleteMapping("/{fileId}")
+    override fun deleteFile(
+        @PathVariable fileId: String,
+    ): ResponseEntity<Unit> {
+        log.info { "Deleting file: $fileId" }
+
+        mediaCommandFacade.deleteFile().execute(
+            DeleteFileUseCase.Command(fileId = fileId),
+        )
+
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/modules/media/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/media/adapter/in/web/dto/FileListResponse.kt
+++ b/modules/media/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/media/adapter/in/web/dto/FileListResponse.kt
@@ -1,0 +1,27 @@
+package cloud.luigi99.blog.media.adapter.`in`.web.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 파일 목록 응답 DTO
+ */
+data class FileListResponse(
+    @field:Schema(description = "파일 목록")
+    val files: List<FileSummary>,
+) {
+    /**
+     * 파일 요약 정보
+     */
+    data class FileSummary(
+        @field:Schema(description = "파일 ID", example = "123e4567-e89b-12d3-a456-426614174000")
+        val fileId: String,
+        @field:Schema(description = "원본 파일명", example = "image.png")
+        val originalFileName: String,
+        @field:Schema(description = "MIME 타입", example = "image/png")
+        val mimeType: String,
+        @field:Schema(description = "파일 크기 (bytes)", example = "1024")
+        val fileSize: Long,
+        @field:Schema(description = "Public URL", example = "https://cdn.example.com/2026/01/image.png")
+        val publicUrl: String,
+    )
+}

--- a/modules/media/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/media/adapter/in/web/dto/FileResponse.kt
+++ b/modules/media/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/media/adapter/in/web/dto/FileResponse.kt
@@ -1,0 +1,19 @@
+package cloud.luigi99.blog.media.adapter.`in`.web.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 파일 응답 DTO
+ */
+data class FileResponse(
+    @field:Schema(description = "파일 ID", example = "123e4567-e89b-12d3-a456-426614174000")
+    val fileId: String,
+    @field:Schema(description = "원본 파일명", example = "image.png")
+    val originalFileName: String,
+    @field:Schema(description = "MIME 타입", example = "image/png")
+    val mimeType: String,
+    @field:Schema(description = "파일 크기 (bytes)", example = "1024")
+    val fileSize: Long,
+    @field:Schema(description = "Public URL", example = "https://cdn.example.com/2026/01/image.png")
+    val publicUrl: String,
+)

--- a/modules/media/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/media/adapter/in/web/MediaControllerTest.kt
+++ b/modules/media/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/media/adapter/in/web/MediaControllerTest.kt
@@ -1,0 +1,162 @@
+package cloud.luigi99.blog.media.adapter.`in`.web
+
+import cloud.luigi99.blog.media.application.media.port.`in`.command.DeleteFileUseCase
+import cloud.luigi99.blog.media.application.media.port.`in`.command.MediaCommandFacade
+import cloud.luigi99.blog.media.application.media.port.`in`.command.UploadFileUseCase
+import cloud.luigi99.blog.media.application.media.port.`in`.query.GetFileListUseCase
+import cloud.luigi99.blog.media.application.media.port.`in`.query.GetFileUseCase
+import cloud.luigi99.blog.media.application.media.port.`in`.query.MediaQueryFacade
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.http.HttpStatus
+import org.springframework.mock.web.MockMultipartFile
+import java.time.LocalDateTime
+
+/**
+ * MediaController 테스트
+ *
+ * 파일 업로드/조회/삭제 API 엔드포인트를 검증합니다.
+ */
+class MediaControllerTest :
+    BehaviorSpec({
+        val mediaCommandFacade = mockk<MediaCommandFacade>()
+        val mediaQueryFacade = mockk<MediaQueryFacade>()
+        val uploadFileUseCase = mockk<UploadFileUseCase>()
+        val getFileUseCase = mockk<GetFileUseCase>()
+        val getFileListUseCase = mockk<GetFileListUseCase>()
+        val deleteFileUseCase = mockk<DeleteFileUseCase>()
+
+        val controller = MediaController(mediaCommandFacade, mediaQueryFacade)
+
+        Given("파일 업로드 요청이 주어졌을 때") {
+            val file =
+                MockMultipartFile(
+                    "file",
+                    "test.png",
+                    "image/png",
+                    "test content".toByteArray(),
+                )
+
+            val uploadResponse =
+                UploadFileUseCase.Response(
+                    fileId = "file-123",
+                    originalFileName = "test.png",
+                    mimeType = "image/png",
+                    fileSize = 12L,
+                    storageKey = "2026/01/test.png",
+                    publicUrl = "https://cdn.example.com/2026/01/test.png",
+                )
+
+            When("파일을 업로드하면") {
+                every { mediaCommandFacade.uploadFile() } returns uploadFileUseCase
+                every { uploadFileUseCase.execute(any()) } returns uploadResponse
+
+                val result = controller.uploadFile(file)
+
+                Then("201 Created 응답이 반환되어야 한다") {
+                    result.statusCode shouldBe HttpStatus.CREATED
+                }
+
+                Then("UploadFileUseCase가 호출되어야 한다") {
+                    verify(exactly = 1) {
+                        uploadFileUseCase.execute(
+                            match {
+                                it.originalFileName == "test.png" &&
+                                    it.mimeType == "image/png" &&
+                                    it.fileSize == 12L
+                            },
+                        )
+                    }
+                }
+            }
+        }
+
+        Given("파일 ID가 주어졌을 때") {
+            val fileId = "file-123"
+            val fileResponse =
+                GetFileUseCase.Response(
+                    fileId = fileId,
+                    originalFileName = "test.png",
+                    mimeType = "image/png",
+                    fileSize = 1024L,
+                    storageKey = "2026/01/test.png",
+                    publicUrl = "https://cdn.example.com/2026/01/test.png",
+                    createdAt = LocalDateTime.now(),
+                )
+
+            When("파일 정보를 조회하면") {
+                every { mediaQueryFacade.getFile() } returns getFileUseCase
+                every { getFileUseCase.execute(any()) } returns fileResponse
+
+                val result = controller.getFile(fileId)
+
+                Then("200 OK 응답이 반환되어야 한다") {
+                    result.statusCode shouldBe HttpStatus.OK
+                }
+
+                Then("GetFileUseCase가 호출되어야 한다") {
+                    verify(exactly = 1) {
+                        getFileUseCase.execute(match { it.fileId == fileId })
+                    }
+                }
+            }
+        }
+
+        Given("파일 목록 조회 요청이 주어졌을 때") {
+            val fileListResponse =
+                GetFileListUseCase.Response(
+                    files =
+                        listOf(
+                            GetFileListUseCase.FileSummary(
+                                fileId = "file-1",
+                                originalFileName = "test1.png",
+                                mimeType = "image/png",
+                                fileSize = 1024L,
+                                publicUrl = "https://cdn.example.com/test1.png",
+                                createdAt = LocalDateTime.now(),
+                            ),
+                        ),
+                )
+
+            When("파일 목록을 조회하면") {
+                every { mediaQueryFacade.getFileList() } returns getFileListUseCase
+                every { getFileListUseCase.execute(any()) } returns fileListResponse
+
+                val result = controller.getFileList()
+
+                Then("200 OK 응답이 반환되어야 한다") {
+                    result.statusCode shouldBe HttpStatus.OK
+                }
+
+                Then("GetFileListUseCase가 호출되어야 한다") {
+                    verify(exactly = 1) {
+                        getFileListUseCase.execute(any())
+                    }
+                }
+            }
+        }
+
+        Given("삭제할 파일 ID가 주어졌을 때") {
+            val fileId = "file-123"
+
+            When("파일을 삭제하면") {
+                every { mediaCommandFacade.deleteFile() } returns deleteFileUseCase
+                every { deleteFileUseCase.execute(any()) } returns Unit
+
+                val result = controller.deleteFile(fileId)
+
+                Then("204 No Content 응답이 반환되어야 한다") {
+                    result.statusCode shouldBe HttpStatus.NO_CONTENT
+                }
+
+                Then("DeleteFileUseCase가 호출되어야 한다") {
+                    verify(exactly = 1) {
+                        deleteFileUseCase.execute(match { it.fileId == fileId })
+                    }
+                }
+            }
+        }
+    })

--- a/modules/media/adapter/out/persistence/jpa/build.gradle.kts
+++ b/modules/media/adapter/out/persistence/jpa/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    springBootConventions
+}
+
+dependencies {
+    implementation(project(":libs:common"))
+    implementation(project(":libs:adapter:persistence:jpa"))
+    implementation(project(":modules:media:domain"))
+    api(project(":modules:media:application"))
+
+    implementation(libs.bundles.spring.boot.data)
+
+    testImplementation(libs.bundles.kotlin.test)
+    testImplementation(libs.spring.boot.starter.test)
+}

--- a/modules/media/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/media/adapter/out/persistence/jpa/media/MediaFileJpaEntity.kt
+++ b/modules/media/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/media/adapter/out/persistence/jpa/media/MediaFileJpaEntity.kt
@@ -1,0 +1,67 @@
+package cloud.luigi99.blog.media.adapter.out.persistence.jpa.media
+
+import cloud.luigi99.blog.adapter.persistence.jpa.JpaAggregateRoot
+import cloud.luigi99.blog.media.domain.media.vo.MediaFileId
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.DynamicUpdate
+import java.util.UUID
+
+/**
+ * 미디어 파일 JPA Entity
+ *
+ * 미디어 파일 메타데이터를 데이터베이스에 저장합니다.
+ */
+@Entity
+@Table(name = "media_file")
+@DynamicUpdate
+class MediaFileJpaEntity private constructor(
+    @Id
+    @Column(name = "id")
+    val id: UUID,
+    @Column(name = "original_file_name", nullable = false, length = 255)
+    val originalFileName: String,
+    @Column(name = "mime_type", nullable = false, length = 50)
+    val mimeType: String,
+    @Column(name = "file_size", nullable = false)
+    val fileSize: Long,
+    @Column(name = "storage_key", nullable = false, unique = true, length = 500)
+    val storageKey: String,
+    @Column(name = "public_url", nullable = false, length = 1000)
+    val publicUrl: String,
+) : JpaAggregateRoot<MediaFileId>() {
+    override val entityId: MediaFileId
+        get() = MediaFileId(id)
+
+    companion object {
+        /**
+         * JPA Entity를 생성합니다.
+         *
+         * @param entityId 파일 ID
+         * @param originalFileName 원본 파일명
+         * @param mimeType MIME 타입
+         * @param fileSize 파일 크기 (bytes)
+         * @param storageKey 저장소 키
+         * @param publicUrl Public URL
+         * @return MediaFileJpaEntity 인스턴스
+         */
+        fun from(
+            entityId: UUID,
+            originalFileName: String,
+            mimeType: String,
+            fileSize: Long,
+            storageKey: String,
+            publicUrl: String,
+        ): MediaFileJpaEntity =
+            MediaFileJpaEntity(
+                id = entityId,
+                originalFileName = originalFileName,
+                mimeType = mimeType,
+                fileSize = fileSize,
+                storageKey = storageKey,
+                publicUrl = publicUrl,
+            )
+    }
+}

--- a/modules/media/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/media/adapter/out/persistence/jpa/media/MediaFileJpaRepository.kt
+++ b/modules/media/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/media/adapter/out/persistence/jpa/media/MediaFileJpaRepository.kt
@@ -1,0 +1,26 @@
+package cloud.luigi99.blog.media.adapter.out.persistence.jpa.media
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+/**
+ * MediaFile JPA Repository
+ *
+ * Spring Data JPA를 사용한 미디어 파일 데이터 접근 인터페이스입니다.
+ */
+@Repository
+interface MediaFileJpaRepository : JpaRepository<MediaFileJpaEntity, UUID> {
+    /**
+     * StorageKey로 미디어 파일을 조회합니다.
+     *
+     * @param storageKey 저장소 키
+     * @return MediaFileJpaEntity 또는 null
+     */
+    @Query("SELECT m FROM MediaFileJpaEntity m WHERE m.storageKey = :storageKey")
+    fun findByStorageKeyValue(
+        @Param("storageKey") storageKey: String,
+    ): MediaFileJpaEntity?
+}

--- a/modules/media/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/media/adapter/out/persistence/jpa/media/MediaFileMapper.kt
+++ b/modules/media/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/media/adapter/out/persistence/jpa/media/MediaFileMapper.kt
@@ -1,0 +1,54 @@
+package cloud.luigi99.blog.media.adapter.out.persistence.jpa.media
+
+import cloud.luigi99.blog.media.domain.media.model.MediaFile
+import cloud.luigi99.blog.media.domain.media.vo.FileSize
+import cloud.luigi99.blog.media.domain.media.vo.MediaFileId
+import cloud.luigi99.blog.media.domain.media.vo.MimeType
+import cloud.luigi99.blog.media.domain.media.vo.OriginalFileName
+import cloud.luigi99.blog.media.domain.media.vo.PublicUrl
+import cloud.luigi99.blog.media.domain.media.vo.StorageKey
+
+/**
+ * MediaFile Domain ↔ JPA Entity 변환 Mapper
+ *
+ * Domain 모델과 JPA Entity 간의 변환을 담당합니다.
+ */
+object MediaFileMapper {
+    /**
+     * JPA Entity를 Domain 모델로 변환합니다.
+     *
+     * @param entity JPA Entity
+     * @return Domain 모델
+     */
+    fun toDomain(entity: MediaFileJpaEntity): MediaFile =
+        MediaFile.from(
+            entityId = MediaFileId(entity.id),
+            originalFileName = OriginalFileName(entity.originalFileName),
+            mimeType = MimeType(entity.mimeType),
+            fileSize = FileSize(entity.fileSize),
+            storageKey = StorageKey(entity.storageKey),
+            publicUrl = PublicUrl(entity.publicUrl),
+            createdAt = entity.createdAt,
+            updatedAt = entity.updatedAt,
+        )
+
+    /**
+     * Domain 모델을 JPA Entity로 변환합니다.
+     *
+     * @param mediaFile Domain 모델
+     * @return JPA Entity
+     */
+    fun toEntity(mediaFile: MediaFile): MediaFileJpaEntity =
+        MediaFileJpaEntity
+            .from(
+                entityId = mediaFile.entityId.value,
+                originalFileName = mediaFile.originalFileName.value,
+                mimeType = mediaFile.mimeType.value,
+                fileSize = mediaFile.fileSize.bytes,
+                storageKey = mediaFile.storageKey.value,
+                publicUrl = mediaFile.publicUrl.value,
+            ).apply {
+                createdAt = mediaFile.createdAt
+                updatedAt = mediaFile.updatedAt
+            }
+}

--- a/modules/media/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/media/adapter/out/persistence/jpa/media/MediaFileRepositoryAdapter.kt
+++ b/modules/media/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/media/adapter/out/persistence/jpa/media/MediaFileRepositoryAdapter.kt
@@ -1,0 +1,97 @@
+package cloud.luigi99.blog.media.adapter.out.persistence.jpa.media
+
+import cloud.luigi99.blog.common.application.port.out.DomainEventPublisher
+import cloud.luigi99.blog.common.application.port.out.EventContextManager
+import cloud.luigi99.blog.media.application.media.port.out.MediaFileRepository
+import cloud.luigi99.blog.media.domain.media.model.MediaFile
+import cloud.luigi99.blog.media.domain.media.vo.MediaFileId
+import cloud.luigi99.blog.media.domain.media.vo.StorageKey
+import mu.KotlinLogging
+import org.springframework.stereotype.Repository
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 미디어 파일 저장소 어댑터 구현체
+ *
+ * JPA 리포지토리를 사용하여 미디어 파일 데이터를 영속화하고, 도메인 이벤트를 발행합니다.
+ */
+@Repository
+class MediaFileRepositoryAdapter(
+    private val jpaRepository: MediaFileJpaRepository,
+    private val eventContextManager: EventContextManager,
+    private val domainEventPublisher: DomainEventPublisher,
+) : MediaFileRepository {
+    /**
+     * 미디어 파일 엔티티를 저장합니다.
+     * 저장 후 누적된 도메인 이벤트를 발행합니다.
+     *
+     * @param entity 저장할 미디어 파일
+     * @return 저장된 미디어 파일
+     */
+    override fun save(entity: MediaFile): MediaFile {
+        log.debug { "Saving media file: ${entity.entityId}" }
+
+        // 1. Domain → JPA
+        val jpaEntity = MediaFileMapper.toEntity(entity)
+
+        // 2. Save to DB
+        val saved = jpaRepository.save(jpaEntity)
+
+        // 3. Publish domain events
+        val events = eventContextManager.getDomainEventsAndClear()
+        events.forEach { domainEventPublisher.publish(it) }
+
+        log.debug { "Successfully saved media file: ${saved.entityId}" }
+
+        // 4. JPA → Domain
+        return MediaFileMapper.toDomain(saved)
+    }
+
+    /**
+     * ID로 미디어 파일을 조회합니다.
+     *
+     * @param id 미디어 파일 ID
+     * @return 미디어 파일 또는 null
+     */
+    override fun findById(id: MediaFileId): MediaFile? {
+        log.debug { "Finding media file by ID: $id" }
+        return jpaRepository
+            .findById(id.value)
+            .map { MediaFileMapper.toDomain(it) }
+            .orElse(null)
+    }
+
+    /**
+     * StorageKey로 미디어 파일을 조회합니다.
+     *
+     * @param storageKey 저장소 키
+     * @return 미디어 파일 또는 null
+     */
+    override fun findByStorageKey(storageKey: StorageKey): MediaFile? {
+        log.debug { "Finding media file by storage key: $storageKey" }
+        return jpaRepository
+            .findByStorageKeyValue(storageKey.value)
+            ?.let { MediaFileMapper.toDomain(it) }
+    }
+
+    /**
+     * 모든 미디어 파일을 조회합니다.
+     *
+     * @return 미디어 파일 목록
+     */
+    override fun findAll(): List<MediaFile> {
+        log.debug { "Finding all media files" }
+        return jpaRepository.findAll().map { MediaFileMapper.toDomain(it) }
+    }
+
+    /**
+     * ID로 미디어 파일을 삭제합니다.
+     *
+     * @param id 미디어 파일 ID
+     */
+    override fun deleteById(id: MediaFileId) {
+        log.debug { "Deleting media file by ID: $id" }
+        jpaRepository.deleteById(id.value)
+    }
+}

--- a/modules/media/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/media/adapter/out/persistence/jpa/media/MediaFileMapperTest.kt
+++ b/modules/media/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/media/adapter/out/persistence/jpa/media/MediaFileMapperTest.kt
@@ -1,0 +1,116 @@
+package cloud.luigi99.blog.media.adapter.out.persistence.jpa.media
+
+import cloud.luigi99.blog.common.domain.event.EventManager
+import cloud.luigi99.blog.media.domain.media.model.MediaFile
+import cloud.luigi99.blog.media.domain.media.vo.FileSize
+import cloud.luigi99.blog.media.domain.media.vo.MediaFileId
+import cloud.luigi99.blog.media.domain.media.vo.MimeType
+import cloud.luigi99.blog.media.domain.media.vo.OriginalFileName
+import cloud.luigi99.blog.media.domain.media.vo.PublicUrl
+import cloud.luigi99.blog.media.domain.media.vo.StorageKey
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import java.time.LocalDateTime
+
+/**
+ * MediaFileMapper 테스트
+ *
+ * Domain 모델과 JPA Entity 간의 변환을 검증합니다.
+ */
+class MediaFileMapperTest :
+    BehaviorSpec({
+        beforeTest {
+            mockkObject(EventManager)
+            every { EventManager.eventContextManager } returns mockk(relaxed = true)
+        }
+        Given("Domain 모델이 주어졌을 때") {
+            val now = LocalDateTime.now()
+            val mediaFile =
+                MediaFile.from(
+                    entityId = MediaFileId.generate(),
+                    originalFileName = OriginalFileName("test.png"),
+                    mimeType = MimeType("image/png"),
+                    fileSize = FileSize(1024L),
+                    storageKey = StorageKey("2026/01/test-uuid.png"),
+                    publicUrl = PublicUrl("https://cdn.example.com/2026/01/test-uuid.png"),
+                    createdAt = now,
+                    updatedAt = now,
+                )
+
+            When("JPA Entity로 변환하면") {
+                val jpaEntity = MediaFileMapper.toEntity(mediaFile)
+
+                Then("모든 필드가 올바르게 매핑되어야 한다") {
+                    jpaEntity.id shouldBe mediaFile.entityId.value
+                    jpaEntity.originalFileName shouldBe mediaFile.originalFileName.value
+                    jpaEntity.mimeType shouldBe mediaFile.mimeType.value
+                    jpaEntity.fileSize shouldBe mediaFile.fileSize.bytes
+                    jpaEntity.storageKey shouldBe mediaFile.storageKey.value
+                    jpaEntity.publicUrl shouldBe mediaFile.publicUrl.value
+                    jpaEntity.createdAt shouldBe now
+                    jpaEntity.updatedAt shouldBe now
+                }
+            }
+        }
+
+        Given("JPA Entity가 주어졌을 때") {
+            val now = LocalDateTime.now()
+            val fileId = MediaFileId.generate()
+            val jpaEntity =
+                MediaFileJpaEntity
+                    .from(
+                        entityId = fileId.value,
+                        originalFileName = "test.png",
+                        mimeType = "image/png",
+                        fileSize = 1024L,
+                        storageKey = "2026/01/test-uuid.png",
+                        publicUrl = "https://cdn.example.com/2026/01/test-uuid.png",
+                    ).apply {
+                        createdAt = now
+                        updatedAt = now
+                    }
+
+            When("Domain 모델로 변환하면") {
+                val mediaFile = MediaFileMapper.toDomain(jpaEntity)
+
+                Then("모든 필드가 올바르게 매핑되어야 한다") {
+                    mediaFile.entityId.value shouldBe jpaEntity.id
+                    mediaFile.originalFileName.value shouldBe jpaEntity.originalFileName
+                    mediaFile.mimeType.value shouldBe jpaEntity.mimeType
+                    mediaFile.fileSize.bytes shouldBe jpaEntity.fileSize
+                    mediaFile.storageKey.value shouldBe jpaEntity.storageKey
+                    mediaFile.publicUrl.value shouldBe jpaEntity.publicUrl
+                    mediaFile.createdAt shouldBe now
+                    mediaFile.updatedAt shouldBe now
+                }
+            }
+        }
+
+        Given("Domain 모델과 JPA Entity가 주어졌을 때") {
+            val mediaFile =
+                MediaFile.upload(
+                    originalFileName = OriginalFileName("test.png"),
+                    mimeType = MimeType("image/png"),
+                    fileSize = FileSize(1024L),
+                    storageKey = StorageKey("2026/01/test-uuid.png"),
+                    publicUrl = PublicUrl("https://cdn.example.com/2026/01/test-uuid.png"),
+                )
+
+            When("Domain → JPA → Domain 변환을 수행하면") {
+                val jpaEntity = MediaFileMapper.toEntity(mediaFile)
+                val converted = MediaFileMapper.toDomain(jpaEntity)
+
+                Then("원본과 동일한 값을 가져야 한다") {
+                    converted.entityId shouldBe mediaFile.entityId
+                    converted.originalFileName shouldBe mediaFile.originalFileName
+                    converted.mimeType shouldBe mediaFile.mimeType
+                    converted.fileSize shouldBe mediaFile.fileSize
+                    converted.storageKey shouldBe mediaFile.storageKey
+                    converted.publicUrl shouldBe mediaFile.publicUrl
+                }
+            }
+        }
+    })

--- a/modules/media/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/media/adapter/out/persistence/jpa/media/MediaFileRepositoryAdapterTest.kt
+++ b/modules/media/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/media/adapter/out/persistence/jpa/media/MediaFileRepositoryAdapterTest.kt
@@ -1,0 +1,193 @@
+package cloud.luigi99.blog.media.adapter.out.persistence.jpa.media
+
+import cloud.luigi99.blog.common.application.port.out.DomainEventPublisher
+import cloud.luigi99.blog.common.application.port.out.EventContextManager
+import cloud.luigi99.blog.common.domain.event.EventManager
+import cloud.luigi99.blog.media.domain.media.event.MediaFileUploadedEvent
+import cloud.luigi99.blog.media.domain.media.model.MediaFile
+import cloud.luigi99.blog.media.domain.media.vo.FileSize
+import cloud.luigi99.blog.media.domain.media.vo.MediaFileId
+import cloud.luigi99.blog.media.domain.media.vo.MimeType
+import cloud.luigi99.blog.media.domain.media.vo.OriginalFileName
+import cloud.luigi99.blog.media.domain.media.vo.PublicUrl
+import cloud.luigi99.blog.media.domain.media.vo.StorageKey
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verify
+import java.util.Optional
+
+/**
+ * MediaFileRepositoryAdapter 테스트
+ *
+ * JPA를 통한 미디어 파일 데이터 영속화 및 도메인 이벤트 발행을 검증합니다.
+ */
+class MediaFileRepositoryAdapterTest :
+    BehaviorSpec({
+        beforeTest {
+            mockkObject(EventManager)
+            every { EventManager.eventContextManager } returns mockk(relaxed = true)
+        }
+
+        val jpaRepository = mockk<MediaFileJpaRepository>()
+        val eventContextManager = mockk<EventContextManager>()
+        val domainEventPublisher = mockk<DomainEventPublisher>()
+        val adapter = MediaFileRepositoryAdapter(jpaRepository, eventContextManager, domainEventPublisher)
+
+        Given("새로운 파일을 업로드할 때") {
+            val mediaFile =
+                MediaFile.upload(
+                    originalFileName = OriginalFileName("test.png"),
+                    mimeType = MimeType("image/png"),
+                    fileSize = FileSize(1024L),
+                    storageKey = StorageKey("2026/01/test-uuid.png"),
+                    publicUrl = PublicUrl("https://cdn.example.com/2026/01/test-uuid.png"),
+                )
+
+            When("파일 정보를 저장하면") {
+                val jpaEntity = MediaFileMapper.toEntity(mediaFile)
+                val events =
+                    listOf(
+                        MediaFileUploadedEvent(
+                            fileId = mediaFile.entityId,
+                            originalFileName = mediaFile.originalFileName,
+                            fileSize = mediaFile.fileSize,
+                        ),
+                    )
+
+                every { jpaRepository.save(any()) } returns jpaEntity
+                every { eventContextManager.getDomainEventsAndClear() } returns events
+                justRun { domainEventPublisher.publish(any()) }
+
+                val saved = adapter.save(mediaFile)
+
+                Then("저장된 파일 정보가 반환되어야 한다") {
+                    saved shouldNotBe null
+                    saved.entityId shouldBe mediaFile.entityId
+                    saved.originalFileName shouldBe mediaFile.originalFileName
+                    saved.mimeType shouldBe mediaFile.mimeType
+                    saved.fileSize shouldBe mediaFile.fileSize
+                }
+
+                Then("도메인 이벤트가 발행되어야 한다") {
+                    verify(exactly = 1) {
+                        domainEventPublisher.publish(match { it is MediaFileUploadedEvent })
+                    }
+                }
+            }
+        }
+
+        Given("파일 ID가 주어졌을 때") {
+            val fileId = MediaFileId.generate()
+
+            When("해당 ID로 파일을 조회하면") {
+                val jpaEntity =
+                    MediaFileJpaEntity.from(
+                        entityId = fileId.value,
+                        originalFileName = "test.png",
+                        mimeType = "image/png",
+                        fileSize = 1024L,
+                        storageKey = "2026/01/test-uuid.png",
+                        publicUrl = "https://cdn.example.com/2026/01/test-uuid.png",
+                    )
+
+                every { jpaRepository.findById(fileId.value) } returns Optional.of(jpaEntity)
+
+                val found = adapter.findById(fileId)
+
+                Then("파일이 조회되어야 한다") {
+                    found shouldNotBe null
+                    found?.entityId shouldBe fileId
+                    found?.originalFileName?.value shouldBe "test.png"
+                }
+            }
+
+            When("존재하지 않는 ID로 조회하면") {
+                every { jpaRepository.findById(fileId.value) } returns Optional.empty()
+
+                val found = adapter.findById(fileId)
+
+                Then("null이 반환되어야 한다") {
+                    found shouldBe null
+                }
+            }
+        }
+
+        Given("StorageKey가 주어졌을 때") {
+            val storageKey = StorageKey("2026/01/test-uuid.png")
+
+            When("해당 키로 파일을 조회하면") {
+                val jpaEntity =
+                    MediaFileJpaEntity.from(
+                        entityId = MediaFileId.generate().value,
+                        originalFileName = "test.png",
+                        mimeType = "image/png",
+                        fileSize = 1024L,
+                        storageKey = storageKey.value,
+                        publicUrl = "https://cdn.example.com/2026/01/test-uuid.png",
+                    )
+
+                every { jpaRepository.findByStorageKeyValue(storageKey.value) } returns jpaEntity
+
+                val found = adapter.findByStorageKey(storageKey)
+
+                Then("파일이 조회되어야 한다") {
+                    found shouldNotBe null
+                    found?.storageKey shouldBe storageKey
+                }
+            }
+        }
+
+        Given("여러 파일이 저장되어 있을 때") {
+            When("전체 파일 목록을 조회하면") {
+                val entities =
+                    listOf(
+                        MediaFileJpaEntity.from(
+                            entityId = MediaFileId.generate().value,
+                            originalFileName = "test1.png",
+                            mimeType = "image/png",
+                            fileSize = 1024L,
+                            storageKey = "2026/01/test1.png",
+                            publicUrl = "https://cdn.example.com/2026/01/test1.png",
+                        ),
+                        MediaFileJpaEntity.from(
+                            entityId = MediaFileId.generate().value,
+                            originalFileName = "test2.jpg",
+                            mimeType = "image/jpeg",
+                            fileSize = 2048L,
+                            storageKey = "2026/01/test2.jpg",
+                            publicUrl = "https://cdn.example.com/2026/01/test2.jpg",
+                        ),
+                    )
+
+                every { jpaRepository.findAll() } returns entities
+
+                val files = adapter.findAll()
+
+                Then("모든 파일이 조회되어야 한다") {
+                    files shouldHaveSize 2
+                    files[0].originalFileName.value shouldBe "test1.png"
+                    files[1].originalFileName.value shouldBe "test2.jpg"
+                }
+            }
+        }
+
+        Given("삭제할 파일 ID가 주어졌을 때") {
+            val fileId = MediaFileId.generate()
+
+            When("파일을 삭제하면") {
+                justRun { jpaRepository.deleteById(fileId.value) }
+
+                adapter.deleteById(fileId)
+
+                Then("Repository의 deleteById가 호출되어야 한다") {
+                    verify(exactly = 1) { jpaRepository.deleteById(fileId.value) }
+                }
+            }
+        }
+    })

--- a/modules/media/adapter/out/storage/r2/build.gradle.kts
+++ b/modules/media/adapter/out/storage/r2/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    springBootConventions
+}
+
+dependencies {
+    implementation(project(":libs:common"))
+    implementation(project(":modules:media:domain"))
+    api(project(":modules:media:application"))
+
+    // AWS SDK for S3 (Cloudflare R2)
+    implementation(libs.bundles.aws.s3)
+
+    implementation(libs.spring.boot.starter.core)
+
+    testImplementation(libs.bundles.kotlin.test)
+    testImplementation(libs.spring.boot.starter.test)
+}

--- a/modules/media/adapter/out/storage/r2/src/main/kotlin/cloud/luigi99/blog/media/adapter/out/storage/r2/CloudflareR2StorageAdapter.kt
+++ b/modules/media/adapter/out/storage/r2/src/main/kotlin/cloud/luigi99/blog/media/adapter/out/storage/r2/CloudflareR2StorageAdapter.kt
@@ -1,0 +1,84 @@
+package cloud.luigi99.blog.media.adapter.out.storage.r2
+
+import cloud.luigi99.blog.media.application.media.port.out.StoragePort
+import cloud.luigi99.blog.media.domain.media.exception.FileUploadFailedException
+import cloud.luigi99.blog.media.domain.media.vo.PublicUrl
+import cloud.luigi99.blog.media.domain.media.vo.StorageKey
+import mu.KotlinLogging
+import org.springframework.stereotype.Component
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Cloudflare R2 Storage Adapter
+ *
+ * AWS S3 호환 API를 사용하여 R2에 파일을 저장/삭제하고 Public URL을 생성합니다.
+ */
+@Component
+class CloudflareR2StorageAdapter(
+    private val s3Client: S3Client,
+    private val bucketName: String,
+    private val publicUrl: String,
+) : StoragePort {
+    /**
+     * 파일을 R2에 업로드합니다.
+     *
+     * @param storageKey 저장소 키
+     * @param fileData 파일 바이트 데이터
+     * @param contentType MIME 타입
+     * @throws FileUploadFailedException 업로드 실패 시
+     */
+    override fun upload(storageKey: StorageKey, fileData: ByteArray, contentType: String) {
+        try {
+            val request =
+                PutObjectRequest
+                    .builder()
+                    .bucket(bucketName)
+                    .key(storageKey.value)
+                    .contentType(contentType)
+                    .contentLength(fileData.size.toLong())
+                    .build()
+
+            s3Client.putObject(request, RequestBody.fromBytes(fileData))
+
+            logger.info { "파일 업로드 성공: ${storageKey.value}" }
+        } catch (e: Exception) {
+            logger.error(e) { "파일 업로드 실패: ${storageKey.value}" }
+            throw FileUploadFailedException("파일 업로드에 실패했습니다: ${e.message}")
+        }
+    }
+
+    /**
+     * R2에서 파일을 삭제합니다.
+     *
+     * @param storageKey 저장소 키
+     */
+    override fun delete(storageKey: StorageKey) {
+        try {
+            val request =
+                DeleteObjectRequest
+                    .builder()
+                    .bucket(bucketName)
+                    .key(storageKey.value)
+                    .build()
+
+            s3Client.deleteObject(request)
+
+            logger.info { "파일 삭제 성공: ${storageKey.value}" }
+        } catch (e: Exception) {
+            logger.error(e) { "파일 삭제 실패: ${storageKey.value}" }
+        }
+    }
+
+    /**
+     * 파일의 Public URL을 생성합니다.
+     *
+     * @param storageKey 저장소 키
+     * @return Public URL
+     */
+    override fun getPublicUrl(storageKey: StorageKey): PublicUrl = PublicUrl("$publicUrl/${storageKey.value}")
+}

--- a/modules/media/adapter/out/storage/r2/src/main/kotlin/cloud/luigi99/blog/media/adapter/out/storage/r2/config/R2Config.kt
+++ b/modules/media/adapter/out/storage/r2/src/main/kotlin/cloud/luigi99/blog/media/adapter/out/storage/r2/config/R2Config.kt
@@ -1,0 +1,42 @@
+package cloud.luigi99.blog.media.adapter.out.storage.r2.config
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import java.net.URI
+
+/**
+ * Cloudflare R2 Storage 설정
+ *
+ * R2는 AWS S3 호환 API를 제공하므로 AWS SDK S3Client를 사용합니다.
+ */
+@Configuration
+@EnableConfigurationProperties(R2Properties::class)
+class R2Config(private val properties: R2Properties) {
+    /**
+     * R2용 S3Client Bean을 생성합니다.
+     *
+     * @return S3Client R2에 연결된 S3 클라이언트
+     */
+    @Bean
+    fun s3Client(): S3Client =
+        S3Client
+            .builder()
+            .region(Region.US_EAST_1)
+            .endpointOverride(URI.create("https://${properties.accountId}.r2.cloudflarestorage.com"))
+            .credentialsProvider(
+                StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(properties.accessKeyId, properties.secretAccessKey),
+                ),
+            ).build()
+
+    @Bean
+    fun bucketName(): String = properties.bucketName
+
+    @Bean
+    fun publicUrl(): String = properties.publicUrl
+}

--- a/modules/media/adapter/out/storage/r2/src/main/kotlin/cloud/luigi99/blog/media/adapter/out/storage/r2/config/R2Properties.kt
+++ b/modules/media/adapter/out/storage/r2/src/main/kotlin/cloud/luigi99/blog/media/adapter/out/storage/r2/config/R2Properties.kt
@@ -1,0 +1,17 @@
+package cloud.luigi99.blog.media.adapter.out.storage.r2.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Cloudflare R2 설정 프로퍼티
+ *
+ * application.yml의 cloudflare.r2 설정을 바인딩합니다.
+ */
+@ConfigurationProperties(prefix = "cloudflare.r2")
+data class R2Properties(
+    val accountId: String,
+    val accessKeyId: String,
+    val secretAccessKey: String,
+    val bucketName: String,
+    val publicUrl: String,
+)

--- a/modules/media/adapter/out/storage/r2/src/test/kotlin/cloud/luigi99/blog/media/adapter/out/storage/r2/CloudflareR2StorageAdapterTest.kt
+++ b/modules/media/adapter/out/storage/r2/src/test/kotlin/cloud/luigi99/blog/media/adapter/out/storage/r2/CloudflareR2StorageAdapterTest.kt
@@ -1,0 +1,115 @@
+package cloud.luigi99.blog.media.adapter.out.storage.r2
+
+import cloud.luigi99.blog.media.domain.media.exception.FileUploadFailedException
+import cloud.luigi99.blog.media.domain.media.vo.PublicUrl
+import cloud.luigi99.blog.media.domain.media.vo.StorageKey
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
+import software.amazon.awssdk.services.s3.model.DeleteObjectResponse
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import software.amazon.awssdk.services.s3.model.PutObjectResponse
+
+/**
+ * CloudflareR2StorageAdapter 테스트
+ *
+ * S3Client Mock을 사용하여 파일 업로드/삭제/URL 생성 기능을 검증합니다.
+ */
+class CloudflareR2StorageAdapterTest :
+    BehaviorSpec({
+        val s3Client = mockk<S3Client>()
+        val bucketName = "test-bucket"
+        val publicUrl = "https://cdn.example.com"
+        val adapter = CloudflareR2StorageAdapter(s3Client, bucketName, publicUrl)
+
+        Given("파일 데이터가 주어졌을 때") {
+            val storageKey = StorageKey("2026/01/test-uuid.png")
+            val fileData = "test file content".toByteArray()
+            val contentType = "image/png"
+
+            When("파일을 업로드하면") {
+                every {
+                    s3Client.putObject(any<PutObjectRequest>(), any<RequestBody>())
+                } returns PutObjectResponse.builder().build()
+
+                adapter.upload(storageKey, fileData, contentType)
+
+                Then("S3Client의 putObject가 호출되어야 한다") {
+                    verify(exactly = 1) {
+                        s3Client.putObject(
+                            match<PutObjectRequest> {
+                                it.bucket() == bucketName &&
+                                    it.key() == storageKey.value &&
+                                    it.contentType() == contentType &&
+                                    it.contentLength() == fileData.size.toLong()
+                            },
+                            any<RequestBody>(),
+                        )
+                    }
+                }
+            }
+
+            When("업로드 중 예외가 발생하면") {
+                every {
+                    s3Client.putObject(any<PutObjectRequest>(), any<RequestBody>())
+                } throws RuntimeException("S3 upload failed")
+
+                val exception =
+                    shouldThrow<FileUploadFailedException> {
+                        adapter.upload(storageKey, fileData, contentType)
+                    }
+
+                Then("FileUploadFailedException이 발생해야 한다") {
+                    exception.message shouldContain "파일 업로드에 실패했습니다"
+                }
+            }
+        }
+
+        Given("StorageKey가 주어졌을 때") {
+            val storageKey = StorageKey("2026/01/test-uuid.png")
+
+            When("파일을 삭제하면") {
+                every {
+                    s3Client.deleteObject(any<DeleteObjectRequest>())
+                } returns DeleteObjectResponse.builder().build()
+
+                adapter.delete(storageKey)
+
+                Then("S3Client의 deleteObject가 호출되어야 한다") {
+                    verify(exactly = 1) {
+                        s3Client.deleteObject(
+                            match<DeleteObjectRequest> {
+                                it.bucket() == bucketName &&
+                                    it.key() == storageKey.value
+                            },
+                        )
+                    }
+                }
+            }
+
+            When("삭제 중 예외가 발생해도") {
+                every {
+                    s3Client.deleteObject(any<DeleteObjectRequest>())
+                } throws RuntimeException("S3 delete failed")
+
+                Then("예외가 발생하지 않아야 한다") {
+                    adapter.delete(storageKey)
+                }
+            }
+
+            When("Public URL을 생성하면") {
+                val publicUrlResult = adapter.getPublicUrl(storageKey)
+
+                Then("올바른 URL이 반환되어야 한다") {
+                    publicUrlResult shouldBe PublicUrl("$publicUrl/${storageKey.value}")
+                }
+            }
+        }
+    })

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,6 +30,7 @@ include("modules:media:domain")
 include("modules:media:application")
 include("modules:media:adapter:in:web")
 include("modules:media:adapter:out:persistence:jpa")
+include("modules:media:adapter:out:storage:r2")
 
 include("libs:adapter:persistence:jpa")
 include("libs:adapter:persistence:redis")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,6 +28,8 @@ include("modules:content:adapter:out:persistence:jpa")
 
 include("modules:media:domain")
 include("modules:media:application")
+include("modules:media:adapter:in:web")
+include("modules:media:adapter:out:persistence:jpa")
 
 include("libs:adapter:persistence:jpa")
 include("libs:adapter:persistence:redis")


### PR DESCRIPTION
## 📋 개요
미디어 모듈의 아웃바운드 어댑터 계층을 구현했습니다.
미디어 파일의 메타데이터를 저장하기 위한 JPA 어댑터와 실제 파일을 Cloudflare R2에 업로드하기 위한 스토리지 어댑터를 추가했습니다.

## 🔗 관련 이슈
- Closes #57

## ☑️ 체크리스트
- [x] 코딩 컨벤션을 준수했나요? (`./gradlew ktlintCheck`)
- [x] 모든 테스트를 통과했나요? (`./gradlew test`)
- [x] 불필요한 주석이나 로그는 제거했나요?