### PR TITLE
feat: 회원 가입 프로필 이미지 지원 및 다중 프로필 조회 기능 추가

### DIFF
--- a/modules/member/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/member/MemberRepositoryAdapter.kt
+++ b/modules/member/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/member/MemberRepositoryAdapter.kt
@@ -78,4 +78,14 @@ class MemberRepositoryAdapter(
         jpaRepository.deleteById(id.value)
         log.info { "Deleted member: $id" }
     }
+
+    /**
+     * 여러 ID로 회원 목록을 조회합니다.
+     */
+    override fun findAllById(ids: List<MemberId>): List<Member> {
+        log.debug { "Finding members by IDs: $ids" }
+        return jpaRepository
+            .findAllById(ids.map { it.value })
+            .map { MemberMapper.toDomain(it) }
+    }
 }

--- a/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/port/in/command/RegisterMemberUseCase.kt
+++ b/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/port/in/command/RegisterMemberUseCase.kt
@@ -3,7 +3,12 @@ package cloud.luigi99.blog.member.application.member.port.`in`.command
 interface RegisterMemberUseCase {
     fun execute(command: Command): Response
 
-    data class Command(val email: String, val username: String)
+    data class Command(val email: String, val username: String, val profileImgUrl: String?)
 
-    data class Response(val memberId: String, val email: String, val username: String)
+    data class Response(
+        val memberId: String,
+        val email: String,
+        val username: String,
+        val profileImgUrl: String?,
+    )
 }

--- a/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/port/in/query/GetMembersProfileUseCase.kt
+++ b/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/port/in/query/GetMembersProfileUseCase.kt
@@ -1,0 +1,28 @@
+package cloud.luigi99.blog.member.application.member.port.`in`.query
+
+interface GetMembersProfileUseCase {
+    fun execute(query: Query): Response
+
+    data class Query(val memberIds: List<String>)
+
+    data class Response(val members: List<MemberProfile>)
+
+    data class MemberProfile(
+        val memberId: String,
+        val email: String,
+        val username: String,
+        val profile: ProfileResponse?,
+    )
+
+    data class ProfileResponse(
+        val profileId: String,
+        val nickname: String,
+        val bio: String?,
+        val profileImageUrl: String?,
+        val jobTitle: String?,
+        val techStack: List<String>,
+        val githubUrl: String?,
+        val contactEmail: String?,
+        val websiteUrl: String?,
+    )
+}

--- a/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/port/in/query/MemberQueryFacade.kt
+++ b/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/port/in/query/MemberQueryFacade.kt
@@ -4,4 +4,6 @@ interface MemberQueryFacade {
     fun getCurrentMember(): GetCurrentMemberUseCase
 
     fun getMemberProfile(): GetMemberProfileUseCase
+
+    fun getMembersProfile(): GetMembersProfileUseCase
 }

--- a/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/port/out/MemberRepository.kt
+++ b/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/port/out/MemberRepository.kt
@@ -9,4 +9,6 @@ interface MemberRepository : Repository<Member, MemberId> {
     fun findByEmail(email: Email): Member?
 
     fun existsByEmail(email: Email): Boolean
+
+    fun findAllById(ids: List<MemberId>): List<Member>
 }

--- a/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/service/command/RegisterMemberService.kt
+++ b/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/service/command/RegisterMemberService.kt
@@ -7,6 +7,7 @@ import cloud.luigi99.blog.member.domain.member.vo.Email
 import cloud.luigi99.blog.member.domain.member.vo.Username
 import cloud.luigi99.blog.member.domain.profile.model.Profile
 import cloud.luigi99.blog.member.domain.profile.vo.Nickname
+import cloud.luigi99.blog.member.domain.profile.vo.Url
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -40,6 +41,7 @@ class RegisterMemberService(private val memberRepository: MemberRepository) : Re
         val profile =
             Profile.create(
                 nickname = Nickname(command.username),
+                profileImageUrl = command.profileImgUrl?.let { Url(it) },
             )
 
         // 프로필 연결 및 저장
@@ -54,6 +56,10 @@ class RegisterMemberService(private val memberRepository: MemberRepository) : Re
                     .toString(),
             email = savedMember.email.value,
             username = savedMember.username.value,
+            profileImgUrl =
+                savedMember.profile
+                    ?.profileImageUrl
+                    ?.value,
         )
     }
 }

--- a/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/service/query/GetMembersProfileService.kt
+++ b/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/service/query/GetMembersProfileService.kt
@@ -1,0 +1,52 @@
+package cloud.luigi99.blog.member.application.member.service.query
+
+import cloud.luigi99.blog.member.application.member.port.`in`.query.GetMembersProfileUseCase
+import cloud.luigi99.blog.member.application.member.port.out.MemberRepository
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private val log = KotlinLogging.logger {}
+
+@Service
+@Transactional(readOnly = true)
+class GetMembersProfileService(private val memberRepository: MemberRepository) : GetMembersProfileUseCase {
+    override fun execute(query: GetMembersProfileUseCase.Query): GetMembersProfileUseCase.Response {
+        log.debug { "Fetching profiles for members: ${query.memberIds}" }
+
+        val memberIds = query.memberIds.map { MemberId.from(it) }
+        val members = memberRepository.findAllById(memberIds)
+
+        val memberProfiles =
+            members.map { member ->
+                val profileResponse =
+                    member.profile?.let {
+                        GetMembersProfileUseCase.ProfileResponse(
+                            profileId =
+                                it.entityId.value
+                                    .toString(),
+                            nickname = it.nickname.value,
+                            bio = it.bio?.value,
+                            profileImageUrl = it.profileImageUrl?.value,
+                            jobTitle = it.jobTitle?.value,
+                            techStack = it.techStack.values,
+                            githubUrl = it.githubUrl?.value,
+                            contactEmail = it.contactEmail?.value,
+                            websiteUrl = it.websiteUrl?.value,
+                        )
+                    }
+
+                GetMembersProfileUseCase.MemberProfile(
+                    memberId =
+                        member.entityId.value
+                            .toString(),
+                    email = member.email.value,
+                    username = member.username.value,
+                    profile = profileResponse,
+                )
+            }
+
+        return GetMembersProfileUseCase.Response(members = memberProfiles)
+    }
+}

--- a/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/service/query/MemberQueryService.kt
+++ b/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/service/query/MemberQueryService.kt
@@ -2,6 +2,7 @@ package cloud.luigi99.blog.member.application.member.service.query
 
 import cloud.luigi99.blog.member.application.member.port.`in`.query.GetCurrentMemberUseCase
 import cloud.luigi99.blog.member.application.member.port.`in`.query.GetMemberProfileUseCase
+import cloud.luigi99.blog.member.application.member.port.`in`.query.GetMembersProfileUseCase
 import cloud.luigi99.blog.member.application.member.port.`in`.query.MemberQueryFacade
 import org.springframework.stereotype.Service
 
@@ -9,8 +10,11 @@ import org.springframework.stereotype.Service
 class MemberQueryService(
     private val getCurrentMemberUseCase: GetCurrentMemberUseCase,
     private val getMemberProfileUseCase: GetMemberProfileUseCase,
+    private val getMembersProfileUseCase: GetMembersProfileUseCase,
 ) : MemberQueryFacade {
     override fun getCurrentMember(): GetCurrentMemberUseCase = getCurrentMemberUseCase
 
     override fun getMemberProfile(): GetMemberProfileUseCase = getMemberProfileUseCase
+
+    override fun getMembersProfile(): GetMembersProfileUseCase = getMembersProfileUseCase
 }

--- a/modules/member/application/src/test/kotlin/cloud/luigi99/blog/member/application/member/service/command/RegisterMemberServiceTest.kt
+++ b/modules/member/application/src/test/kotlin/cloud/luigi99/blog/member/application/member/service/command/RegisterMemberServiceTest.kt
@@ -43,6 +43,7 @@ class RegisterMemberServiceTest :
                     RegisterMemberUseCase.Command(
                         email = "user@example.com",
                         username = "john_doe",
+                        profileImgUrl = "https://example.com/profile.jpg",
                     )
 
                 val savedMemberSlot = slot<Member>()
@@ -95,6 +96,7 @@ class RegisterMemberServiceTest :
                     RegisterMemberUseCase.Command(
                         email = "test@example.com",
                         username = "testuser",
+                        profileImgUrl = "https://example.com/profile.jpg",
                     )
 
                 val memberSlot = slot<Member>()
@@ -138,6 +140,7 @@ class RegisterMemberServiceTest :
                             RegisterMemberUseCase.Command(
                                 email = email,
                                 username = username,
+                                profileImgUrl = "https://example.com/profile.jpg",
                             ),
                         )
                     }
@@ -172,6 +175,7 @@ class RegisterMemberServiceTest :
                     RegisterMemberUseCase.Command(
                         email = "domain@example.com",
                         username = "domainuser",
+                        profileImgUrl = "https://example.com/profile.jpg",
                     )
 
                 val memberSlot = slot<Member>()

--- a/modules/member/application/src/test/kotlin/cloud/luigi99/blog/member/application/member/service/query/GetMembersProfileServiceTest.kt
+++ b/modules/member/application/src/test/kotlin/cloud/luigi99/blog/member/application/member/service/query/GetMembersProfileServiceTest.kt
@@ -1,0 +1,107 @@
+package cloud.luigi99.blog.member.application.member.service.query
+
+import cloud.luigi99.blog.common.domain.event.EventManager
+import cloud.luigi99.blog.member.application.member.port.`in`.query.GetMembersProfileUseCase
+import cloud.luigi99.blog.member.application.member.port.out.MemberRepository
+import cloud.luigi99.blog.member.domain.member.model.Member
+import cloud.luigi99.blog.member.domain.member.vo.Email
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import cloud.luigi99.blog.member.domain.member.vo.Username
+import cloud.luigi99.blog.member.domain.profile.model.Profile
+import cloud.luigi99.blog.member.domain.profile.vo.Nickname
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+
+class GetMembersProfileServiceTest :
+    BehaviorSpec({
+
+        beforeTest {
+            mockkObject(EventManager)
+            every { EventManager.eventContextManager } returns mockk(relaxed = true)
+        }
+
+        Given("여러 회원이 존재할 때") {
+            val memberRepository = mockk<MemberRepository>()
+            val service = GetMembersProfileService(memberRepository)
+
+            val member1 =
+                Member.from(
+                    entityId = MemberId.generate(),
+                    email = Email("user1@example.com"),
+                    username = Username("user1"),
+                    profile = Profile.create(Nickname("User One")),
+                    createdAt = null,
+                    updatedAt = null,
+                )
+
+            val member2 =
+                Member.from(
+                    entityId = MemberId.generate(),
+                    email = Email("user2@example.com"),
+                    username = Username("user2"),
+                    profile = Profile.create(Nickname("User Two")),
+                    createdAt = null,
+                    updatedAt = null,
+                )
+
+            When("여러 회원의 프로필을 조회하면") {
+                val query =
+                    GetMembersProfileUseCase.Query(
+                        memberIds = listOf(member1.entityId.toString(), member2.entityId.toString()),
+                    )
+
+                every { memberRepository.findAllById(any()) } returns listOf(member1, member2)
+
+                val response = service.execute(query)
+
+                Then("요청한 모든 회원의 정보가 반환된다") {
+                    response.members shouldHaveSize 2
+                }
+
+                Then("각 회원의 정보가 정확히 매핑된다") {
+                    val result1 = response.members.find { it.memberId == member1.entityId.toString() }!!
+                    result1.email shouldBe "user1@example.com"
+                    result1.profile?.nickname shouldBe "User One"
+
+                    val result2 = response.members.find { it.memberId == member2.entityId.toString() }!!
+                    result2.email shouldBe "user2@example.com"
+                    result2.profile?.nickname shouldBe "User Two"
+                }
+            }
+        }
+
+        Given("일부 회원만 존재할 때") {
+            val memberRepository = mockk<MemberRepository>()
+            val service = GetMembersProfileService(memberRepository)
+
+            val existingMember =
+                Member.from(
+                    entityId = MemberId.generate(),
+                    email = Email("existing@example.com"),
+                    username = Username("existing"),
+                    profile = null,
+                    createdAt = null,
+                    updatedAt = null,
+                )
+
+            When("존재하는 회원과 존재하지 않는 회원을 함께 조회하면") {
+                val query =
+                    GetMembersProfileUseCase.Query(
+                        memberIds = listOf(existingMember.entityId.toString(), MemberId.generate().toString()),
+                    )
+
+                every { memberRepository.findAllById(any()) } returns listOf(existingMember)
+
+                val response = service.execute(query)
+
+                Then("존재하는 회원의 정보만 반환된다") {
+                    response.members shouldHaveSize 1
+                    response.members[0].memberId shouldBe existingMember.entityId.toString()
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## 📋 개요
회원 모듈의 기능을 확장하고 개선했습니다.
회원 가입 시 프로필 이미지를 설정할 수 있도록 변경하고, 여러 회원의 프로필을 한 번에 조회하는 기능을 추가했습니다.

## 🔗 관련 이슈
- Closes #25

## ☑️ 체크리스트
- [x] 코딩 컨벤션을 준수했나요? (`./gradlew ktlintCheck`)
- [x] 모든 테스트를 통과했나요? (`./gradlew test`)
- [x] 불필요한 주석이나 로그는 제거했나요?
