### PR TITLE
refactor: OAuth2 로그인 시 프로필 이미지 정보 포함하도록 리팩터링

### DIFF
--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/dto/GitHubOAuth2UserInfo.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/dto/GitHubOAuth2UserInfo.kt
@@ -15,4 +15,8 @@ data class GitHubOAuth2UserInfo(private val attributes: Map<String, Any>) : OAut
     override fun getProviderId(): String =
         attributes["id"]?.toString()
             ?: throw IllegalStateException("GitHub provider ID를 찾을 수 없습니다")
+
+    override fun getProfileImgUrl(): String =
+        attributes["avatar_url"]?.toString()
+            ?: throw IllegalStateException("GitHub 프로필 이미지 URL을 찾을 수 없습니다")
 }

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/oauth2/OAuth2AuthenticationSuccessHandler.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/oauth2/OAuth2AuthenticationSuccessHandler.kt
@@ -54,6 +54,7 @@ class OAuth2AuthenticationSuccessHandler(
                         username = userInfo.getUsername(),
                         provider = provider,
                         providerId = userInfo.getProviderId(),
+                        profileImgUrl = userInfo.getProfileImgUrl(),
                     ),
                 )
 

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/oauth2/OAuth2UserInfo.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/oauth2/OAuth2UserInfo.kt
@@ -6,4 +6,6 @@ interface OAuth2UserInfo {
     fun getUsername(): String
 
     fun getProviderId(): String
+
+    fun getProfileImgUrl(): String
 }

--- a/modules/auth/credentials/adapter/out/client/member/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/client/member/MemberClientAdapter.kt
+++ b/modules/auth/credentials/adapter/out/client/member/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/client/member/MemberClientAdapter.kt
@@ -18,6 +18,7 @@ class MemberClientAdapter(private val memberCommandFacade: MemberCommandFacade) 
             RegisterMemberUseCase.Command(
                 email = request.email,
                 username = request.username,
+                profileImgUrl = request.profileImgUrl,
             )
 
         // MSA 전환 시 실제 API 요청 전송 코드로 변경 필요
@@ -27,6 +28,7 @@ class MemberClientAdapter(private val memberCommandFacade: MemberCommandFacade) 
             memberId = response.memberId,
             email = response.email,
             username = response.username,
+            profileImgUrl = response.profileImgUrl,
         )
     }
 }

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/command/LoginUseCase.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/command/LoginUseCase.kt
@@ -10,6 +10,7 @@ interface LoginUseCase {
         val username: String,
         val provider: String,
         val providerId: String,
+        val profileImgUrl: String?,
     )
 
     data class Response(
@@ -17,5 +18,6 @@ interface LoginUseCase {
         val email: String,
         val username: String,
         val role: Role,
+        val profileImgUrl: String?,
     )
 }

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/out/MemberClient.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/out/MemberClient.kt
@@ -3,7 +3,12 @@ package cloud.luigi99.blog.auth.credentials.application.port.out
 interface MemberClient {
     fun execute(request: Request): Response
 
-    data class Request(val email: String, val username: String)
+    data class Request(val email: String, val username: String, val profileImgUrl: String?)
 
-    data class Response(val memberId: String, val email: String, val username: String)
+    data class Response(
+        val memberId: String,
+        val email: String,
+        val username: String,
+        val profileImgUrl: String?,
+    )
 }

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/service/command/LoginService.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/service/command/LoginService.kt
@@ -64,6 +64,7 @@ class LoginService(
             email = command.email,
             username = command.username,
             role = credentials.role,
+            profileImgUrl = command.profileImgUrl,
         )
     }
 
@@ -73,6 +74,7 @@ class LoginService(
                 MemberClient.Request(
                     email = command.email,
                     username = command.username,
+                    profileImgUrl = command.profileImgUrl,
                 ),
             )
 
@@ -81,6 +83,7 @@ class LoginService(
                 memberId = MemberId.from(response.memberId),
                 oauthInfo = oauthInfo,
             )
+
         newCredentials.updateLastLogin()
 
         return newCredentials


### PR DESCRIPTION
## 📋 개요
인증 모듈의 OAuth2 로그인 기능을 개선했습니다.
소셜 로그인(GitHub) 시 프로필 이미지 URL을 가져와 회원 가입 및 로그인 정보에 포함하도록 변경했습니다.

## 🔗 관련 이슈
- Closes #30

## ☑️ 체크리스트
- [x] 코딩 컨벤션을 준수했나요? (`./gradlew ktlintCheck`)
- [x] 모든 테스트를 통과했나요? (`./gradlew test`)
- [x] 불필요한 주석이나 로그는 제거했나요?