### PR TITLE
feat: 게시글 삭제 도메인 로직 추가

### DIFF
--- a/modules/content/domain/src/main/kotlin/cloud/luigi99/blog/content/domain/post/event/PostDeletedEvent.kt
+++ b/modules/content/domain/src/main/kotlin/cloud/luigi99/blog/content/domain/post/event/PostDeletedEvent.kt
@@ -1,0 +1,15 @@
+package cloud.luigi99.blog.content.domain.post.event
+
+import cloud.luigi99.blog.common.domain.event.DomainEvent
+import cloud.luigi99.blog.content.domain.post.vo.PostId
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+
+/**
+ * Post 삭제 이벤트
+ *
+ * Post가 삭제되었을 때 발행됩니다.
+ *
+ * @property postId 삭제된 Post의 ID
+ * @property memberId 삭제된 Post의 작성자 ID
+ */
+data class PostDeletedEvent(val postId: PostId, val memberId: MemberId) : DomainEvent

--- a/modules/content/domain/src/main/kotlin/cloud/luigi99/blog/content/domain/post/model/Post.kt
+++ b/modules/content/domain/src/main/kotlin/cloud/luigi99/blog/content/domain/post/model/Post.kt
@@ -3,6 +3,7 @@ package cloud.luigi99.blog.content.domain.post.model
 import cloud.luigi99.blog.common.domain.AggregateRoot
 import cloud.luigi99.blog.content.domain.post.event.PostArchivedEvent
 import cloud.luigi99.blog.content.domain.post.event.PostCreatedEvent
+import cloud.luigi99.blog.content.domain.post.event.PostDeletedEvent
 import cloud.luigi99.blog.content.domain.post.event.PostPublishedEvent
 import cloud.luigi99.blog.content.domain.post.vo.Body
 import cloud.luigi99.blog.content.domain.post.vo.ContentType
@@ -175,6 +176,30 @@ class Post private constructor(
 
         archived.registerEvent(PostArchivedEvent(archived.entityId, archived.slug))
         return archived
+    }
+
+    /**
+     * Post를 삭제합니다.
+     *
+     * @return 삭제 이벤트가 등록된 Post
+     */
+    fun delete(): Post {
+        val deleted =
+            Post(
+                entityId = entityId,
+                memberId = memberId,
+                title = title,
+                slug = slug,
+                body = body,
+                type = type,
+                status = status,
+                tags = tags,
+            )
+        deleted.createdAt = createdAt
+        deleted.updatedAt = updatedAt
+
+        deleted.registerEvent(PostDeletedEvent(deleted.entityId, deleted.memberId))
+        return deleted
     }
 
     /**

--- a/modules/content/domain/src/test/kotlin/cloud/luigi99/blog/content/domain/post/model/PostTest.kt
+++ b/modules/content/domain/src/test/kotlin/cloud/luigi99/blog/content/domain/post/model/PostTest.kt
@@ -20,6 +20,7 @@ import io.kotest.matchers.types.shouldNotBeSameInstanceAs
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import java.time.LocalDateTime
 
 /**
  * Post Aggregate Root 테스트
@@ -287,7 +288,7 @@ class PostTest :
             val body = Body("재구성 내용")
             val tags = setOf("kotlin", "tdd")
             val metadata =
-                java.time.LocalDateTime
+                LocalDateTime
                     .now()
 
             When("from()으로 Post를 재구성하면") {
@@ -319,6 +320,26 @@ class PostTest :
 
                 Then("이벤트가 발행되지 않는다") {
                     post.getEvents().shouldBeEmpty()
+                }
+            }
+        }
+
+        Given("작성자가 게시글을 삭제하려는 상황에서") {
+            val post =
+                Post.create(
+                    MemberId.generate(),
+                    Title("삭제할 글"),
+                    Slug("delete-post"),
+                    Body("내용"),
+                    ContentType.BLOG,
+                )
+            post.clearEvents()
+
+            When("삭제를 수행하면") {
+                val deleted = post.delete()
+
+                Then("기존 객체와 다른 새로운 인스턴스가 반환된다") {
+                    deleted shouldNotBeSameInstanceAs post
                 }
             }
         }


### PR DESCRIPTION
## 📋 개요
게시글 삭제 기능을 위한 도메인 로직을 구현했습니다.

- `Post` 엔티티에 `delete()` 메서드를 추가하여 상태 변경 로직을 캡슐화했습니다.
- `PostDeletedEvent`를 정의하여 삭제 시 도메인 이벤트가 발행되도록 했습니다.

## 🔗 관련 이슈
- Closes #48

## ☑️ 체크리스트
- [x] 코딩 컨벤션을 준수했나요? (`./gradlew ktlintCheck`)
- [x] 모든 테스트를 통과했나요? (`./gradlew test`)
- [x] 불필요한 주석이나 로그는 제거했나요?