### PR TITLE
feat: 게시글 삭제 유스케이스 및 작성자 정보 조회 추가

### DIFF
--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/command/CreatePostUseCase.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/command/CreatePostUseCase.kt
@@ -1,5 +1,7 @@
 package cloud.luigi99.blog.content.application.post.port.`in`.command
 
+import java.time.LocalDateTime
+
 /**
  * Post 생성 UseCase
  *
@@ -37,7 +39,7 @@ interface CreatePostUseCase {
      * Post 생성 응답
      *
      * @property postId Post ID
-     * @property memberId 작성자 Member ID
+     * @property author 작성자 정보
      * @property title 제목
      * @property slug URL slug
      * @property body 본문
@@ -49,14 +51,19 @@ interface CreatePostUseCase {
      */
     data class Response(
         val postId: String,
-        val memberId: String,
+        val author: AuthorInfo,
         val title: String,
         val slug: String,
         val body: String,
         val type: String,
         val status: String,
         val tags: Set<String>,
-        val createdAt: java.time.LocalDateTime?,
-        val updatedAt: java.time.LocalDateTime?,
+        val createdAt: LocalDateTime?,
+        val updatedAt: LocalDateTime?,
     )
+
+    /**
+     * 작성자 정보
+     */
+    data class AuthorInfo(val memberId: String, val nickname: String, val profileImageUrl: String?)
 }

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/command/DeletePostUseCase.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/command/DeletePostUseCase.kt
@@ -1,0 +1,23 @@
+package cloud.luigi99.blog.content.application.post.port.`in`.command
+
+/**
+ * Post 삭제 UseCase
+ *
+ * Post를 삭제합니다.
+ */
+interface DeletePostUseCase {
+    /**
+     * Post를 삭제합니다.
+     *
+     * @param command 삭제 명령
+     */
+    fun execute(command: Command)
+
+    /**
+     * Post 삭제 명령
+     *
+     * @property memberId 요청자 Member ID
+     * @property postId 삭제할 Post ID
+     */
+    data class Command(val memberId: String, val postId: String)
+}

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/command/PostCommandFacade.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/command/PostCommandFacade.kt
@@ -15,4 +15,9 @@ interface PostCommandFacade {
      * Post 수정 UseCase를 반환합니다.
      */
     fun updatePost(): UpdatePostUseCase
+
+    /**
+     * Post 삭제 UseCase를 반환합니다.
+     */
+    fun deletePost(): DeletePostUseCase
 }

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/command/UpdatePostUseCase.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/command/UpdatePostUseCase.kt
@@ -37,7 +37,7 @@ interface UpdatePostUseCase {
      * Post 수정 응답
      *
      * @property postId Post ID
-     * @property memberId 작성자 Member ID
+     * @property author 작성자 정보
      * @property title 수정된 제목
      * @property slug URL slug
      * @property body 수정된 본문
@@ -49,7 +49,7 @@ interface UpdatePostUseCase {
      */
     data class Response(
         val postId: String,
-        val memberId: String,
+        val author: AuthorInfo,
         val title: String,
         val slug: String,
         val body: String,
@@ -59,4 +59,6 @@ interface UpdatePostUseCase {
         val createdAt: LocalDateTime?,
         val updatedAt: LocalDateTime?,
     )
+
+    data class AuthorInfo(val memberId: String, val nickname: String, val profileImageUrl: String?)
 }

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/query/GetPostByIdUseCase.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/query/GetPostByIdUseCase.kt
@@ -25,7 +25,7 @@ interface GetPostByIdUseCase {
      * Post 조회 응답
      *
      * @property postId Post ID
-     * @property memberId 작성자 Member ID
+     * @property author 작성자 정보
      * @property title 제목
      * @property slug URL slug
      * @property body 본문
@@ -37,7 +37,7 @@ interface GetPostByIdUseCase {
      */
     data class Response(
         val postId: String,
-        val memberId: String,
+        val author: AuthorInfo,
         val title: String,
         val slug: String,
         val body: String,
@@ -47,4 +47,6 @@ interface GetPostByIdUseCase {
         val createdAt: java.time.LocalDateTime?,
         val updatedAt: java.time.LocalDateTime?,
     )
+
+    data class AuthorInfo(val memberId: String, val nickname: String, val profileImageUrl: String?)
 }

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/query/GetPostBySlugUseCase.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/query/GetPostBySlugUseCase.kt
@@ -26,7 +26,7 @@ interface GetPostBySlugUseCase {
      * Post 조회 응답
      *
      * @property postId Post ID
-     * @property memberId 작성자 Member ID
+     * @property author 작성자 정보
      * @property title 제목
      * @property slug URL slug
      * @property body 본문
@@ -38,7 +38,7 @@ interface GetPostBySlugUseCase {
      */
     data class Response(
         val postId: String,
-        val memberId: String,
+        val author: AuthorInfo,
         val title: String,
         val slug: String,
         val body: String,
@@ -48,4 +48,6 @@ interface GetPostBySlugUseCase {
         val createdAt: java.time.LocalDateTime?,
         val updatedAt: java.time.LocalDateTime?,
     )
+
+    data class AuthorInfo(val memberId: String, val nickname: String, val profileImageUrl: String?)
 }

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/query/GetPostsUseCase.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/in/query/GetPostsUseCase.kt
@@ -33,7 +33,7 @@ interface GetPostsUseCase {
      * Post 요약 정보
      *
      * @property postId Post ID
-     * @property memberId 작성자 Member ID
+     * @property author 작성자 정보
      * @property title 제목
      * @property slug URL slug
      * @property type 컨텐츠 타입
@@ -43,7 +43,7 @@ interface GetPostsUseCase {
      */
     data class PostSummary(
         val postId: String,
-        val memberId: String,
+        val author: AuthorInfo,
         val title: String,
         val slug: String,
         val type: String,
@@ -51,4 +51,6 @@ interface GetPostsUseCase {
         val tags: Set<String>,
         val createdAt: java.time.LocalDateTime?,
     )
+
+    data class AuthorInfo(val memberId: String, val nickname: String, val profileImageUrl: String?)
 }

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/out/MemberClient.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/port/out/MemberClient.kt
@@ -1,0 +1,21 @@
+package cloud.luigi99.blog.content.application.post.port.out
+
+/**
+ * 회원 정보 조회를 위한 Outbound Port
+ */
+interface MemberClient {
+    /**
+     * 회원 ID로 작성자 정보를 조회합니다.
+     */
+    fun getAuthor(memberId: String): Author
+
+    /**
+     * 여러 회원 ID로 작성자 정보 목록을 조회합니다.
+     */
+    fun getAuthors(memberIds: List<String>): Map<String, Author>
+
+    /**
+     * 작성자 정보 DTO
+     */
+    data class Author(val memberId: String, val nickname: String, val profileImageUrl: String?)
+}

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/service/command/DeletePostService.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/service/command/DeletePostService.kt
@@ -1,0 +1,44 @@
+package cloud.luigi99.blog.content.application.post.service.command
+
+import cloud.luigi99.blog.content.application.post.port.`in`.command.DeletePostUseCase
+import cloud.luigi99.blog.content.application.post.port.out.PostRepository
+import cloud.luigi99.blog.content.domain.post.exception.PostNotFoundException
+import cloud.luigi99.blog.content.domain.post.exception.UnauthorizedPostAccessException
+import cloud.luigi99.blog.content.domain.post.vo.PostId
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Post 삭제 유스케이스 구현체
+ *
+ * Post를 조회하고 권한을 검증한 후 삭제합니다.
+ */
+@Service
+class DeletePostService(private val postRepository: PostRepository) : DeletePostUseCase {
+    @Transactional
+    override fun execute(command: DeletePostUseCase.Command) {
+        log.info { "Deleting post: ${command.postId} by member: ${command.memberId}" }
+
+        val postId = PostId(UUID.fromString(command.postId))
+        val memberId = MemberId.from(command.memberId)
+
+        val post =
+            postRepository.findById(postId)
+                ?: throw PostNotFoundException("Post ID ${command.postId}를 찾을 수 없습니다")
+
+        if (!post.isOwner(memberId)) {
+            throw UnauthorizedPostAccessException("게시글 ${command.postId}에 대한 삭제 권한이 없습니다")
+        }
+
+        post.delete()
+
+        postRepository.deleteById(postId)
+
+        log.info { "Successfully deleted post: $postId" }
+    }
+}

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/service/command/PostCommandService.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/service/command/PostCommandService.kt
@@ -1,6 +1,7 @@
 package cloud.luigi99.blog.content.application.post.service.command
 
 import cloud.luigi99.blog.content.application.post.port.`in`.command.CreatePostUseCase
+import cloud.luigi99.blog.content.application.post.port.`in`.command.DeletePostUseCase
 import cloud.luigi99.blog.content.application.post.port.`in`.command.PostCommandFacade
 import cloud.luigi99.blog.content.application.post.port.`in`.command.UpdatePostUseCase
 import org.springframework.stereotype.Service
@@ -8,14 +9,17 @@ import org.springframework.stereotype.Service
 /**
  * Post Command Facade 구현체
  *
- * Post 생성/수정 관련 UseCase들을 그룹핑하여 제공합니다 (RESTful 설계).
+ * Post 생성/수정 관련 UseCase들을 그룹핑하여 제공합니다.
  */
 @Service
 class PostCommandService(
     private val createPostUseCase: CreatePostUseCase,
     private val updatePostUseCase: UpdatePostUseCase,
+    private val deletePostUseCase: DeletePostUseCase,
 ) : PostCommandFacade {
     override fun createPost(): CreatePostUseCase = createPostUseCase
 
     override fun updatePost(): UpdatePostUseCase = updatePostUseCase
+
+    override fun deletePost(): DeletePostUseCase = deletePostUseCase
 }

--- a/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/service/query/GetPostsService.kt
+++ b/modules/content/application/src/main/kotlin/cloud/luigi99/blog/content/application/post/service/query/GetPostsService.kt
@@ -1,6 +1,7 @@
 package cloud.luigi99.blog.content.application.post.service.query
 
 import cloud.luigi99.blog.content.application.post.port.`in`.query.GetPostsUseCase
+import cloud.luigi99.blog.content.application.post.port.out.MemberClient
 import cloud.luigi99.blog.content.application.post.port.out.PostRepository
 import cloud.luigi99.blog.content.domain.post.vo.ContentType
 import cloud.luigi99.blog.content.domain.post.vo.PostStatus
@@ -16,7 +17,8 @@ private val log = KotlinLogging.logger {}
  * 필터링 조건에 따라 Post 목록을 조회합니다.
  */
 @Service
-class GetPostsService(private val postRepository: PostRepository) : GetPostsUseCase {
+class GetPostsService(private val postRepository: PostRepository, private val memberClient: MemberClient) :
+    GetPostsUseCase {
     @Transactional(readOnly = true)
     override fun execute(query: GetPostsUseCase.Query): GetPostsUseCase.Response {
         log.info { "Listing posts with filters - status: ${query.status}, type: ${query.type}" }
@@ -46,15 +48,31 @@ class GetPostsService(private val postRepository: PostRepository) : GetPostsUseC
                 }
             }
 
+        val memberIds =
+            posts
+                .map {
+                    it.memberId.value
+                        .toString()
+                }.distinct()
+        val authors = memberClient.getAuthors(memberIds)
+
         val summaries =
             posts.map { post ->
+                val memberIdStr =
+                    post.memberId.value
+                        .toString()
+                val author = authors[memberIdStr] ?: MemberClient.Author(memberIdStr, "Unknown", null)
+
                 GetPostsUseCase.PostSummary(
                     postId =
                         post.entityId.value
                             .toString(),
-                    memberId =
-                        post.memberId.value
-                            .toString(),
+                    author =
+                        GetPostsUseCase.AuthorInfo(
+                            memberId = author.memberId,
+                            nickname = author.nickname,
+                            profileImageUrl = author.profileImageUrl,
+                        ),
                     title = post.title.value,
                     slug = post.slug.value,
                     type = post.type.name,

--- a/modules/content/application/src/test/kotlin/cloud/luigi99/blog/content/application/post/service/command/CreatePostServiceTest.kt
+++ b/modules/content/application/src/test/kotlin/cloud/luigi99/blog/content/application/post/service/command/CreatePostServiceTest.kt
@@ -2,6 +2,7 @@ package cloud.luigi99.blog.content.application.post.service.command
 
 import cloud.luigi99.blog.common.domain.event.EventManager
 import cloud.luigi99.blog.content.application.post.port.`in`.command.CreatePostUseCase
+import cloud.luigi99.blog.content.application.post.port.out.MemberClient
 import cloud.luigi99.blog.content.application.post.port.out.PostRepository
 import cloud.luigi99.blog.content.domain.post.exception.DuplicateSlugException
 import cloud.luigi99.blog.content.domain.post.model.Post
@@ -36,7 +37,8 @@ class CreatePostServiceTest :
 
         Given("블로그 글을 생성할 때") {
             val postRepository = mockk<PostRepository>()
-            val service = CreatePostService(postRepository)
+            val memberClient = mockk<MemberClient>()
+            val service = CreatePostService(postRepository, memberClient)
             val memberId = UUID.randomUUID().toString()
 
             When("유효한 memberId, 제목, slug로 생성하면") {
@@ -71,6 +73,12 @@ class CreatePostServiceTest :
                     )
                 } returns false
                 every { postRepository.save(capture(savedPostSlot)) } returns savedPost
+                every { memberClient.getAuthor(memberId) } returns
+                    MemberClient.Author(
+                        memberId = memberId,
+                        nickname = "TestUser",
+                        profileImageUrl = null,
+                    )
 
                 val response = service.execute(command)
 
@@ -78,8 +86,9 @@ class CreatePostServiceTest :
                     response.postId shouldNotBe null
                 }
 
-                Then("memberId가 반환된다") {
-                    response.memberId shouldBe memberId
+                Then("작성자 정보가 반환된다") {
+                    response.author.memberId shouldBe memberId
+                    response.author.nickname shouldBe "TestUser"
                 }
 
                 Then("제목이 반환된다") {
@@ -110,7 +119,8 @@ class CreatePostServiceTest :
 
         Given("사용자가 중복된 slug로 글을 생성하려고 할 때") {
             val postRepository = mockk<PostRepository>()
-            val service = CreatePostService(postRepository)
+            val memberClient = mockk<MemberClient>()
+            val service = CreatePostService(postRepository, memberClient)
             val memberId = UUID.randomUUID().toString()
 
             When("이미 자신이 사용 중인 slug를 사용하면") {
@@ -140,7 +150,8 @@ class CreatePostServiceTest :
 
         Given("다른 사용자가 동일한 slug를 사용할 때") {
             val postRepository = mockk<PostRepository>()
-            val service = CreatePostService(postRepository)
+            val memberClient = mockk<MemberClient>()
+            val service = CreatePostService(postRepository, memberClient)
             val memberId = UUID.randomUUID().toString()
 
             When("다른 사용자가 이미 사용 중인 slug로 글을 생성하면") {
@@ -176,6 +187,12 @@ class CreatePostServiceTest :
                     )
                 } returns false
                 every { postRepository.save(any()) } returns savedPost
+                every { memberClient.getAuthor(memberId) } returns
+                    MemberClient.Author(
+                        memberId = memberId,
+                        nickname = "TestUser",
+                        profileImageUrl = null,
+                    )
 
                 val response = service.execute(command)
 
@@ -188,7 +205,8 @@ class CreatePostServiceTest :
 
         Given("태그와 함께 글을 생성할 때") {
             val postRepository = mockk<PostRepository>()
-            val service = CreatePostService(postRepository)
+            val memberClient = mockk<MemberClient>()
+            val service = CreatePostService(postRepository, memberClient)
             val memberId = UUID.randomUUID().toString()
 
             When("여러 태그를 포함하여 생성하면") {
@@ -224,6 +242,12 @@ class CreatePostServiceTest :
                     )
                 } returns false
                 every { postRepository.save(any()) } returns savedPost
+                every { memberClient.getAuthor(memberId) } returns
+                    MemberClient.Author(
+                        memberId = memberId,
+                        nickname = "TestUser",
+                        profileImageUrl = null,
+                    )
 
                 val response = service.execute(command)
 
@@ -235,7 +259,8 @@ class CreatePostServiceTest :
 
         Given("여러 타입의 글을 생성할 때") {
             val postRepository = mockk<PostRepository>()
-            val service = CreatePostService(postRepository)
+            val memberClient = mockk<MemberClient>()
+            val service = CreatePostService(postRepository, memberClient)
             val memberId = UUID.randomUUID().toString()
 
             When("BLOG 타입으로 생성하면") {
@@ -256,6 +281,12 @@ class CreatePostServiceTest :
                     )
                 } returns false
                 every { postRepository.save(capture(postSlot)) } answers { firstArg() }
+                every { memberClient.getAuthor(memberId) } returns
+                    MemberClient.Author(
+                        memberId = memberId,
+                        nickname = "TestUser",
+                        profileImageUrl = null,
+                    )
 
                 service.execute(command)
 
@@ -288,6 +319,12 @@ class CreatePostServiceTest :
                     )
                 } returns false
                 every { postRepository.save(capture(postSlot)) } answers { firstArg() }
+                every { memberClient.getAuthor(memberId) } returns
+                    MemberClient.Author(
+                        memberId = memberId,
+                        nickname = "TestUser",
+                        profileImageUrl = null,
+                    )
 
                 service.execute(command)
 

--- a/modules/content/application/src/test/kotlin/cloud/luigi99/blog/content/application/post/service/command/DeletePostServiceTest.kt
+++ b/modules/content/application/src/test/kotlin/cloud/luigi99/blog/content/application/post/service/command/DeletePostServiceTest.kt
@@ -1,0 +1,106 @@
+package cloud.luigi99.blog.content.application.post.service.command
+
+import cloud.luigi99.blog.common.domain.event.EventManager
+import cloud.luigi99.blog.content.application.post.port.`in`.command.DeletePostUseCase
+import cloud.luigi99.blog.content.application.post.port.out.PostRepository
+import cloud.luigi99.blog.content.domain.post.exception.PostNotFoundException
+import cloud.luigi99.blog.content.domain.post.exception.UnauthorizedPostAccessException
+import cloud.luigi99.blog.content.domain.post.model.Post
+import cloud.luigi99.blog.content.domain.post.vo.Body
+import cloud.luigi99.blog.content.domain.post.vo.ContentType
+import cloud.luigi99.blog.content.domain.post.vo.PostId
+import cloud.luigi99.blog.content.domain.post.vo.Slug
+import cloud.luigi99.blog.content.domain.post.vo.Title
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verify
+
+/**
+ * DeletePostService 테스트
+ */
+class DeletePostServiceTest :
+    BehaviorSpec({
+
+        beforeTest {
+            mockkObject(EventManager)
+            every { EventManager.eventContextManager } returns mockk(relaxed = true)
+        }
+
+        Given("게시글이 존재하고 작성자가 삭제를 요청하는 상황에서") {
+            val postRepository = mockk<PostRepository>()
+            val service = DeletePostService(postRepository)
+            val memberId = MemberId.generate()
+            val postId = PostId.generate()
+
+            val post =
+                Post.create(
+                    memberId = memberId,
+                    title = Title("삭제할 글"),
+                    slug = Slug("delete-post"),
+                    body = Body("내용"),
+                    type = ContentType.BLOG,
+                )
+
+            every { postRepository.findById(postId) } returns post
+
+            When("정상적으로 삭제를 시도하면") {
+                val command =
+                    DeletePostUseCase.Command(
+                        memberId = memberId.value.toString(),
+                        postId = postId.value.toString(),
+                    )
+
+                every { postRepository.deleteById(any()) } just Runs
+
+                service.execute(command)
+
+                Then("게시글 삭제 로직이 실행된다") {
+                    verify(exactly = 1) { postRepository.deleteById(any()) }
+                }
+            }
+
+            When("작성자가 아닌 다른 사용자가 삭제를 시도하면") {
+                val otherMemberId = MemberId.generate()
+                val command =
+                    DeletePostUseCase.Command(
+                        memberId = otherMemberId.value.toString(),
+                        postId = postId.value.toString(),
+                    )
+
+                Then("권한 없음 예외(UnauthorizedPostAccessException)가 발생하여 삭제가 거부된다") {
+                    shouldThrow<UnauthorizedPostAccessException> {
+                        service.execute(command)
+                    }
+                }
+            }
+        }
+
+        Given("존재하지 않는 게시글을 삭제하려는 상황에서") {
+            val postRepository = mockk<PostRepository>()
+            val service = DeletePostService(postRepository)
+            val memberId = MemberId.generate()
+            val postId = PostId.generate()
+
+            When("삭제 요청을 보내면") {
+                val command =
+                    DeletePostUseCase.Command(
+                        memberId = memberId.value.toString(),
+                        postId = postId.value.toString(),
+                    )
+
+                every { postRepository.findById(postId) } returns null
+
+                Then("게시글을 찾을 수 없다는 예외(PostNotFoundException)가 발생한다") {
+                    shouldThrow<PostNotFoundException> {
+                        service.execute(command)
+                    }
+                }
+            }
+        }
+    })

--- a/modules/content/application/src/test/kotlin/cloud/luigi99/blog/content/application/post/service/command/UpdatePostServiceTest.kt
+++ b/modules/content/application/src/test/kotlin/cloud/luigi99/blog/content/application/post/service/command/UpdatePostServiceTest.kt
@@ -2,6 +2,7 @@ package cloud.luigi99.blog.content.application.post.service.command
 
 import cloud.luigi99.blog.common.domain.event.EventManager
 import cloud.luigi99.blog.content.application.post.port.`in`.command.UpdatePostUseCase
+import cloud.luigi99.blog.content.application.post.port.out.MemberClient
 import cloud.luigi99.blog.content.application.post.port.out.PostRepository
 import cloud.luigi99.blog.content.domain.post.exception.PostNotFoundException
 import cloud.luigi99.blog.content.domain.post.exception.UnauthorizedPostAccessException
@@ -34,7 +35,8 @@ class UpdatePostServiceTest :
 
         Given("글을 수정할 때") {
             val postRepository = mockk<PostRepository>()
-            val service = UpdatePostService(postRepository)
+            val memberClient = mockk<MemberClient>()
+            val service = UpdatePostService(postRepository, memberClient)
             val memberId = MemberId.generate()
 
             When("작성자가 제목과 본문을 수정하면") {
@@ -60,11 +62,21 @@ class UpdatePostServiceTest :
 
                 every { postRepository.findById(postId) } returns originalPost
                 every { postRepository.save(any()) } returns updatedPost
+                every { memberClient.getAuthor(memberId.value.toString()) } returns
+                    MemberClient.Author(
+                        memberId = memberId.value.toString(),
+                        nickname = "TestUser",
+                        profileImageUrl = null,
+                    )
 
                 val response = service.execute(command)
 
                 Then("수정된 제목이 반환된다") {
                     response.title shouldBe "수정된 제목"
+                }
+
+                Then("작성자 정보가 반환된다") {
+                    response.author.nickname shouldBe "TestUser"
                 }
 
                 Then("수정된 본문이 반환된다") {
@@ -79,7 +91,8 @@ class UpdatePostServiceTest :
 
         Given("글의 상태를 PUBLISHED로 변경할 때") {
             val postRepository = mockk<PostRepository>()
-            val service = UpdatePostService(postRepository)
+            val memberClient = mockk<MemberClient>()
+            val service = UpdatePostService(postRepository, memberClient)
             val memberId = MemberId.generate()
 
             When("작성자가 status를 PUBLISHED로 수정하면") {
@@ -106,6 +119,12 @@ class UpdatePostServiceTest :
 
                 every { postRepository.findById(postId) } returns originalPost
                 every { postRepository.save(any()) } returns publishedPost
+                every { memberClient.getAuthor(memberId.value.toString()) } returns
+                    MemberClient.Author(
+                        memberId = memberId.value.toString(),
+                        nickname = "TestUser",
+                        profileImageUrl = null,
+                    )
 
                 val response = service.execute(command)
 
@@ -121,7 +140,8 @@ class UpdatePostServiceTest :
 
         Given("글의 상태를 ARCHIVED로 변경할 때") {
             val postRepository = mockk<PostRepository>()
-            val service = UpdatePostService(postRepository)
+            val memberClient = mockk<MemberClient>()
+            val service = UpdatePostService(postRepository, memberClient)
             val memberId = MemberId.generate()
 
             When("작성자가 status를 ARCHIVED로 수정하면") {
@@ -148,6 +168,12 @@ class UpdatePostServiceTest :
 
                 every { postRepository.findById(postId) } returns originalPost
                 every { postRepository.save(any()) } returns archivedPost
+                every { memberClient.getAuthor(memberId.value.toString()) } returns
+                    MemberClient.Author(
+                        memberId = memberId.value.toString(),
+                        nickname = "TestUser",
+                        profileImageUrl = null,
+                    )
 
                 val response = service.execute(command)
 
@@ -163,7 +189,8 @@ class UpdatePostServiceTest :
 
         Given("제목, 본문, 상태를 동시에 수정할 때") {
             val postRepository = mockk<PostRepository>()
-            val service = UpdatePostService(postRepository)
+            val memberClient = mockk<MemberClient>()
+            val service = UpdatePostService(postRepository, memberClient)
             val memberId = MemberId.generate()
 
             When("작성자가 모든 필드를 수정하면") {
@@ -191,6 +218,12 @@ class UpdatePostServiceTest :
 
                 every { postRepository.findById(postId) } returns originalPost
                 every { postRepository.save(any()) } returns publishedPost
+                every { memberClient.getAuthor(memberId.value.toString()) } returns
+                    MemberClient.Author(
+                        memberId = memberId.value.toString(),
+                        nickname = "TestUser",
+                        profileImageUrl = null,
+                    )
 
                 val response = service.execute(command)
 
@@ -214,7 +247,8 @@ class UpdatePostServiceTest :
 
         Given("존재하지 않는 글을 수정하려고 할 때") {
             val postRepository = mockk<PostRepository>()
-            val service = UpdatePostService(postRepository)
+            val memberClient = mockk<MemberClient>()
+            val service = UpdatePostService(postRepository, memberClient)
             val memberId = MemberId.generate()
 
             When("없는 Post ID로 수정하면") {
@@ -239,7 +273,8 @@ class UpdatePostServiceTest :
 
         Given("다른 사용자의 글을 수정하려고 할 때") {
             val postRepository = mockk<PostRepository>()
-            val service = UpdatePostService(postRepository)
+            val memberClient = mockk<MemberClient>()
+            val service = UpdatePostService(postRepository, memberClient)
             val authorId = MemberId.generate()
             val otherMemberId = MemberId.generate()
 

--- a/modules/content/application/src/test/kotlin/cloud/luigi99/blog/content/application/post/service/query/GetPostByIdServiceTest.kt
+++ b/modules/content/application/src/test/kotlin/cloud/luigi99/blog/content/application/post/service/query/GetPostByIdServiceTest.kt
@@ -2,6 +2,7 @@ package cloud.luigi99.blog.content.application.post.service.query
 
 import cloud.luigi99.blog.common.domain.event.EventManager
 import cloud.luigi99.blog.content.application.post.port.`in`.query.GetPostByIdUseCase
+import cloud.luigi99.blog.content.application.post.port.out.MemberClient
 import cloud.luigi99.blog.content.application.post.port.out.PostRepository
 import cloud.luigi99.blog.content.domain.post.exception.PostNotFoundException
 import cloud.luigi99.blog.content.domain.post.model.Post
@@ -32,7 +33,8 @@ class GetPostByIdServiceTest :
 
         Given("ID로 글을 조회할 때") {
             val postRepository = mockk<PostRepository>()
-            val service = GetPostByIdService(postRepository)
+            val memberClient = mockk<MemberClient>()
+            val service = GetPostByIdService(postRepository, memberClient)
 
             When("존재하는 Post ID로 조회하면") {
                 val postId = PostId.generate()
@@ -48,6 +50,14 @@ class GetPostByIdServiceTest :
                     )
 
                 every { postRepository.findById(postId) } returns post
+                every { memberClient.getAuthor(any()) } returns
+                    MemberClient.Author(
+                        memberId =
+                            post.memberId.value
+                                .toString(),
+                        nickname = "TestUser",
+                        profileImageUrl = null,
+                    )
 
                 val response = service.execute(query)
 
@@ -63,7 +73,8 @@ class GetPostByIdServiceTest :
 
         Given("존재하지 않는 ID로 조회할 때") {
             val postRepository = mockk<PostRepository>()
-            val service = GetPostByIdService(postRepository)
+            val memberClient = mockk<MemberClient>()
+            val service = GetPostByIdService(postRepository, memberClient)
 
             When("없는 Post ID로 조회하면") {
                 val postId = UUID.randomUUID()

--- a/modules/content/application/src/test/kotlin/cloud/luigi99/blog/content/application/post/service/query/GetPostBySlugServiceTest.kt
+++ b/modules/content/application/src/test/kotlin/cloud/luigi99/blog/content/application/post/service/query/GetPostBySlugServiceTest.kt
@@ -2,6 +2,7 @@ package cloud.luigi99.blog.content.application.post.service.query
 
 import cloud.luigi99.blog.common.domain.event.EventManager
 import cloud.luigi99.blog.content.application.post.port.`in`.query.GetPostBySlugUseCase
+import cloud.luigi99.blog.content.application.post.port.out.MemberClient
 import cloud.luigi99.blog.content.application.post.port.out.PostRepository
 import cloud.luigi99.blog.content.domain.post.exception.PostNotFoundException
 import cloud.luigi99.blog.content.domain.post.model.Post
@@ -30,8 +31,9 @@ class GetPostBySlugServiceTest :
 
         Given("Username과 Slug로 글을 조회할 때") {
             val postRepository = mockk<PostRepository>()
+            val memberClient = mockk<MemberClient>()
             // MemberClient 제거됨
-            val service = GetPostBySlugService(postRepository)
+            val service = GetPostBySlugService(postRepository, memberClient)
 
             When("존재하는 Username과 Slug로 조회하면") {
                 val memberId = MemberId.generate()
@@ -49,6 +51,12 @@ class GetPostBySlugServiceTest :
                 // MemberClient 호출 모킹 제거
                 // findByUsernameAndSlug 모킹 추가
                 every { postRepository.findByUsernameAndSlug("testuser", Slug("test-post")) } returns post
+                every { memberClient.getAuthor(any()) } returns
+                    MemberClient.Author(
+                        memberId = memberId.value.toString(),
+                        nickname = "TestUser",
+                        profileImageUrl = null,
+                    )
 
                 val response = service.execute(query)
 
@@ -68,7 +76,8 @@ class GetPostBySlugServiceTest :
 
         Given("존재하지 않는 Username으로 조회할 때") {
             val postRepository = mockk<PostRepository>()
-            val service = GetPostBySlugService(postRepository)
+            val memberClient = mockk<MemberClient>()
+            val service = GetPostBySlugService(postRepository, memberClient)
 
             When("존재하지 않는 Username으로 조회하면") {
                 val query = GetPostBySlugUseCase.Query(username = "nonexistent", slug = "test-post")
@@ -85,7 +94,8 @@ class GetPostBySlugServiceTest :
 
         Given("존재하지 않는 Slug로 조회할 때") {
             val postRepository = mockk<PostRepository>()
-            val service = GetPostBySlugService(postRepository)
+            val memberClient = mockk<MemberClient>()
+            val service = GetPostBySlugService(postRepository, memberClient)
 
             When("존재하는 Username이지만 없는 Slug로 조회하면") {
                 val query = GetPostBySlugUseCase.Query(username = "testuser", slug = "non-existent")


### PR DESCRIPTION
## 📋 개요
게시글 삭제 비즈니스 로직을 구현하고, 게시글 관련 유스케이스를 확장했습니다.

- **게시글 삭제:** `DeletePostUseCase` 및 `DeletePostService`를 구현했습니다.
- **작성자 정보 연동:** `MemberClient` 포트를 정의하고, 게시글 생성/수정/조회 시 회원 모듈로부터 작성자 정보(닉네임, 프로필 이미지)를 조회하여 응답에 포함하도록 로직을 개선했습니다.

## 🔗 관련 이슈
- Closes #49

## ☑️ 체크리스트
- [x] 코딩 컨벤션을 준수했나요? (`./gradlew ktlintCheck`)
- [x] 모든 테스트를 통과했나요? (`./gradlew test`)
- [x] 불필요한 주석이나 로그는 제거했나요?
