### PR TITLE
feat: 게시글 삭제 API 및 작성자 정보 필드 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation(project(":modules:content:application"))
     implementation(project(":modules:content:adapter:in:web"))
     implementation(project(":modules:content:adapter:out:persistence:jpa"))
+    implementation(project(":modules:content:adapter:out:client:member"))
 
     implementation(project(":modules:media:domain"))
     implementation(project(":modules:media:application"))

--- a/modules/content/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/PostApi.kt
+++ b/modules/content/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/PostApi.kt
@@ -48,7 +48,11 @@ interface PostApi {
                                   "success": true,
                                   "data": {
                                     "postId": "550e8400-e29b-41d4-a716-446655440000",
-                                    "memberId": "987e6543-e21b-98d7-a654-426614174111",
+                                    "author": {
+                                      "memberId": "987e6543-e21b-98d7-a654-426614174111",
+                                      "nickname": "Luigi99",
+                                      "profileImageUrl": null
+                                    },
                                     "title": "Kotlin으로 DDD 구현하기",
                                     "slug": "kotlin-ddd-implementation",
                                     "body": "# 시작하기\n\nKotlin과 DDD를 결합하면...",
@@ -256,7 +260,11 @@ interface PostApi {
                                   "success": true,
                                   "data": {
                                     "postId": "550e8400-e29b-41d4-a716-446655440000",
-                                    "memberId": "987e6543-e21b-98d7-a654-426614174111",
+                                    "author": {
+                                      "memberId": "987e6543-e21b-98d7-a654-426614174111",
+                                      "nickname": "Luigi99",
+                                      "profileImageUrl": "https://example.com/profile.jpg"
+                                    },
                                     "title": "Kotlin으로 DDD 구현하기",
                                     "slug": "kotlin-ddd-implementation",
                                     "body": "# 시작하기\n\nKotlin과 DDD를 결합하면...",
@@ -329,7 +337,11 @@ interface PostApi {
                                     "posts": [
                                       {
                                         "postId": "550e8400-e29b-41d4-a716-446655440000",
-                                        "memberId": "987e6543-e21b-98d7-a654-426614174111",
+                                        "author": {
+                                          "memberId": "987e6543-e21b-98d7-a654-426614174111",
+                                          "nickname": "Luigi99",
+                                          "profileImageUrl": "https://example.com/profile.jpg"
+                                        },
                                         "title": "Kotlin으로 DDD 구현하기",
                                         "slug": "kotlin-ddd-implementation",
                                         "type": "BLOG",
@@ -355,4 +367,97 @@ interface PostApi {
         @Parameter(description = "상태 필터 (DRAFT, PUBLISHED, ARCHIVED)") @RequestParam(required = false) status: String?,
         @Parameter(description = "타입 필터 (BLOG, PORTFOLIO)") @RequestParam(required = false) type: String?,
     ): ResponseEntity<CommonResponse<PostListResponse>>
+
+    @Operation(
+        summary = "블로그 글 삭제",
+        description = "Post ID로 블로그 글을 삭제합니다. 작성자만 삭제할 수 있습니다.",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "204",
+                description = "글 삭제 성공",
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "인증되지 않은 사용자",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "Unauthorized",
+                                value = """
+                                {
+                                  "success": false,
+                                  "data": null,
+                                  "error": {
+                                    "code": "AUTH_001",
+                                    "message": "인증에 실패했습니다."
+                                  },
+                                  "timestamp": "2025-12-31T12:00:00"
+                                }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "삭제 권한 없음",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "Forbidden",
+                                value = """
+                                {
+                                  "success": false,
+                                  "data": null,
+                                  "error": {
+                                    "code": "AUTH_003",
+                                    "message": "접근 권한이 없습니다."
+                                  },
+                                  "timestamp": "2025-12-31T12:00:00"
+                                }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "글을 찾을 수 없음",
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "PostNotFound",
+                                value = """
+                                {
+                                  "success": false,
+                                  "data": null,
+                                  "error": {
+                                    "code": "CONTENT_001",
+                                    "message": "글을 찾을 수 없습니다."
+                                  },
+                                  "timestamp": "2025-12-31T12:00:00"
+                                }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun deletePost(
+        @AuthenticationPrincipal memberId: String,
+        @Parameter(description = "Post ID") @PathVariable postId: String,
+    ): ResponseEntity<Unit>
 }

--- a/modules/content/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/dto/AuthorResponse.kt
+++ b/modules/content/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/dto/AuthorResponse.kt
@@ -1,0 +1,12 @@
+package cloud.luigi99.blog.content.adapter.`in`.web.post.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class AuthorResponse(
+    @field:Schema(description = "작성자 ID", example = "987e6543-e21b-98d7-a654-426614174111")
+    val memberId: String,
+    @field:Schema(description = "작성자 닉네임", example = "Luigi99")
+    val nickname: String,
+    @field:Schema(description = "작성자 프로필 이미지 URL", example = "https://example.com/profile.jpg")
+    val profileImageUrl: String?,
+)

--- a/modules/content/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/dto/PostResponse.kt
+++ b/modules/content/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/dto/PostResponse.kt
@@ -9,8 +9,8 @@ import java.time.LocalDateTime
 data class PostResponse(
     @field:Schema(description = "Post ID", example = "123e4567-e89b-12d3-a456-426614174000")
     val postId: String,
-    @field:Schema(description = "작성자 Member ID", example = "987e6543-e21b-98d7-a654-426614174111")
-    val memberId: String,
+    @field:Schema(description = "작성자 정보")
+    val author: AuthorResponse,
     @field:Schema(description = "제목", example = "Kotlin으로 DDD 구현하기")
     val title: String,
     @field:Schema(description = "URL slug", example = "kotlin-ddd-implementation")

--- a/modules/content/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/dto/PostSummaryResponse.kt
+++ b/modules/content/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/adapter/in/web/post/dto/PostSummaryResponse.kt
@@ -9,8 +9,8 @@ import java.time.LocalDateTime
 data class PostSummaryResponse(
     @field:Schema(description = "Post ID", example = "123e4567-e89b-12d3-a456-426614174000")
     val postId: String,
-    @field:Schema(description = "작성자 Member ID", example = "987e6543-e21b-98d7-a654-426614174111")
-    val memberId: String,
+    @field:Schema(description = "작성자 정보")
+    val author: AuthorResponse,
     @field:Schema(description = "제목", example = "Kotlin으로 DDD 구현하기")
     val title: String,
     @field:Schema(description = "URL slug", example = "kotlin-ddd-implementation")

--- a/modules/content/adapter/out/client/member/build.gradle.kts
+++ b/modules/content/adapter/out/client/member/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    springLibraryConventions
+}
+
+dependencies {
+    implementation(project(":libs:common"))
+    implementation(project(":modules:content:application"))
+    implementation(project(":modules:member:application"))
+
+    implementation(libs.spring.boot.starter.core)
+}

--- a/modules/content/adapter/out/client/member/src/main/kotlin/cloud/luigi99/blog/content/adapter/out/client/member/MemberClientAdapter.kt
+++ b/modules/content/adapter/out/client/member/src/main/kotlin/cloud/luigi99/blog/content/adapter/out/client/member/MemberClientAdapter.kt
@@ -1,0 +1,44 @@
+package cloud.luigi99.blog.content.adapter.out.client.member
+
+import cloud.luigi99.blog.content.application.post.port.out.MemberClient
+import cloud.luigi99.blog.member.application.member.port.`in`.query.GetMembersProfileUseCase
+import cloud.luigi99.blog.member.application.member.port.`in`.query.MemberQueryFacade
+import org.springframework.stereotype.Component
+
+@Component
+class MemberClientAdapter(private val memberQueryFacade: MemberQueryFacade) : MemberClient {
+    override fun getAuthor(memberId: String): MemberClient.Author {
+        val response =
+            memberQueryFacade.getMembersProfile().execute(
+                GetMembersProfileUseCase.Query(listOf(memberId)),
+            )
+
+        val memberProfile =
+            response.members.firstOrNull()
+                ?: return MemberClient.Author(memberId, "Unknown", null)
+
+        return MemberClient.Author(
+            memberId = memberProfile.memberId,
+            nickname = memberProfile.profile?.nickname ?: memberProfile.username,
+            profileImageUrl = memberProfile.profile?.profileImageUrl,
+        )
+    }
+
+    override fun getAuthors(memberIds: List<String>): Map<String, MemberClient.Author> {
+        if (memberIds.isEmpty()) return emptyMap()
+
+        val response =
+            memberQueryFacade.getMembersProfile().execute(
+                GetMembersProfileUseCase.Query(memberIds),
+            )
+
+        return response.members.associate { memberProfile ->
+            memberProfile.memberId to
+                MemberClient.Author(
+                    memberId = memberProfile.memberId,
+                    nickname = memberProfile.profile?.nickname ?: memberProfile.username,
+                    profileImageUrl = memberProfile.profile?.profileImageUrl,
+                )
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,6 +25,7 @@ include("modules:content:domain")
 include("modules:content:application")
 include("modules:content:adapter:in:web")
 include("modules:content:adapter:out:persistence:jpa")
+include("modules:content:adapter:out:client:member")
 
 include("modules:media:domain")
 include("modules:media:application")


### PR DESCRIPTION
## 📋 개요
웹 어댑터 계층을 업데이트하여 새로운 기능을 노출했습니다.

- **삭제 API:** `DELETE /api/v1/posts/{postId}` 엔드포인트를 추가했습니다.
- **응답 구조 개선:** `PostResponse` 및 `PostSummaryResponse`에 `AuthorResponse`를 포함시켜 클라이언트에게 작성자 상세 정보를 제공하도록 변경했습니다.

## 🔗 관련 이슈
- Closes #50

## ☑️ 체크리스트
- [x] 코딩 컨벤션을 준수했나요? (`./gradlew ktlintCheck`)
- [x] 모든 테스트를 통과했나요? (`./gradlew test`)
    - `PostControllerTest`: API 동작 및 응답 구조 검증 완료
- [x] 불필요한 주석이나 로그는 제거했나요?