### PR TITLE
feat: 방명록 모듈 추가

### DIFF
--- a/app/src/main/resources/db/migration/V15__create_guestbook_table.sql
+++ b/app/src/main/resources/db/migration/V15__create_guestbook_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE guestbook (
+    guestbook_id UUID PRIMARY KEY,
+    author_id UUID NOT NULL,
+    content TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+CREATE INDEX idx_guestbook_author_id ON guestbook(author_id);
+CREATE INDEX idx_guestbook_created_at ON guestbook(created_at DESC);

--- a/libs/common/src/main/kotlin/cloud/luigi99/blog/common/exception/BusinessException.kt
+++ b/libs/common/src/main/kotlin/cloud/luigi99/blog/common/exception/BusinessException.kt
@@ -33,4 +33,8 @@ enum class ErrorCode(val code: String, val message: String, val status: Int) {
     // Media
     FILE_UPLOAD_FAILED("MEDIA_001", "파일 업로드에 실패했습니다.", 500),
     INVALID_FILE_TYPE("MEDIA_002", "지원하지 않는 파일 형식입니다.", 400),
+
+    // Guestbook
+    GUESTBOOK_NOT_FOUND("GUESTBOOK_001", "방명록을 찾을 수 없습니다.", 404),
+    UNAUTHORIZED_GUESTBOOK_ACCESS("GUESTBOOK_002", "방명록에 대한 권한이 없습니다.", 403),
 }

--- a/modules/content/comment/application/src/test/kotlin/cloud/luigi99/blog/content/comment/application/service/command/UpdateCommentServiceTest.kt
+++ b/modules/content/comment/application/src/test/kotlin/cloud/luigi99/blog/content/comment/application/service/command/UpdateCommentServiceTest.kt
@@ -1,5 +1,6 @@
 package cloud.luigi99.blog.content.comment.application.service.command
 
+import cloud.luigi99.blog.common.domain.event.EventManager
 import cloud.luigi99.blog.content.comment.application.port.`in`.command.UpdateCommentUseCase
 import cloud.luigi99.blog.content.comment.application.port.out.CommentRepository
 import cloud.luigi99.blog.content.comment.application.port.out.MemberClient
@@ -23,8 +24,8 @@ import java.time.LocalDateTime
 class UpdateCommentServiceTest :
     BehaviorSpec({
         beforeTest {
-            mockkObject(cloud.luigi99.blog.common.domain.event.EventManager)
-            every { cloud.luigi99.blog.common.domain.event.EventManager.eventContextManager } returns
+            mockkObject(EventManager)
+            every { EventManager.eventContextManager } returns
                 mockk(relaxed = true)
         }
 
@@ -35,8 +36,10 @@ class UpdateCommentServiceTest :
 
             val commentId = CommentId.generate()
             val authorId = MemberId.generate()
+            val postId = PostId.generate()
             val content = "기존 댓글 내용"
             val newContent = "수정된 댓글 내용"
+            val now = LocalDateTime.now()
 
             val command =
                 UpdateCommentUseCase.Command(
@@ -45,19 +48,21 @@ class UpdateCommentServiceTest :
                     content = newContent,
                 )
 
-            val comment =
+            val existingComment =
                 Comment.from(
                     entityId = commentId,
-                    postId = PostId.generate(),
+                    postId = postId,
                     authorId = authorId,
                     content = CommentContent(content),
-                    createdAt = LocalDateTime.now(),
-                    updatedAt = LocalDateTime.now(),
+                    createdAt = now,
+                    updatedAt = now,
                 )
 
             When("정상적으로 댓글 수정을 요청하면") {
-                every { commentRepository.findById(commentId) } returns comment
-                every { commentRepository.save(any()) } returns comment
+                every { commentRepository.findById(commentId) } returns existingComment
+                every { commentRepository.save(any()) } answers {
+                    firstArg<Comment>()
+                }
                 every { memberClient.getAuthor(authorId.value.toString()) } returns
                     MemberClient.Author(
                         memberId = authorId.value.toString(),
@@ -94,7 +99,7 @@ class UpdateCommentServiceTest :
                 val otherAuthorId = MemberId.generate()
                 val unauthorizedCommand = command.copy(authorId = otherAuthorId.value.toString())
 
-                every { commentRepository.findById(commentId) } returns comment
+                every { commentRepository.findById(commentId) } returns existingComment
 
                 Then("UnauthorizedCommentAccessException이 발생한다") {
                     shouldThrow<UnauthorizedCommentAccessException> {

--- a/modules/content/guestbook/adapter/in/web/build.gradle.kts
+++ b/modules/content/guestbook/adapter/in/web/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    springBootConventions
+}
+
+dependencies {
+    implementation(project(":libs:common"))
+    implementation(project(":modules:content:guestbook:domain"))
+    implementation(project(":modules:content:guestbook:application"))
+    implementation(project(":libs:adapter:web"))
+
+    implementation(libs.bundles.spring.boot.web)
+    implementation(libs.bundles.spring.boot.security)
+
+    testImplementation(libs.bundles.kotlin.test)
+}

--- a/modules/content/guestbook/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/guestbook/adapter/in/web/GuestbookApi.kt
+++ b/modules/content/guestbook/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/guestbook/adapter/in/web/GuestbookApi.kt
@@ -1,0 +1,102 @@
+package cloud.luigi99.blog.content.guestbook.adapter.`in`.web
+
+import cloud.luigi99.blog.adapter.web.dto.CommonResponse
+import cloud.luigi99.blog.content.guestbook.adapter.`in`.web.dto.CreateGuestbookRequest
+import cloud.luigi99.blog.content.guestbook.adapter.`in`.web.dto.GuestbookResponse
+import cloud.luigi99.blog.content.guestbook.adapter.`in`.web.dto.ModifyGuestbookRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+
+/**
+ * Guestbook API 인터페이스
+ *
+ * 방명록 관련 API를 정의합니다.
+ */
+@Tag(name = "Guestbook", description = "방명록 관리 API")
+interface GuestbookApi {
+    @Operation(
+        summary = "방명록 작성",
+        description = "새로운 방명록 글을 작성합니다. 로그인한 회원만 작성 가능합니다.",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "201", description = "방명록 작성 성공"),
+            ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+        ],
+    )
+    fun createGuestbook(
+        @AuthenticationPrincipal memberId: String,
+        @RequestBody request: CreateGuestbookRequest,
+    ): ResponseEntity<CommonResponse<GuestbookResponse>>
+
+    @Operation(
+        summary = "방명록 수정",
+        description = "기존 방명록 글을 수정합니다. 작성자만 수정 가능합니다.",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "방명록 수정 성공"),
+            ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            ApiResponse(responseCode = "403", description = "수정 권한 없음"),
+            ApiResponse(responseCode = "404", description = "방명록을 찾을 수 없음"),
+        ],
+    )
+    fun modifyGuestbook(
+        @AuthenticationPrincipal memberId: String,
+        @Parameter(description = "방명록 ID") @PathVariable guestbookId: String,
+        @RequestBody request: ModifyGuestbookRequest,
+    ): ResponseEntity<CommonResponse<GuestbookResponse>>
+
+    @Operation(
+        summary = "방명록 삭제",
+        description = "방명록 글을 삭제합니다. 작성자만 삭제 가능합니다.",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "방명록 삭제 성공"),
+            ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            ApiResponse(responseCode = "403", description = "삭제 권한 없음"),
+            ApiResponse(responseCode = "404", description = "방명록을 찾을 수 없음"),
+        ],
+    )
+    fun deleteGuestbook(
+        @AuthenticationPrincipal memberId: String,
+        @Parameter(description = "방명록 ID") @PathVariable guestbookId: String,
+    ): ResponseEntity<Unit>
+
+    @Operation(
+        summary = "방명록 목록 조회",
+        description = "모든 방명록 글을 조회합니다. 비회원도 조회 가능합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "방명록 목록 조회 성공"),
+        ],
+    )
+    fun getGuestbooks(): ResponseEntity<CommonResponse<List<GuestbookResponse>>>
+
+    @Operation(
+        summary = "단일 방명록 조회",
+        description = "특정 방명록 글을 조회합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "방명록 조회 성공"),
+            ApiResponse(responseCode = "404", description = "방명록을 찾을 수 없음"),
+        ],
+    )
+    fun getGuestbook(
+        @Parameter(description = "방명록 ID") @PathVariable guestbookId: String,
+    ): ResponseEntity<CommonResponse<GuestbookResponse>>
+}

--- a/modules/content/guestbook/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/guestbook/adapter/in/web/GuestbookController.kt
+++ b/modules/content/guestbook/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/guestbook/adapter/in/web/GuestbookController.kt
@@ -1,0 +1,189 @@
+package cloud.luigi99.blog.content.guestbook.adapter.`in`.web
+
+import cloud.luigi99.blog.adapter.web.dto.CommonResponse
+import cloud.luigi99.blog.content.guestbook.adapter.`in`.web.dto.AuthorResponse
+import cloud.luigi99.blog.content.guestbook.adapter.`in`.web.dto.CreateGuestbookRequest
+import cloud.luigi99.blog.content.guestbook.adapter.`in`.web.dto.GuestbookResponse
+import cloud.luigi99.blog.content.guestbook.adapter.`in`.web.dto.ModifyGuestbookRequest
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.command.CreateGuestbookUseCase
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.command.DeleteGuestbookUseCase
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.command.GuestbookCommandFacade
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.command.ModifyGuestbookUseCase
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.query.GetGuestbookUseCase
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.query.GuestbookQueryFacade
+import mu.KotlinLogging
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 방명록 컨트롤러
+ *
+ * 방명록 작성, 수정, 삭제, 조회 등 방명록 관련 요청을 처리합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/guestbooks")
+class GuestbookController(
+    private val guestbookCommandFacade: GuestbookCommandFacade,
+    private val guestbookQueryFacade: GuestbookQueryFacade,
+) : GuestbookApi {
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
+    @PostMapping
+    override fun createGuestbook(
+        @AuthenticationPrincipal memberId: String,
+        @RequestBody request: CreateGuestbookRequest,
+    ): ResponseEntity<CommonResponse<GuestbookResponse>> {
+        log.info { "Creating guestbook entry by member: $memberId" }
+
+        val command =
+            CreateGuestbookUseCase.Command(
+                authorId = memberId,
+                content = request.content,
+            )
+
+        val response = guestbookCommandFacade.createGuestbook().execute(command)
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+            CommonResponse.success(
+                GuestbookResponse(
+                    guestbookId = response.guestbookId,
+                    author =
+                        AuthorResponse(
+                            memberId = response.author.memberId,
+                            nickname = response.author.nickname,
+                            profileImageUrl = response.author.profileImageUrl,
+                            username = response.author.username,
+                        ),
+                    content = response.content,
+                    createdAt = "",
+                    updatedAt = "",
+                ),
+            ),
+        )
+    }
+
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
+    @PutMapping("/{guestbookId}")
+    override fun modifyGuestbook(
+        @AuthenticationPrincipal memberId: String,
+        @PathVariable guestbookId: String,
+        @RequestBody request: ModifyGuestbookRequest,
+    ): ResponseEntity<CommonResponse<GuestbookResponse>> {
+        log.info { "Modifying guestbook: $guestbookId by member: $memberId" }
+
+        val command =
+            ModifyGuestbookUseCase.Command(
+                guestbookId = guestbookId,
+                requesterId = memberId,
+                content = request.content,
+            )
+
+        guestbookCommandFacade.modifyGuestbook().execute(command)
+
+        val query = GetGuestbookUseCase.Query(guestbookId)
+        val getResponse = guestbookQueryFacade.getGuestbook().execute(query)
+
+        return ResponseEntity.ok(
+            CommonResponse.success(
+                GuestbookResponse(
+                    guestbookId = getResponse.guestbookId,
+                    author =
+                        AuthorResponse(
+                            memberId = getResponse.author.memberId,
+                            nickname = getResponse.author.nickname,
+                            profileImageUrl = getResponse.author.profileImageUrl,
+                            username = getResponse.author.username,
+                        ),
+                    content = getResponse.content,
+                    createdAt = getResponse.createdAt,
+                    updatedAt = getResponse.updatedAt,
+                ),
+            ),
+        )
+    }
+
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
+    @DeleteMapping("/{guestbookId}")
+    override fun deleteGuestbook(
+        @AuthenticationPrincipal memberId: String,
+        @PathVariable guestbookId: String,
+    ): ResponseEntity<Unit> {
+        log.info { "Deleting guestbook: $guestbookId by member: $memberId" }
+
+        val command =
+            DeleteGuestbookUseCase.Command(
+                guestbookId = guestbookId,
+                requesterId = memberId,
+            )
+
+        guestbookCommandFacade.deleteGuestbook().execute(command)
+
+        return ResponseEntity.noContent().build()
+    }
+
+    @GetMapping
+    override fun getGuestbooks(): ResponseEntity<CommonResponse<List<GuestbookResponse>>> {
+        log.info { "Getting all guestbooks" }
+
+        val responses = guestbookQueryFacade.getGuestbookList().execute()
+
+        return ResponseEntity.ok(
+            CommonResponse.success(
+                responses.map { response ->
+                    GuestbookResponse(
+                        guestbookId = response.guestbookId,
+                        author =
+                            AuthorResponse(
+                                memberId = response.author.memberId,
+                                nickname = response.author.nickname,
+                                profileImageUrl = response.author.profileImageUrl,
+                                username = response.author.username,
+                            ),
+                        content = response.content,
+                        createdAt = response.createdAt,
+                        updatedAt = response.updatedAt,
+                    )
+                },
+            ),
+        )
+    }
+
+    @GetMapping("/{guestbookId}")
+    override fun getGuestbook(
+        @PathVariable guestbookId: String,
+    ): ResponseEntity<CommonResponse<GuestbookResponse>> {
+        log.info { "Getting guestbook: $guestbookId" }
+
+        val query = GetGuestbookUseCase.Query(guestbookId)
+        val response = guestbookQueryFacade.getGuestbook().execute(query)
+
+        return ResponseEntity.ok(
+            CommonResponse.success(
+                GuestbookResponse(
+                    guestbookId = response.guestbookId,
+                    author =
+                        AuthorResponse(
+                            memberId = response.author.memberId,
+                            nickname = response.author.nickname,
+                            profileImageUrl = response.author.profileImageUrl,
+                            username = response.author.username,
+                        ),
+                    content = response.content,
+                    createdAt = response.createdAt,
+                    updatedAt = response.updatedAt,
+                ),
+            ),
+        )
+    }
+}

--- a/modules/content/guestbook/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/guestbook/adapter/in/web/dto/AuthorResponse.kt
+++ b/modules/content/guestbook/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/guestbook/adapter/in/web/dto/AuthorResponse.kt
@@ -1,0 +1,17 @@
+package cloud.luigi99.blog.content.guestbook.adapter.`in`.web.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 작성자 정보 응답 DTO
+ */
+data class AuthorResponse(
+    @field:Schema(description = "작성자 ID", example = "987e6543-e21b-98d7-a654-426614174111")
+    val memberId: String,
+    @field:Schema(description = "작성자 닉네임", example = "Luigi99")
+    val nickname: String,
+    @field:Schema(description = "작성자 프로필 이미지 URL", example = "https://example.com/profile.jpg")
+    val profileImageUrl: String?,
+    @field:Schema(description = "작성자 사용자 이름", example = "luigi99")
+    val username: String,
+)

--- a/modules/content/guestbook/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/guestbook/adapter/in/web/dto/CreateGuestbookRequest.kt
+++ b/modules/content/guestbook/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/guestbook/adapter/in/web/dto/CreateGuestbookRequest.kt
@@ -1,0 +1,11 @@
+package cloud.luigi99.blog.content.guestbook.adapter.`in`.web.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 방명록 작성 요청 DTO
+ */
+data class CreateGuestbookRequest(
+    @field:Schema(description = "방명록 내용", example = "안녕하세요! 블로그 잘 보고 있습니다.")
+    val content: String,
+)

--- a/modules/content/guestbook/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/guestbook/adapter/in/web/dto/GuestbookResponse.kt
+++ b/modules/content/guestbook/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/guestbook/adapter/in/web/dto/GuestbookResponse.kt
@@ -1,0 +1,19 @@
+package cloud.luigi99.blog.content.guestbook.adapter.`in`.web.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 방명록 응답 DTO
+ */
+data class GuestbookResponse(
+    @field:Schema(description = "방명록 ID", example = "123e4567-e89b-12d3-a456-426614174000")
+    val guestbookId: String,
+    @field:Schema(description = "작성자 정보")
+    val author: AuthorResponse,
+    @field:Schema(description = "방명록 내용", example = "안녕하세요! 블로그 잘 보고 있습니다.")
+    val content: String,
+    @field:Schema(description = "생성일시", example = "2024-01-09T12:00:00")
+    val createdAt: String,
+    @field:Schema(description = "수정일시", example = "2024-01-09T12:00:00")
+    val updatedAt: String,
+)

--- a/modules/content/guestbook/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/guestbook/adapter/in/web/dto/ModifyGuestbookRequest.kt
+++ b/modules/content/guestbook/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/guestbook/adapter/in/web/dto/ModifyGuestbookRequest.kt
@@ -1,0 +1,11 @@
+package cloud.luigi99.blog.content.guestbook.adapter.`in`.web.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 방명록 수정 요청 DTO
+ */
+data class ModifyGuestbookRequest(
+    @field:Schema(description = "수정할 방명록 내용", example = "수정된 내용입니다.")
+    val content: String,
+)

--- a/modules/content/guestbook/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/content/guestbook/adapter/in/web/GuestbookControllerTest.kt
+++ b/modules/content/guestbook/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/content/guestbook/adapter/in/web/GuestbookControllerTest.kt
@@ -1,0 +1,227 @@
+package cloud.luigi99.blog.content.guestbook.adapter.`in`.web
+
+import cloud.luigi99.blog.content.guestbook.adapter.`in`.web.dto.CreateGuestbookRequest
+import cloud.luigi99.blog.content.guestbook.adapter.`in`.web.dto.ModifyGuestbookRequest
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.command.CreateGuestbookUseCase
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.command.DeleteGuestbookUseCase
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.command.GuestbookCommandFacade
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.command.ModifyGuestbookUseCase
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.query.GetGuestbookListUseCase
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.query.GetGuestbookUseCase
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.query.GuestbookQueryFacade
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.http.HttpStatus
+
+class GuestbookControllerTest :
+    BehaviorSpec({
+
+        Given("로그인한 사용자가 방명록을 작성하려 할 때") {
+            val guestbookCommandFacade = mockk<GuestbookCommandFacade>()
+            val guestbookQueryFacade = mockk<GuestbookQueryFacade>()
+            val controller = GuestbookController(guestbookCommandFacade, guestbookQueryFacade)
+
+            val memberId = "123e4567-e89b-12d3-a456-426614174000"
+            val createUseCase = mockk<CreateGuestbookUseCase>()
+            val request = CreateGuestbookRequest(content = "안녕하세요!")
+
+            val response =
+                CreateGuestbookUseCase.Response(
+                    guestbookId = "550e8400-e29b-41d4-a716-446655440000",
+                    author =
+                        CreateGuestbookUseCase.AuthorInfo(
+                            memberId = memberId,
+                            nickname = "TestUser",
+                            profileImageUrl = null,
+                            username = "testuser",
+                        ),
+                    content = request.content,
+                )
+
+            When("방명록 작성을 요청하면") {
+                every { guestbookCommandFacade.createGuestbook() } returns createUseCase
+                every { createUseCase.execute(any()) } returns response
+
+                Then("201 Created 응답과 생성된 방명록 정보가 반환된다") {
+                    val result = controller.createGuestbook(memberId, request)
+
+                    result.statusCode shouldBe HttpStatus.CREATED
+                    result.body
+                        ?.data
+                        ?.content shouldBe request.content
+                    result.body
+                        ?.data
+                        ?.author
+                        ?.nickname shouldBe "TestUser"
+                }
+            }
+        }
+
+        Given("로그인한 사용자가 자신의 방명록을 수정하려 할 때") {
+            val guestbookCommandFacade = mockk<GuestbookCommandFacade>()
+            val guestbookQueryFacade = mockk<GuestbookQueryFacade>()
+            val controller = GuestbookController(guestbookCommandFacade, guestbookQueryFacade)
+
+            val memberId = "123e4567-e89b-12d3-a456-426614174000"
+            val guestbookId = "550e8400-e29b-41d4-a716-446655440000"
+            val modifyUseCase = mockk<ModifyGuestbookUseCase>()
+            val getUseCase = mockk<GetGuestbookUseCase>()
+            val request = ModifyGuestbookRequest(content = "수정된 내용입니다.")
+
+            val modifyResponse =
+                ModifyGuestbookUseCase.Response(
+                    guestbookId = guestbookId,
+                    content = request.content,
+                )
+
+            val getResponse =
+                GetGuestbookUseCase.Response(
+                    guestbookId = guestbookId,
+                    author =
+                        GetGuestbookUseCase.AuthorInfo(
+                            memberId = memberId,
+                            nickname = "TestUser",
+                            profileImageUrl = null,
+                            username = "testuser",
+                        ),
+                    content = request.content,
+                    createdAt = "2024-01-01T00:00:00",
+                    updatedAt = "2024-01-01T00:00:00",
+                )
+
+            When("수정을 요청하면") {
+                every { guestbookCommandFacade.modifyGuestbook() } returns modifyUseCase
+                every { modifyUseCase.execute(any()) } returns modifyResponse
+                every { guestbookQueryFacade.getGuestbook() } returns getUseCase
+                every { getUseCase.execute(any()) } returns getResponse
+
+                Then("200 OK 응답과 수정된 방명록 정보가 반환된다") {
+                    val result = controller.modifyGuestbook(memberId, guestbookId, request)
+
+                    result.statusCode shouldBe HttpStatus.OK
+                    result.body
+                        ?.data
+                        ?.content shouldBe request.content
+                }
+            }
+        }
+
+        Given("로그인한 사용자가 자신의 방명록을 삭제하려 할 때") {
+            val guestbookCommandFacade = mockk<GuestbookCommandFacade>()
+            val guestbookQueryFacade = mockk<GuestbookQueryFacade>()
+            val controller = GuestbookController(guestbookCommandFacade, guestbookQueryFacade)
+
+            val memberId = "123e4567-e89b-12d3-a456-426614174000"
+            val guestbookId = "550e8400-e29b-41d4-a716-446655440000"
+            val deleteUseCase = mockk<DeleteGuestbookUseCase>()
+
+            When("삭제를 요청하면") {
+                every { guestbookCommandFacade.deleteGuestbook() } returns deleteUseCase
+                every { deleteUseCase.execute(any()) } just Runs
+
+                Then("204 No Content 응답이 반환되고 삭제가 수행된다") {
+                    val result = controller.deleteGuestbook(memberId, guestbookId)
+
+                    result.statusCode shouldBe HttpStatus.NO_CONTENT
+                    verify(exactly = 1) { deleteUseCase.execute(any()) }
+                }
+            }
+        }
+
+        Given("방명록 목록을 조회하려 할 때") {
+            val guestbookCommandFacade = mockk<GuestbookCommandFacade>()
+            val guestbookQueryFacade = mockk<GuestbookQueryFacade>()
+            val controller = GuestbookController(guestbookCommandFacade, guestbookQueryFacade)
+
+            val listUseCase = mockk<GetGuestbookListUseCase>()
+            val responses =
+                listOf(
+                    GetGuestbookListUseCase.Response(
+                        guestbookId = "id1",
+                        author =
+                            GetGuestbookListUseCase.AuthorInfo(
+                                memberId = "author1",
+                                nickname = "User1",
+                                profileImageUrl = null,
+                                username = "user1",
+                            ),
+                        content = "첫 번째 방명록",
+                        createdAt = "2024-01-01T00:00:00",
+                        updatedAt = "2024-01-01T00:00:00",
+                    ),
+                    GetGuestbookListUseCase.Response(
+                        guestbookId = "id2",
+                        author =
+                            GetGuestbookListUseCase.AuthorInfo(
+                                memberId = "author2",
+                                nickname = "User2",
+                                profileImageUrl = null,
+                                username = "user2",
+                            ),
+                        content = "두 번째 방명록",
+                        createdAt = "2024-01-02T00:00:00",
+                        updatedAt = "2024-01-02T00:00:00",
+                    ),
+                )
+
+            When("목록을 조회하면") {
+                every { guestbookQueryFacade.getGuestbookList() } returns listUseCase
+                every { listUseCase.execute() } returns responses
+
+                Then("200 OK 응답과 모든 방명록이 반환된다") {
+                    val result = controller.getGuestbooks()
+
+                    result.statusCode shouldBe HttpStatus.OK
+                    result.body
+                        ?.data
+                        ?.size shouldBe 2
+                }
+            }
+        }
+
+        Given("특정 방명록을 조회하려 할 때") {
+            val guestbookCommandFacade = mockk<GuestbookCommandFacade>()
+            val guestbookQueryFacade = mockk<GuestbookQueryFacade>()
+            val controller = GuestbookController(guestbookCommandFacade, guestbookQueryFacade)
+
+            val guestbookId = "550e8400-e29b-41d4-a716-446655440000"
+            val getUseCase = mockk<GetGuestbookUseCase>()
+            val response =
+                GetGuestbookUseCase.Response(
+                    guestbookId = guestbookId,
+                    author =
+                        GetGuestbookUseCase.AuthorInfo(
+                            memberId = "author1",
+                            nickname = "TestUser",
+                            profileImageUrl = null,
+                            username = "testuser",
+                        ),
+                    content = "조회할 방명록",
+                    createdAt = "2024-01-01T00:00:00",
+                    updatedAt = "2024-01-01T00:00:00",
+                )
+
+            When("조회하면") {
+                every { guestbookQueryFacade.getGuestbook() } returns getUseCase
+                every { getUseCase.execute(any()) } returns response
+
+                Then("200 OK 응답과 해당 방명록 정보가 반환된다") {
+                    val result = controller.getGuestbook(guestbookId)
+
+                    result.statusCode shouldBe HttpStatus.OK
+                    result.body
+                        ?.data
+                        ?.guestbookId shouldBe guestbookId
+                    result.body
+                        ?.data
+                        ?.author
+                        ?.nickname shouldBe "TestUser"
+                }
+            }
+        }
+    })

--- a/modules/content/guestbook/adapter/out/persistence/jpa/build.gradle.kts
+++ b/modules/content/guestbook/adapter/out/persistence/jpa/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    springBootConventions
+}
+
+dependencies {
+    implementation(project(":libs:common"))
+    implementation(project(":modules:content:guestbook:domain"))
+    implementation(project(":modules:content:guestbook:application"))
+    implementation(project(":libs:adapter:persistence:jpa"))
+    implementation(project(":libs:adapter:message:spring"))
+
+    implementation(libs.spring.boot.starter.data.jpa)
+
+    testImplementation(libs.bundles.kotlin.test)
+}

--- a/modules/content/guestbook/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/guestbook/adapter/out/persistence/GuestbookRepositoryAdapter.kt
+++ b/modules/content/guestbook/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/guestbook/adapter/out/persistence/GuestbookRepositoryAdapter.kt
@@ -1,0 +1,82 @@
+package cloud.luigi99.blog.content.guestbook.adapter.out.persistence
+
+import cloud.luigi99.blog.common.application.port.out.DomainEventPublisher
+import cloud.luigi99.blog.common.application.port.out.EventContextManager
+import cloud.luigi99.blog.content.guestbook.adapter.out.persistence.mapper.GuestbookMapper
+import cloud.luigi99.blog.content.guestbook.adapter.out.persistence.repository.GuestbookJpaRepository
+import cloud.luigi99.blog.content.guestbook.application.port.out.GuestbookRepository
+import cloud.luigi99.blog.content.guestbook.domain.model.Guestbook
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookId
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import mu.KotlinLogging
+import org.springframework.stereotype.Repository
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 방명록 저장소 어댑터
+ *
+ * JPA 리포지토리를 사용하여 방명록 데이터를 영속화하고, 도메인 이벤트를 발행합니다.
+ */
+@Repository
+class GuestbookRepositoryAdapter(
+    private val jpaRepository: GuestbookJpaRepository,
+    private val eventContextManager: EventContextManager,
+    private val domainEventPublisher: DomainEventPublisher,
+) : GuestbookRepository {
+    /**
+     * 방명록 엔티티를 저장합니다.
+     */
+    override fun save(entity: Guestbook): Guestbook {
+        log.debug { "Saving guestbook: ${entity.entityId}" }
+
+        val jpaEntity = GuestbookMapper.toEntity(entity)
+        val saved = jpaRepository.save(jpaEntity)
+
+        val events = eventContextManager.getDomainEventsAndClear()
+        events.forEach { domainEventPublisher.publish(it) }
+
+        log.debug { "Successfully saved guestbook: ${saved.entityId}" }
+
+        return GuestbookMapper.toDomain(saved)
+    }
+
+    /**
+     * ID로 방명록을 조회합니다.
+     */
+    override fun findById(id: GuestbookId): Guestbook? {
+        log.debug { "Finding guestbook by ID: $id" }
+        return jpaRepository
+            .findById(id.value)
+            .map { GuestbookMapper.toDomain(it) }
+            .orElse(null)
+    }
+
+    /**
+     * ID로 방명록을 삭제합니다.
+     */
+    override fun deleteById(id: GuestbookId) {
+        log.debug { "Deleting guestbook by ID: $id" }
+        jpaRepository.deleteById(id.value)
+    }
+
+    /**
+     * 특정 작성자의 방명록 목록을 조회합니다.
+     */
+    override fun findByAuthorId(authorId: MemberId): List<Guestbook> {
+        log.debug { "Finding guestbooks by author ID: $authorId" }
+        return jpaRepository
+            .findByAuthorIdOrderByCreatedAtDesc(authorId.value)
+            .map { GuestbookMapper.toDomain(it) }
+    }
+
+    /**
+     * 모든 방명록을 생성일 기준 내림차순으로 조회합니다.
+     */
+    override fun findAllOrderByCreatedAtDesc(): List<Guestbook> {
+        log.debug { "Finding all guestbooks ordered by created date desc" }
+        return jpaRepository
+            .findAllByOrderByCreatedAtDesc()
+            .map { GuestbookMapper.toDomain(it) }
+    }
+}

--- a/modules/content/guestbook/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/guestbook/adapter/out/persistence/entity/GuestbookJpaEntity.kt
+++ b/modules/content/guestbook/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/guestbook/adapter/out/persistence/entity/GuestbookJpaEntity.kt
@@ -1,0 +1,39 @@
+package cloud.luigi99.blog.content.guestbook.adapter.out.persistence.entity
+
+import cloud.luigi99.blog.adapter.persistence.jpa.JpaAggregateRoot
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookId
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.DynamicUpdate
+import java.util.UUID
+
+/**
+ * 방명록 JPA 엔티티
+ *
+ * 방명록 도메인 엔티티의 영속화를 담당하는 JPA 엔티티입니다.
+ */
+@Entity
+@Table(name = "guestbook")
+@DynamicUpdate
+class GuestbookJpaEntity private constructor(
+    @Id
+    @Column(name = "guestbook_id")
+    val id: UUID,
+    @Column(name = "author_id", nullable = false)
+    val authorId: UUID,
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    val content: String,
+) : JpaAggregateRoot<GuestbookId>() {
+    override val entityId: GuestbookId
+        get() = GuestbookId(id)
+
+    companion object {
+        /**
+         * 원시 값들로부터 JPA 엔티티를 생성합니다.
+         */
+        fun from(id: UUID, authorId: UUID, content: String): GuestbookJpaEntity =
+            GuestbookJpaEntity(id, authorId, content)
+    }
+}

--- a/modules/content/guestbook/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/guestbook/adapter/out/persistence/mapper/GuestbookMapper.kt
+++ b/modules/content/guestbook/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/guestbook/adapter/out/persistence/mapper/GuestbookMapper.kt
@@ -1,0 +1,41 @@
+package cloud.luigi99.blog.content.guestbook.adapter.out.persistence.mapper
+
+import cloud.luigi99.blog.content.guestbook.adapter.out.persistence.entity.GuestbookJpaEntity
+import cloud.luigi99.blog.content.guestbook.domain.model.Guestbook
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookContent
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookId
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+
+/**
+ * 방명록 매퍼
+ *
+ * 도메인 엔티티와 JPA 엔티티 간의 변환을 담당합니다.
+ */
+object GuestbookMapper {
+    /**
+     * JPA 엔티티를 도메인 엔티티로 변환합니다.
+     */
+    fun toDomain(entity: GuestbookJpaEntity): Guestbook =
+        Guestbook.from(
+            entityId = GuestbookId(entity.id),
+            authorId = MemberId(entity.authorId),
+            content = GuestbookContent(entity.content),
+            createdAt = entity.createdAt,
+            updatedAt = entity.updatedAt,
+        )
+
+    /**
+     * 도메인 엔티티를 JPA 엔티티로 변환합니다.
+     */
+    fun toEntity(guestbook: Guestbook): GuestbookJpaEntity {
+        val jpaEntity =
+            GuestbookJpaEntity.from(
+                id = guestbook.entityId.value,
+                authorId = guestbook.authorId.value,
+                content = guestbook.content.value,
+            )
+        jpaEntity.createdAt = guestbook.createdAt
+        jpaEntity.updatedAt = guestbook.updatedAt
+        return jpaEntity
+    }
+}

--- a/modules/content/guestbook/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/guestbook/adapter/out/persistence/repository/GuestbookJpaRepository.kt
+++ b/modules/content/guestbook/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/guestbook/adapter/out/persistence/repository/GuestbookJpaRepository.kt
@@ -1,0 +1,28 @@
+package cloud.luigi99.blog.content.guestbook.adapter.out.persistence.repository
+
+import cloud.luigi99.blog.content.guestbook.adapter.out.persistence.entity.GuestbookJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+/**
+ * 방명록 Spring Data JPA 리포지토리
+ */
+@Repository
+interface GuestbookJpaRepository : JpaRepository<GuestbookJpaEntity, UUID> {
+    /**
+     * 특정 작성자의 방명록 목록을 조회합니다.
+     */
+    @Query("SELECT g FROM GuestbookJpaEntity g WHERE g.authorId = :authorId ORDER BY g.createdAt DESC")
+    fun findByAuthorIdOrderByCreatedAtDesc(
+        @Param("authorId") authorId: UUID,
+    ): List<GuestbookJpaEntity>
+
+    /**
+     * 모든 방명록을 생성일 기준 내림차순으로 조회합니다.
+     */
+    @Query("SELECT g FROM GuestbookJpaEntity g ORDER BY g.createdAt DESC")
+    fun findAllByOrderByCreatedAtDesc(): List<GuestbookJpaEntity>
+}

--- a/modules/content/guestbook/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/content/guestbook/adapter/out/persistence/GuestbookRepositoryAdapterTest.kt
+++ b/modules/content/guestbook/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/content/guestbook/adapter/out/persistence/GuestbookRepositoryAdapterTest.kt
@@ -1,0 +1,145 @@
+package cloud.luigi99.blog.content.guestbook.adapter.out.persistence
+
+import cloud.luigi99.blog.common.application.port.out.DomainEventPublisher
+import cloud.luigi99.blog.common.application.port.out.EventContextManager
+import cloud.luigi99.blog.common.domain.event.EventManager
+import cloud.luigi99.blog.content.guestbook.adapter.out.persistence.mapper.GuestbookMapper
+import cloud.luigi99.blog.content.guestbook.adapter.out.persistence.repository.GuestbookJpaRepository
+import cloud.luigi99.blog.content.guestbook.domain.event.GuestbookCreatedEvent
+import cloud.luigi99.blog.content.guestbook.domain.model.Guestbook
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookContent
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookId
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verify
+import java.util.Optional
+
+class GuestbookRepositoryAdapterTest :
+    BehaviorSpec({
+
+        beforeTest {
+            mockkObject(EventManager)
+            every { EventManager.eventContextManager } returns mockk(relaxed = true)
+        }
+
+        Given("신규 방명록 정보가 생성되어 영구 저장이 필요할 때") {
+            val jpaRepository = mockk<GuestbookJpaRepository>()
+            val eventContextManager = mockk<EventContextManager>()
+            val domainEventPublisher = mockk<DomainEventPublisher>()
+
+            val adapter =
+                GuestbookRepositoryAdapter(
+                    jpaRepository,
+                    eventContextManager,
+                    domainEventPublisher,
+                )
+
+            val guestbook =
+                Guestbook.create(
+                    authorId = MemberId.generate(),
+                    content = GuestbookContent("새 방명록 내용입니다."),
+                )
+
+            When("저장소를 통해 저장을 요청하면") {
+                val savedEntity = GuestbookMapper.toEntity(guestbook)
+                every { jpaRepository.save(any()) } returns savedEntity
+                every { eventContextManager.getDomainEventsAndClear() } returns
+                    listOf(
+                        GuestbookCreatedEvent(guestbook.entityId, guestbook.authorId),
+                    )
+                every { domainEventPublisher.publish(any()) } just Runs
+
+                val saved = adapter.save(guestbook)
+
+                Then("방명록 정보가 정상적으로 저장되고 반환된다") {
+                    saved.entityId shouldBe guestbook.entityId
+                    saved.content shouldBe guestbook.content
+                }
+
+                Then("방명록 생성 이벤트가 시스템에 전파된다") {
+                    verify(exactly = 1) {
+                        domainEventPublisher.publish(match { it is GuestbookCreatedEvent })
+                    }
+                }
+            }
+        }
+
+        Given("특정 ID의 방명록을 조회하려 할 때") {
+            val jpaRepository = mockk<GuestbookJpaRepository>()
+            val eventContextManager = mockk<EventContextManager>()
+            val domainEventPublisher = mockk<DomainEventPublisher>()
+
+            val adapter =
+                GuestbookRepositoryAdapter(
+                    jpaRepository,
+                    eventContextManager,
+                    domainEventPublisher,
+                )
+
+            val guestbook =
+                Guestbook.create(
+                    authorId = MemberId.generate(),
+                    content = GuestbookContent("조회 테스트 방명록"),
+                )
+            val jpaEntity = GuestbookMapper.toEntity(guestbook)
+
+            When("존재하는 ID로 조회하면") {
+                every { jpaRepository.findById(guestbook.entityId.value) } returns Optional.of(jpaEntity)
+
+                val found = adapter.findById(guestbook.entityId)
+
+                Then("해당 방명록이 반환된다") {
+                    found shouldBe guestbook
+                }
+            }
+
+            When("존재하지 않는 ID로 조회하면") {
+                val nonExistentId = GuestbookId.generate()
+                every { jpaRepository.findById(nonExistentId.value) } returns Optional.empty()
+
+                val found = adapter.findById(nonExistentId)
+
+                Then("null이 반환된다") {
+                    found shouldBe null
+                }
+            }
+        }
+
+        Given("특정 작성자의 방명록 목록을 조회하려 할 때") {
+            val jpaRepository = mockk<GuestbookJpaRepository>()
+            val eventContextManager = mockk<EventContextManager>()
+            val domainEventPublisher = mockk<DomainEventPublisher>()
+
+            val adapter =
+                GuestbookRepositoryAdapter(
+                    jpaRepository,
+                    eventContextManager,
+                    domainEventPublisher,
+                )
+
+            val authorId = MemberId.generate()
+            val guestbook1 = Guestbook.create(authorId, GuestbookContent("첫 번째 방명록"))
+            val guestbook2 = Guestbook.create(authorId, GuestbookContent("두 번째 방명록"))
+            val jpaEntities =
+                listOf(
+                    GuestbookMapper.toEntity(guestbook1),
+                    GuestbookMapper.toEntity(guestbook2),
+                )
+
+            When("작성자 ID로 조회하면") {
+                every { jpaRepository.findByAuthorIdOrderByCreatedAtDesc(authorId.value) } returns jpaEntities
+
+                val result = adapter.findByAuthorId(authorId)
+
+                Then("해당 작성자의 모든 방명록이 반환된다") {
+                    result.size shouldBe 2
+                }
+            }
+        }
+    })

--- a/modules/content/guestbook/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/content/guestbook/adapter/out/persistence/mapper/GuestbookMapperTest.kt
+++ b/modules/content/guestbook/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/content/guestbook/adapter/out/persistence/mapper/GuestbookMapperTest.kt
@@ -1,0 +1,82 @@
+package cloud.luigi99.blog.content.guestbook.adapter.out.persistence.mapper
+
+import cloud.luigi99.blog.common.domain.event.EventManager
+import cloud.luigi99.blog.content.guestbook.domain.model.Guestbook
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookContent
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookId
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import java.time.LocalDateTime
+
+class GuestbookMapperTest :
+    BehaviorSpec({
+
+        beforeTest {
+            mockkObject(EventManager)
+            every { EventManager.eventContextManager } returns mockk(relaxed = true)
+        }
+
+        Given("비즈니스 로직에서 처리된 방명록 정보를 데이터베이스에 저장하려 할 때") {
+            val guestbook =
+                Guestbook.create(
+                    authorId = MemberId.generate(),
+                    content = GuestbookContent("테스트 방명록 내용입니다."),
+                )
+
+            When("데이터베이스 엔티티로 변환하면") {
+                val entity = GuestbookMapper.toEntity(guestbook)
+
+                Then("비즈니스 데이터가 영속성 모델로 정확히 매핑된다") {
+                    entity.id shouldBe guestbook.entityId.value
+                    entity.authorId shouldBe guestbook.authorId.value
+                    entity.content shouldBe guestbook.content.value
+                }
+            }
+        }
+
+        Given("데이터베이스에 저장된 방명록 정보를 조회하여 비즈니스 객체로 변환할 때") {
+            val guestbook =
+                Guestbook.create(
+                    authorId = MemberId.generate(),
+                    content = GuestbookContent("테스트 방명록 내용입니다."),
+                )
+
+            When("비즈니스 모델로 변환하면") {
+                val entity = GuestbookMapper.toEntity(guestbook)
+                val converted = GuestbookMapper.toDomain(entity)
+
+                Then("원본 데이터가 손실 없이 복원되어야 한다") {
+                    converted.entityId shouldBe guestbook.entityId
+                    converted.authorId shouldBe guestbook.authorId
+                    converted.content shouldBe guestbook.content
+                }
+            }
+        }
+
+        Given("생성일과 수정일이 설정된 방명록을 변환할 때") {
+            val createdAt = LocalDateTime.now().minusDays(3)
+            val updatedAt = LocalDateTime.now().minusDays(1)
+            val guestbook =
+                Guestbook.from(
+                    entityId = GuestbookId.generate(),
+                    authorId = MemberId.generate(),
+                    content = GuestbookContent("타임스탬프 테스트"),
+                    createdAt = createdAt,
+                    updatedAt = updatedAt,
+                )
+
+            When("JPA 엔티티로 변환 후 다시 도메인으로 변환하면") {
+                val entity = GuestbookMapper.toEntity(guestbook)
+                val converted = GuestbookMapper.toDomain(entity)
+
+                Then("타임스탬프 정보가 보존된다") {
+                    converted.createdAt shouldBe createdAt
+                    converted.updatedAt shouldBe updatedAt
+                }
+            }
+        }
+    })

--- a/modules/content/guestbook/application/build.gradle.kts
+++ b/modules/content/guestbook/application/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    springBootConventions
+}
+
+dependencies {
+    implementation(project(":libs:common"))
+    api(project(":modules:content:guestbook:domain"))
+    implementation(project(":modules:member:application"))
+
+    implementation(libs.spring.boot.starter.core)
+    implementation(libs.spring.boot.starter.data.jpa)
+    testImplementation(libs.bundles.kotlin.test)
+}

--- a/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/adapter/MemberClientAdapter.kt
+++ b/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/adapter/MemberClientAdapter.kt
@@ -1,0 +1,51 @@
+package cloud.luigi99.blog.content.guestbook.application.adapter
+
+import cloud.luigi99.blog.content.guestbook.application.port.out.MemberQueryPort
+import cloud.luigi99.blog.member.application.member.port.`in`.query.GetMembersProfileUseCase
+import cloud.luigi99.blog.member.application.member.port.`in`.query.MemberQueryFacade
+import org.springframework.stereotype.Component
+
+/**
+ * 회원 정보 조회 어댑터
+ *
+ * Member 모듈의 MemberQueryFacade를 통해 회원 정보를 조회합니다.
+ */
+@Component("guestbookMemberClientAdapter")
+class MemberClientAdapter(private val memberQueryFacade: MemberQueryFacade) : MemberQueryPort {
+    override fun getAuthor(memberId: String): MemberQueryPort.Author {
+        val response =
+            memberQueryFacade.getMembersProfile().execute(
+                GetMembersProfileUseCase.Query(listOf(memberId)),
+            )
+
+        val memberProfile =
+            response.members.firstOrNull()
+                ?: return MemberQueryPort.Author(memberId, "Unknown", null, "unknown")
+
+        return MemberQueryPort.Author(
+            memberId = memberProfile.memberId,
+            nickname = memberProfile.profile?.nickname ?: memberProfile.username,
+            profileImageUrl = memberProfile.profile?.profileImageUrl,
+            username = memberProfile.username,
+        )
+    }
+
+    override fun getAuthors(memberIds: List<String>): Map<String, MemberQueryPort.Author> {
+        if (memberIds.isEmpty()) return emptyMap()
+
+        val response =
+            memberQueryFacade.getMembersProfile().execute(
+                GetMembersProfileUseCase.Query(memberIds),
+            )
+
+        return response.members.associate { memberProfile ->
+            memberProfile.memberId to
+                MemberQueryPort.Author(
+                    memberId = memberProfile.memberId,
+                    nickname = memberProfile.profile?.nickname ?: memberProfile.username,
+                    profileImageUrl = memberProfile.profile?.profileImageUrl,
+                    username = memberProfile.username,
+                )
+        }
+    }
+}

--- a/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/port/in/command/CreateGuestbookUseCase.kt
+++ b/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/port/in/command/CreateGuestbookUseCase.kt
@@ -1,0 +1,33 @@
+package cloud.luigi99.blog.content.guestbook.application.port.`in`.command
+
+/**
+ * 방명록 작성 유스케이스
+ *
+ * 로그인한 회원이 새 방명록을 작성합니다.
+ */
+interface CreateGuestbookUseCase {
+    /**
+     * 방명록 작성을 실행합니다.
+     */
+    fun execute(command: Command): Response
+
+    /**
+     * 방명록 작성 명령
+     */
+    data class Command(val authorId: String, val content: String)
+
+    /**
+     * 방명록 작성 응답
+     */
+    data class Response(val guestbookId: String, val author: AuthorInfo, val content: String)
+
+    /**
+     * 작성자 정보
+     */
+    data class AuthorInfo(
+        val memberId: String,
+        val nickname: String,
+        val profileImageUrl: String?,
+        val username: String,
+    )
+}

--- a/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/port/in/command/DeleteGuestbookUseCase.kt
+++ b/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/port/in/command/DeleteGuestbookUseCase.kt
@@ -1,0 +1,18 @@
+package cloud.luigi99.blog.content.guestbook.application.port.`in`.command
+
+/**
+ * 방명록 삭제 유스케이스
+ *
+ * 작성자가 자신의 방명록을 삭제합니다.
+ */
+interface DeleteGuestbookUseCase {
+    /**
+     * 방명록 삭제를 실행합니다.
+     */
+    fun execute(command: Command)
+
+    /**
+     * 방명록 삭제 명령
+     */
+    data class Command(val guestbookId: String, val requesterId: String)
+}

--- a/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/port/in/command/GuestbookCommandFacade.kt
+++ b/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/port/in/command/GuestbookCommandFacade.kt
@@ -1,0 +1,23 @@
+package cloud.luigi99.blog.content.guestbook.application.port.`in`.command
+
+/**
+ * 방명록 명령 파사드
+ *
+ * 방명록 관련 Command UseCase들을 그룹화합니다.
+ */
+interface GuestbookCommandFacade {
+    /**
+     * 방명록 작성 유스케이스를 반환합니다.
+     */
+    fun createGuestbook(): CreateGuestbookUseCase
+
+    /**
+     * 방명록 수정 유스케이스를 반환합니다.
+     */
+    fun modifyGuestbook(): ModifyGuestbookUseCase
+
+    /**
+     * 방명록 삭제 유스케이스를 반환합니다.
+     */
+    fun deleteGuestbook(): DeleteGuestbookUseCase
+}

--- a/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/port/in/command/ModifyGuestbookUseCase.kt
+++ b/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/port/in/command/ModifyGuestbookUseCase.kt
@@ -1,0 +1,23 @@
+package cloud.luigi99.blog.content.guestbook.application.port.`in`.command
+
+/**
+ * 방명록 수정 유스케이스
+ *
+ * 작성자가 자신의 방명록을 수정합니다.
+ */
+interface ModifyGuestbookUseCase {
+    /**
+     * 방명록 수정을 실행합니다.
+     */
+    fun execute(command: Command): Response
+
+    /**
+     * 방명록 수정 명령
+     */
+    data class Command(val guestbookId: String, val requesterId: String, val content: String)
+
+    /**
+     * 방명록 수정 응답
+     */
+    data class Response(val guestbookId: String, val content: String)
+}

--- a/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/port/in/query/GetGuestbookListUseCase.kt
+++ b/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/port/in/query/GetGuestbookListUseCase.kt
@@ -1,0 +1,32 @@
+package cloud.luigi99.blog.content.guestbook.application.port.`in`.query
+
+/**
+ * 방명록 목록 조회 유스케이스
+ */
+interface GetGuestbookListUseCase {
+    /**
+     * 방명록 목록을 조회합니다.
+     */
+    fun execute(): List<Response>
+
+    /**
+     * 방명록 목록 응답
+     */
+    data class Response(
+        val guestbookId: String,
+        val author: AuthorInfo,
+        val content: String,
+        val createdAt: String,
+        val updatedAt: String,
+    )
+
+    /**
+     * 작성자 정보
+     */
+    data class AuthorInfo(
+        val memberId: String,
+        val nickname: String,
+        val profileImageUrl: String?,
+        val username: String,
+    )
+}

--- a/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/port/in/query/GetGuestbookUseCase.kt
+++ b/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/port/in/query/GetGuestbookUseCase.kt
@@ -1,0 +1,37 @@
+package cloud.luigi99.blog.content.guestbook.application.port.`in`.query
+
+/**
+ * 단일 방명록 조회 유스케이스
+ */
+interface GetGuestbookUseCase {
+    /**
+     * 방명록을 조회합니다.
+     */
+    fun execute(query: Query): Response
+
+    /**
+     * 방명록 조회 쿼리
+     */
+    data class Query(val guestbookId: String)
+
+    /**
+     * 방명록 조회 응답
+     */
+    data class Response(
+        val guestbookId: String,
+        val author: AuthorInfo,
+        val content: String,
+        val createdAt: String,
+        val updatedAt: String,
+    )
+
+    /**
+     * 작성자 정보
+     */
+    data class AuthorInfo(
+        val memberId: String,
+        val nickname: String,
+        val profileImageUrl: String?,
+        val username: String,
+    )
+}

--- a/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/port/in/query/GuestbookQueryFacade.kt
+++ b/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/port/in/query/GuestbookQueryFacade.kt
@@ -1,0 +1,18 @@
+package cloud.luigi99.blog.content.guestbook.application.port.`in`.query
+
+/**
+ * 방명록 조회 파사드
+ *
+ * 방명록 관련 Query UseCase들을 그룹화합니다.
+ */
+interface GuestbookQueryFacade {
+    /**
+     * 단일 방명록 조회 유스케이스를 반환합니다.
+     */
+    fun getGuestbook(): GetGuestbookUseCase
+
+    /**
+     * 방명록 목록 조회 유스케이스를 반환합니다.
+     */
+    fun getGuestbookList(): GetGuestbookListUseCase
+}

--- a/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/port/out/GuestbookRepository.kt
+++ b/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/port/out/GuestbookRepository.kt
@@ -1,0 +1,23 @@
+package cloud.luigi99.blog.content.guestbook.application.port.out
+
+import cloud.luigi99.blog.common.application.port.out.Repository
+import cloud.luigi99.blog.content.guestbook.domain.model.Guestbook
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookId
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+
+/**
+ * 방명록 저장소 포트
+ *
+ * 방명록 도메인 엔티티의 영속화를 위한 아웃바운드 포트입니다.
+ */
+interface GuestbookRepository : Repository<Guestbook, GuestbookId> {
+    /**
+     * 특정 작성자의 방명록 목록을 조회합니다.
+     */
+    fun findByAuthorId(authorId: MemberId): List<Guestbook>
+
+    /**
+     * 모든 방명록을 생성일 기준 내림차순으로 조회합니다.
+     */
+    fun findAllOrderByCreatedAtDesc(): List<Guestbook>
+}

--- a/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/port/out/MemberQueryPort.kt
+++ b/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/port/out/MemberQueryPort.kt
@@ -1,0 +1,28 @@
+package cloud.luigi99.blog.content.guestbook.application.port.out
+
+/**
+ * 회원 정보 조회 클라이언트 포트
+ *
+ * 방명록 작성자의 회원 정보를 조회합니다.
+ */
+interface MemberQueryPort {
+    /**
+     * 회원 ID로 작성자 정보를 조회합니다.
+     */
+    fun getAuthor(memberId: String): Author
+
+    /**
+     * 여러 회원 ID로 작성자 정보를 조회합니다.
+     */
+    fun getAuthors(memberIds: List<String>): Map<String, Author>
+
+    /**
+     * 작성자 정보
+     */
+    data class Author(
+        val memberId: String,
+        val nickname: String,
+        val profileImageUrl: String?,
+        val username: String,
+    )
+}

--- a/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/service/command/CreateGuestbookService.kt
+++ b/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/service/command/CreateGuestbookService.kt
@@ -1,0 +1,53 @@
+package cloud.luigi99.blog.content.guestbook.application.service.command
+
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.command.CreateGuestbookUseCase
+import cloud.luigi99.blog.content.guestbook.application.port.out.GuestbookRepository
+import cloud.luigi99.blog.content.guestbook.application.port.out.MemberQueryPort
+import cloud.luigi99.blog.content.guestbook.domain.model.Guestbook
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookContent
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 방명록 작성 서비스
+ *
+ * 새 방명록 글 작성을 처리합니다.
+ */
+@Service
+class CreateGuestbookService(
+    private val guestbookRepository: GuestbookRepository,
+    private val memberQueryPort: MemberQueryPort,
+) : CreateGuestbookUseCase {
+    @Transactional
+    override fun execute(command: CreateGuestbookUseCase.Command): CreateGuestbookUseCase.Response {
+        log.info { "Creating new guestbook entry by author: ${command.authorId}" }
+
+        val authorId = MemberId.from(command.authorId)
+        val content = GuestbookContent(command.content)
+
+        val guestbook = Guestbook.create(authorId, content)
+        val savedGuestbook = guestbookRepository.save(guestbook)
+
+        val author = memberQueryPort.getAuthor(command.authorId)
+
+        log.info { "Successfully created guestbook: ${savedGuestbook.entityId}" }
+
+        return CreateGuestbookUseCase.Response(
+            guestbookId =
+                savedGuestbook.entityId.value
+                    .toString(),
+            author =
+                CreateGuestbookUseCase.AuthorInfo(
+                    memberId = author.memberId,
+                    nickname = author.nickname,
+                    profileImageUrl = author.profileImageUrl,
+                    username = author.username,
+                ),
+            content = savedGuestbook.content.value,
+        )
+    }
+}

--- a/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/service/command/DeleteGuestbookService.kt
+++ b/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/service/command/DeleteGuestbookService.kt
@@ -1,0 +1,41 @@
+package cloud.luigi99.blog.content.guestbook.application.service.command
+
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.command.DeleteGuestbookUseCase
+import cloud.luigi99.blog.content.guestbook.application.port.out.GuestbookRepository
+import cloud.luigi99.blog.content.guestbook.domain.exception.GuestbookNotFoundException
+import cloud.luigi99.blog.content.guestbook.domain.exception.UnauthorizedGuestbookAccessException
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookId
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 방명록 삭제 서비스
+ *
+ * 방명록 삭제를 처리합니다.
+ */
+@Service
+class DeleteGuestbookService(private val guestbookRepository: GuestbookRepository) : DeleteGuestbookUseCase {
+    @Transactional
+    override fun execute(command: DeleteGuestbookUseCase.Command) {
+        log.info { "Deleting guestbook: ${command.guestbookId}" }
+
+        val guestbookId = GuestbookId.from(command.guestbookId)
+        val requesterId = MemberId.from(command.requesterId)
+
+        val guestbook =
+            guestbookRepository.findById(guestbookId)
+                ?: throw GuestbookNotFoundException()
+
+        if (!guestbook.isOwnedBy(requesterId)) {
+            throw UnauthorizedGuestbookAccessException()
+        }
+
+        guestbookRepository.deleteById(guestbookId)
+
+        log.info { "Successfully deleted guestbook: $guestbookId" }
+    }
+}

--- a/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/service/command/GuestbookCommandService.kt
+++ b/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/service/command/GuestbookCommandService.kt
@@ -1,0 +1,25 @@
+package cloud.luigi99.blog.content.guestbook.application.service.command
+
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.command.CreateGuestbookUseCase
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.command.DeleteGuestbookUseCase
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.command.GuestbookCommandFacade
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.command.ModifyGuestbookUseCase
+import org.springframework.stereotype.Service
+
+/**
+ * 방명록 명령 파사드 구현체
+ *
+ * Command UseCase들을 그룹화하여 제공합니다.
+ */
+@Service
+class GuestbookCommandService(
+    private val createGuestbookUseCase: CreateGuestbookUseCase,
+    private val modifyGuestbookUseCase: ModifyGuestbookUseCase,
+    private val deleteGuestbookUseCase: DeleteGuestbookUseCase,
+) : GuestbookCommandFacade {
+    override fun createGuestbook(): CreateGuestbookUseCase = createGuestbookUseCase
+
+    override fun modifyGuestbook(): ModifyGuestbookUseCase = modifyGuestbookUseCase
+
+    override fun deleteGuestbook(): DeleteGuestbookUseCase = deleteGuestbookUseCase
+}

--- a/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/service/command/ModifyGuestbookService.kt
+++ b/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/service/command/ModifyGuestbookService.kt
@@ -1,0 +1,51 @@
+package cloud.luigi99.blog.content.guestbook.application.service.command
+
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.command.ModifyGuestbookUseCase
+import cloud.luigi99.blog.content.guestbook.application.port.out.GuestbookRepository
+import cloud.luigi99.blog.content.guestbook.domain.exception.GuestbookNotFoundException
+import cloud.luigi99.blog.content.guestbook.domain.exception.UnauthorizedGuestbookAccessException
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookContent
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookId
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 방명록 수정 서비스
+ *
+ * 방명록 내용 수정을 처리합니다.
+ */
+@Service
+class ModifyGuestbookService(private val guestbookRepository: GuestbookRepository) : ModifyGuestbookUseCase {
+    @Transactional
+    override fun execute(command: ModifyGuestbookUseCase.Command): ModifyGuestbookUseCase.Response {
+        log.info { "Modifying guestbook: ${command.guestbookId}" }
+
+        val guestbookId = GuestbookId.from(command.guestbookId)
+        val requesterId = MemberId.from(command.requesterId)
+
+        val guestbook =
+            guestbookRepository.findById(guestbookId)
+                ?: throw GuestbookNotFoundException()
+
+        if (!guestbook.isOwnedBy(requesterId)) {
+            throw UnauthorizedGuestbookAccessException()
+        }
+
+        val newContent = GuestbookContent(command.content)
+        val updatedGuestbook = guestbook.updateContent(newContent)
+        val savedGuestbook = guestbookRepository.save(updatedGuestbook)
+
+        log.info { "Successfully modified guestbook: ${savedGuestbook.entityId}" }
+
+        return ModifyGuestbookUseCase.Response(
+            guestbookId =
+                savedGuestbook.entityId.value
+                    .toString(),
+            content = savedGuestbook.content.value,
+        )
+    }
+}

--- a/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/service/query/GetGuestbookListService.kt
+++ b/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/service/query/GetGuestbookListService.kt
@@ -1,0 +1,65 @@
+package cloud.luigi99.blog.content.guestbook.application.service.query
+
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.query.GetGuestbookListUseCase
+import cloud.luigi99.blog.content.guestbook.application.port.out.GuestbookRepository
+import cloud.luigi99.blog.content.guestbook.application.port.out.MemberQueryPort
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 방명록 목록 조회 서비스
+ */
+@Service
+class GetGuestbookListService(
+    private val guestbookRepository: GuestbookRepository,
+    private val memberQueryPort: MemberQueryPort,
+) : GetGuestbookListUseCase {
+    @Transactional(readOnly = true)
+    override fun execute(): List<GetGuestbookListUseCase.Response> {
+        log.info { "Getting all guestbooks" }
+
+        val guestbooks = guestbookRepository.findAllOrderByCreatedAtDesc()
+
+        if (guestbooks.isEmpty()) return emptyList()
+
+        val authorIds =
+            guestbooks
+                .map {
+                    it.authorId.value
+                        .toString()
+                }.distinct()
+        val authors = memberQueryPort.getAuthors(authorIds)
+
+        return guestbooks.map { guestbook ->
+            val authorId =
+                guestbook.authorId.value
+                    .toString()
+            val author =
+                authors[authorId] ?: MemberQueryPort.Author(
+                    memberId = authorId,
+                    nickname = "Unknown",
+                    profileImageUrl = null,
+                    username = "unknown",
+                )
+
+            GetGuestbookListUseCase.Response(
+                guestbookId =
+                    guestbook.entityId.value
+                        .toString(),
+                author =
+                    GetGuestbookListUseCase.AuthorInfo(
+                        memberId = author.memberId,
+                        nickname = author.nickname,
+                        profileImageUrl = author.profileImageUrl,
+                        username = author.username,
+                    ),
+                content = guestbook.content.value,
+                createdAt = guestbook.createdAt?.toString() ?: "",
+                updatedAt = guestbook.updatedAt?.toString() ?: "",
+            )
+        }
+    }
+}

--- a/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/service/query/GetGuestbookService.kt
+++ b/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/service/query/GetGuestbookService.kt
@@ -1,0 +1,53 @@
+package cloud.luigi99.blog.content.guestbook.application.service.query
+
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.query.GetGuestbookUseCase
+import cloud.luigi99.blog.content.guestbook.application.port.out.GuestbookRepository
+import cloud.luigi99.blog.content.guestbook.application.port.out.MemberQueryPort
+import cloud.luigi99.blog.content.guestbook.domain.exception.GuestbookNotFoundException
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookId
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 단일 방명록 조회 서비스
+ */
+@Service
+class GetGuestbookService(
+    private val guestbookRepository: GuestbookRepository,
+    private val memberQueryPort: MemberQueryPort,
+) : GetGuestbookUseCase {
+    @Transactional(readOnly = true)
+    override fun execute(query: GetGuestbookUseCase.Query): GetGuestbookUseCase.Response {
+        log.info { "Getting guestbook: ${query.guestbookId}" }
+
+        val guestbookId = GuestbookId.from(query.guestbookId)
+        val guestbook =
+            guestbookRepository.findById(guestbookId)
+                ?: throw GuestbookNotFoundException()
+
+        val author =
+            memberQueryPort.getAuthor(
+                guestbook.authorId.value
+                    .toString(),
+            )
+
+        return GetGuestbookUseCase.Response(
+            guestbookId =
+                guestbook.entityId.value
+                    .toString(),
+            author =
+                GetGuestbookUseCase.AuthorInfo(
+                    memberId = author.memberId,
+                    nickname = author.nickname,
+                    profileImageUrl = author.profileImageUrl,
+                    username = author.username,
+                ),
+            content = guestbook.content.value,
+            createdAt = guestbook.createdAt?.toString() ?: "",
+            updatedAt = guestbook.updatedAt?.toString() ?: "",
+        )
+    }
+}

--- a/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/service/query/GuestbookQueryService.kt
+++ b/modules/content/guestbook/application/src/main/kotlin/cloud/luigi99/blog/content/guestbook/application/service/query/GuestbookQueryService.kt
@@ -1,0 +1,21 @@
+package cloud.luigi99.blog.content.guestbook.application.service.query
+
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.query.GetGuestbookListUseCase
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.query.GetGuestbookUseCase
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.query.GuestbookQueryFacade
+import org.springframework.stereotype.Service
+
+/**
+ * 방명록 조회 파사드 구현체
+ *
+ * Query UseCase들을 그룹화하여 제공합니다.
+ */
+@Service
+class GuestbookQueryService(
+    private val getGuestbookUseCase: GetGuestbookUseCase,
+    private val getGuestbookListUseCase: GetGuestbookListUseCase,
+) : GuestbookQueryFacade {
+    override fun getGuestbook(): GetGuestbookUseCase = getGuestbookUseCase
+
+    override fun getGuestbookList(): GetGuestbookListUseCase = getGuestbookListUseCase
+}

--- a/modules/content/guestbook/application/src/test/kotlin/cloud/luigi99/blog/content/guestbook/application/service/command/CreateGuestbookServiceTest.kt
+++ b/modules/content/guestbook/application/src/test/kotlin/cloud/luigi99/blog/content/guestbook/application/service/command/CreateGuestbookServiceTest.kt
@@ -1,0 +1,56 @@
+package cloud.luigi99.blog.content.guestbook.application.service.command
+
+import cloud.luigi99.blog.common.domain.event.EventManager
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.command.CreateGuestbookUseCase
+import cloud.luigi99.blog.content.guestbook.application.port.out.GuestbookRepository
+import cloud.luigi99.blog.content.guestbook.application.port.out.MemberQueryPort
+import cloud.luigi99.blog.content.guestbook.domain.model.Guestbook
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+
+class CreateGuestbookServiceTest :
+    BehaviorSpec({
+
+        beforeTest {
+            mockkObject(EventManager)
+            every { EventManager.eventContextManager } returns mockk(relaxed = true)
+        }
+
+        Given("회원이 방명록을 작성하려 할 때") {
+            val guestbookRepository = mockk<GuestbookRepository>()
+            val memberQueryPort = mockk<MemberQueryPort>()
+            val service = CreateGuestbookService(guestbookRepository, memberQueryPort)
+
+            val command =
+                CreateGuestbookUseCase.Command(
+                    authorId = "123e4567-e89b-12d3-a456-426614174000",
+                    content = "안녕하세요! 블로그 잘 보고 있습니다.",
+                )
+
+            every { guestbookRepository.save(any()) } answers {
+                firstArg<Guestbook>()
+            }
+            every { memberQueryPort.getAuthor(command.authorId) } returns
+                MemberQueryPort.Author(
+                    memberId = command.authorId,
+                    nickname = "TestUser",
+                    profileImageUrl = "https://example.com/profile.jpg",
+                    username = "testuser",
+                )
+
+            When("방명록 작성을 실행하면") {
+                Then("방명록 ID, 작성자 정보, 내용이 반환된다") {
+                    val response = service.execute(command)
+
+                    response.guestbookId shouldNotBe null
+                    response.author.memberId shouldBe command.authorId
+                    response.author.nickname shouldBe "TestUser"
+                    response.content shouldBe command.content
+                }
+            }
+        }
+    })

--- a/modules/content/guestbook/application/src/test/kotlin/cloud/luigi99/blog/content/guestbook/application/service/command/DeleteGuestbookServiceTest.kt
+++ b/modules/content/guestbook/application/src/test/kotlin/cloud/luigi99/blog/content/guestbook/application/service/command/DeleteGuestbookServiceTest.kt
@@ -1,0 +1,107 @@
+package cloud.luigi99.blog.content.guestbook.application.service.command
+
+import cloud.luigi99.blog.common.domain.event.EventManager
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.command.DeleteGuestbookUseCase
+import cloud.luigi99.blog.content.guestbook.application.port.out.GuestbookRepository
+import cloud.luigi99.blog.content.guestbook.domain.exception.GuestbookNotFoundException
+import cloud.luigi99.blog.content.guestbook.domain.exception.UnauthorizedGuestbookAccessException
+import cloud.luigi99.blog.content.guestbook.domain.model.Guestbook
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookContent
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookId
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verify
+
+class DeleteGuestbookServiceTest :
+    BehaviorSpec({
+
+        beforeTest {
+            mockkObject(EventManager)
+            every { EventManager.eventContextManager } returns mockk(relaxed = true)
+        }
+
+        Given("작성자가 자신의 방명록을 삭제하려 할 때") {
+            val guestbookRepository = mockk<GuestbookRepository>()
+            val service = DeleteGuestbookService(guestbookRepository)
+
+            val authorId = MemberId.generate()
+            val guestbook = Guestbook.create(authorId, GuestbookContent("삭제할 방명록"))
+
+            val command =
+                DeleteGuestbookUseCase.Command(
+                    guestbookId =
+                        guestbook.entityId.value
+                            .toString(),
+                    requesterId = authorId.value.toString(),
+                )
+
+            When("삭제를 처리하면") {
+                every { guestbookRepository.findById(guestbook.entityId) } returns guestbook
+                every { guestbookRepository.deleteById(guestbook.entityId) } just Runs
+
+                Then("방명록이 저장소에서 삭제된다") {
+                    service.execute(command)
+                    verify(exactly = 1) { guestbookRepository.deleteById(guestbook.entityId) }
+                }
+            }
+        }
+
+        Given("다른 회원이 방명록을 삭제하려 할 때") {
+            val guestbookRepository = mockk<GuestbookRepository>()
+            val service = DeleteGuestbookService(guestbookRepository)
+
+            val authorId = MemberId.generate()
+            val otherId = MemberId.generate()
+            val guestbook = Guestbook.create(authorId, GuestbookContent("삭제 대상"))
+
+            val command =
+                DeleteGuestbookUseCase.Command(
+                    guestbookId =
+                        guestbook.entityId.value
+                            .toString(),
+                    requesterId = otherId.value.toString(),
+                )
+
+            When("삭제를 시도하면") {
+                every { guestbookRepository.findById(guestbook.entityId) } returns guestbook
+
+                Then("권한 없음 예외가 발생한다") {
+                    shouldThrow<UnauthorizedGuestbookAccessException> {
+                        service.execute(command)
+                    }
+                }
+            }
+        }
+
+        Given("존재하지 않는 방명록을 삭제하려 할 때") {
+            val guestbookRepository = mockk<GuestbookRepository>()
+            val service = DeleteGuestbookService(guestbookRepository)
+
+            val nonExistentId = GuestbookId.generate()
+            val command =
+                DeleteGuestbookUseCase.Command(
+                    guestbookId = nonExistentId.value.toString(),
+                    requesterId =
+                        MemberId
+                            .generate()
+                            .value
+                            .toString(),
+                )
+
+            When("삭제를 시도하면") {
+                every { guestbookRepository.findById(nonExistentId) } returns null
+
+                Then("방명록을 찾을 수 없음 예외가 발생한다") {
+                    shouldThrow<GuestbookNotFoundException> {
+                        service.execute(command)
+                    }
+                }
+            }
+        }
+    })

--- a/modules/content/guestbook/application/src/test/kotlin/cloud/luigi99/blog/content/guestbook/application/service/command/ModifyGuestbookServiceTest.kt
+++ b/modules/content/guestbook/application/src/test/kotlin/cloud/luigi99/blog/content/guestbook/application/service/command/ModifyGuestbookServiceTest.kt
@@ -1,0 +1,111 @@
+package cloud.luigi99.blog.content.guestbook.application.service.command
+
+import cloud.luigi99.blog.common.domain.event.EventManager
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.command.ModifyGuestbookUseCase
+import cloud.luigi99.blog.content.guestbook.application.port.out.GuestbookRepository
+import cloud.luigi99.blog.content.guestbook.domain.exception.GuestbookNotFoundException
+import cloud.luigi99.blog.content.guestbook.domain.exception.UnauthorizedGuestbookAccessException
+import cloud.luigi99.blog.content.guestbook.domain.model.Guestbook
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookContent
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookId
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verify
+
+class ModifyGuestbookServiceTest :
+    BehaviorSpec({
+
+        beforeTest {
+            mockkObject(EventManager)
+            every { EventManager.eventContextManager } returns mockk(relaxed = true)
+        }
+
+        Given("작성자가 자신의 방명록을 수정하려 할 때") {
+            val guestbookRepository = mockk<GuestbookRepository>()
+            val service = ModifyGuestbookService(guestbookRepository)
+
+            val authorId = MemberId.generate()
+            val guestbook = Guestbook.create(authorId, GuestbookContent("원래 내용"))
+
+            val command =
+                ModifyGuestbookUseCase.Command(
+                    guestbookId =
+                        guestbook.entityId.value
+                            .toString(),
+                    requesterId = authorId.value.toString(),
+                    content = "수정된 내용입니다.",
+                )
+
+            When("수정을 처리하면") {
+                every { guestbookRepository.findById(guestbook.entityId) } returns guestbook
+                every { guestbookRepository.save(any()) } answers { firstArg<Guestbook>() }
+
+                Then("수정된 내용이 저장되고 반환된다") {
+                    val response = service.execute(command)
+
+                    verify(exactly = 1) { guestbookRepository.save(any()) }
+                    response.content shouldBe command.content
+                }
+            }
+        }
+
+        Given("다른 회원이 방명록을 수정하려 할 때") {
+            val guestbookRepository = mockk<GuestbookRepository>()
+            val service = ModifyGuestbookService(guestbookRepository)
+
+            val authorId = MemberId.generate()
+            val otherId = MemberId.generate()
+            val guestbook = Guestbook.create(authorId, GuestbookContent("원래 내용"))
+
+            val command =
+                ModifyGuestbookUseCase.Command(
+                    guestbookId =
+                        guestbook.entityId.value
+                            .toString(),
+                    requesterId = otherId.value.toString(),
+                    content = "수정하려는 내용",
+                )
+
+            When("수정을 시도하면") {
+                every { guestbookRepository.findById(guestbook.entityId) } returns guestbook
+
+                Then("권한 없음 예외가 발생한다") {
+                    shouldThrow<UnauthorizedGuestbookAccessException> {
+                        service.execute(command)
+                    }
+                }
+            }
+        }
+
+        Given("존재하지 않는 방명록을 수정하려 할 때") {
+            val guestbookRepository = mockk<GuestbookRepository>()
+            val service = ModifyGuestbookService(guestbookRepository)
+
+            val nonExistentId = GuestbookId.generate()
+            val command =
+                ModifyGuestbookUseCase.Command(
+                    guestbookId = nonExistentId.value.toString(),
+                    requesterId =
+                        MemberId
+                            .generate()
+                            .value
+                            .toString(),
+                    content = "수정하려는 내용",
+                )
+
+            When("수정을 시도하면") {
+                every { guestbookRepository.findById(nonExistentId) } returns null
+
+                Then("방명록을 찾을 수 없음 예외가 발생한다") {
+                    shouldThrow<GuestbookNotFoundException> {
+                        service.execute(command)
+                    }
+                }
+            }
+        }
+    })

--- a/modules/content/guestbook/application/src/test/kotlin/cloud/luigi99/blog/content/guestbook/application/service/query/GetGuestbookListServiceTest.kt
+++ b/modules/content/guestbook/application/src/test/kotlin/cloud/luigi99/blog/content/guestbook/application/service/query/GetGuestbookListServiceTest.kt
@@ -1,0 +1,75 @@
+package cloud.luigi99.blog.content.guestbook.application.service.query
+
+import cloud.luigi99.blog.common.domain.event.EventManager
+import cloud.luigi99.blog.content.guestbook.application.port.out.GuestbookRepository
+import cloud.luigi99.blog.content.guestbook.application.port.out.MemberQueryPort
+import cloud.luigi99.blog.content.guestbook.domain.model.Guestbook
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookContent
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+
+class GetGuestbookListServiceTest :
+    BehaviorSpec({
+
+        beforeTest {
+            mockkObject(EventManager)
+            every { EventManager.eventContextManager } returns mockk(relaxed = true)
+        }
+
+        Given("방명록 목록을 조회하려 할 때") {
+            val guestbookRepository = mockk<GuestbookRepository>()
+            val memberQueryPort = mockk<MemberQueryPort>()
+            val service = GetGuestbookListService(guestbookRepository, memberQueryPort)
+
+            val memberId1 = MemberId.generate()
+            val memberId2 = MemberId.generate()
+
+            When("방명록이 존재하면") {
+                val guestbooks =
+                    listOf(
+                        Guestbook.create(memberId1, GuestbookContent("첫 번째 방명록")),
+                        Guestbook.create(memberId2, GuestbookContent("두 번째 방명록")),
+                    )
+
+                every { guestbookRepository.findAllOrderByCreatedAtDesc() } returns guestbooks
+                every { memberQueryPort.getAuthors(any()) } returns
+                    mapOf(
+                        memberId1.value.toString() to
+                            MemberQueryPort.Author(
+                                memberId = memberId1.value.toString(),
+                                nickname = "User1",
+                                profileImageUrl = null,
+                                username = "user1",
+                            ),
+                        memberId2.value.toString() to
+                            MemberQueryPort.Author(
+                                memberId = memberId2.value.toString(),
+                                nickname = "User2",
+                                profileImageUrl = null,
+                                username = "user2",
+                            ),
+                    )
+
+                Then("모든 방명록과 작성자 정보가 반환된다") {
+                    val responses = service.execute()
+
+                    responses.size shouldBe 2
+                    responses[0].author.nickname shouldBe "User1"
+                    responses[1].author.nickname shouldBe "User2"
+                }
+            }
+
+            When("방명록이 없으면") {
+                every { guestbookRepository.findAllOrderByCreatedAtDesc() } returns emptyList()
+
+                Then("빈 목록이 반환된다") {
+                    val responses = service.execute()
+                    responses shouldBe emptyList()
+                }
+            }
+        }
+    })

--- a/modules/content/guestbook/application/src/test/kotlin/cloud/luigi99/blog/content/guestbook/application/service/query/GetGuestbookServiceTest.kt
+++ b/modules/content/guestbook/application/src/test/kotlin/cloud/luigi99/blog/content/guestbook/application/service/query/GetGuestbookServiceTest.kt
@@ -1,0 +1,69 @@
+package cloud.luigi99.blog.content.guestbook.application.service.query
+
+import cloud.luigi99.blog.content.guestbook.application.port.`in`.query.GetGuestbookUseCase
+import cloud.luigi99.blog.content.guestbook.application.port.out.GuestbookRepository
+import cloud.luigi99.blog.content.guestbook.application.port.out.MemberQueryPort
+import cloud.luigi99.blog.content.guestbook.domain.exception.GuestbookNotFoundException
+import cloud.luigi99.blog.content.guestbook.domain.model.Guestbook
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookContent
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookId
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class GetGuestbookServiceTest :
+    BehaviorSpec({
+
+        Given("특정 방명록을 조회하려 할 때") {
+            val guestbookRepository = mockk<GuestbookRepository>()
+            val memberQueryPort = mockk<MemberQueryPort>()
+            val service = GetGuestbookService(guestbookRepository, memberQueryPort)
+
+            val guestbookId = GuestbookId.generate()
+            val memberId = MemberId.generate()
+            val guestbook =
+                Guestbook.from(
+                    entityId = guestbookId,
+                    authorId = memberId,
+                    content = GuestbookContent("테스트 방명록 내용"),
+                    createdAt = null,
+                    updatedAt = null,
+                )
+
+            When("해당 방명록이 존재하면") {
+                every { guestbookRepository.findById(guestbookId) } returns guestbook
+                every { memberQueryPort.getAuthor(memberId.value.toString()) } returns
+                    MemberQueryPort.Author(
+                        memberId = memberId.value.toString(),
+                        nickname = "TestUser",
+                        profileImageUrl = null,
+                        username = "testuser",
+                    )
+
+                Then("방명록 정보와 작성자 정보가 반환된다") {
+                    val query = GetGuestbookUseCase.Query(guestbookId.value.toString())
+                    val response = service.execute(query)
+
+                    response.guestbookId shouldBe guestbookId.value.toString()
+                    response.content shouldBe "테스트 방명록 내용"
+                    response.author.memberId shouldBe memberId.value.toString()
+                    response.author.nickname shouldBe "TestUser"
+                }
+            }
+
+            When("해당 방명록이 존재하지 않으면") {
+                val notExistId = GuestbookId.generate()
+                every { guestbookRepository.findById(notExistId) } returns null
+
+                Then("GuestbookNotFoundException이 발생한다") {
+                    val query = GetGuestbookUseCase.Query(notExistId.value.toString())
+                    shouldThrow<GuestbookNotFoundException> {
+                        service.execute(query)
+                    }
+                }
+            }
+        }
+    })

--- a/modules/content/guestbook/domain/build.gradle.kts
+++ b/modules/content/guestbook/domain/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    conventions
+}
+
+dependencies {
+    api(project(":libs:common"))
+    api(project(":modules:member:domain"))
+    testImplementation(libs.bundles.kotlin.test)
+}

--- a/modules/content/guestbook/domain/src/main/kotlin/cloud/luigi99/blog/content/guestbook/domain/event/GuestbookCreatedEvent.kt
+++ b/modules/content/guestbook/domain/src/main/kotlin/cloud/luigi99/blog/content/guestbook/domain/event/GuestbookCreatedEvent.kt
@@ -1,0 +1,12 @@
+package cloud.luigi99.blog.content.guestbook.domain.event
+
+import cloud.luigi99.blog.common.domain.event.DomainEvent
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookId
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+
+/**
+ * 방명록 생성 이벤트
+ *
+ * 새로운 방명록이 작성되었을 때 발행되는 도메인 이벤트입니다.
+ */
+data class GuestbookCreatedEvent(val guestbookId: GuestbookId, val authorId: MemberId) : DomainEvent

--- a/modules/content/guestbook/domain/src/main/kotlin/cloud/luigi99/blog/content/guestbook/domain/exception/GuestbookException.kt
+++ b/modules/content/guestbook/domain/src/main/kotlin/cloud/luigi99/blog/content/guestbook/domain/exception/GuestbookException.kt
@@ -1,0 +1,16 @@
+package cloud.luigi99.blog.content.guestbook.domain.exception
+
+import cloud.luigi99.blog.common.exception.BusinessException
+import cloud.luigi99.blog.common.exception.ErrorCode
+
+/**
+ * 방명록을 찾을 수 없는 경우 발생하는 예외
+ */
+class GuestbookNotFoundException(message: String = "방명록을 찾을 수 없습니다") :
+    BusinessException(ErrorCode.GUESTBOOK_NOT_FOUND, message)
+
+/**
+ * 방명록에 대한 권한이 없는 경우 발생하는 예외
+ */
+class UnauthorizedGuestbookAccessException(message: String = "방명록에 대한 권한이 없습니다") :
+    BusinessException(ErrorCode.UNAUTHORIZED_GUESTBOOK_ACCESS, message)

--- a/modules/content/guestbook/domain/src/main/kotlin/cloud/luigi99/blog/content/guestbook/domain/model/Guestbook.kt
+++ b/modules/content/guestbook/domain/src/main/kotlin/cloud/luigi99/blog/content/guestbook/domain/model/Guestbook.kt
@@ -1,0 +1,66 @@
+package cloud.luigi99.blog.content.guestbook.domain.model
+
+import cloud.luigi99.blog.common.domain.AggregateRoot
+import cloud.luigi99.blog.content.guestbook.domain.event.GuestbookCreatedEvent
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookContent
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookId
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import java.time.LocalDateTime
+
+/**
+ * 방명록 애그리거트 루트
+ *
+ * 블로그 방명록의 핵심 도메인 엔티티로, 방명록의 생성, 수정 등 비즈니스 로직을 담당합니다.
+ */
+class Guestbook private constructor(
+    override val entityId: GuestbookId,
+    val authorId: MemberId,
+    val content: GuestbookContent,
+) : AggregateRoot<GuestbookId>() {
+    companion object {
+        /**
+         * 새 방명록을 생성합니다.
+         */
+        fun create(authorId: MemberId, content: GuestbookContent): Guestbook {
+            val guestbook =
+                Guestbook(
+                    entityId = GuestbookId.generate(),
+                    authorId = authorId,
+                    content = content,
+                )
+            guestbook.registerEvent(GuestbookCreatedEvent(guestbook.entityId, authorId))
+            return guestbook
+        }
+
+        /**
+         * 영속성 계층에서 데이터를 로드하여 도메인 엔티티를 재구성합니다.
+         */
+        fun from(
+            entityId: GuestbookId,
+            authorId: MemberId,
+            content: GuestbookContent,
+            createdAt: LocalDateTime?,
+            updatedAt: LocalDateTime?,
+        ): Guestbook {
+            val guestbook = Guestbook(entityId, authorId, content)
+            guestbook.createdAt = createdAt
+            guestbook.updatedAt = updatedAt
+            return guestbook
+        }
+    }
+
+    /**
+     * 방명록 내용을 수정합니다.
+     */
+    fun updateContent(newContent: GuestbookContent): Guestbook {
+        val updated = Guestbook(entityId, authorId, newContent)
+        updated.createdAt = createdAt
+        updated.updatedAt = updatedAt
+        return updated
+    }
+
+    /**
+     * 해당 회원이 이 방명록의 작성자인지 확인합니다.
+     */
+    fun isOwnedBy(memberId: MemberId): Boolean = authorId == memberId
+}

--- a/modules/content/guestbook/domain/src/main/kotlin/cloud/luigi99/blog/content/guestbook/domain/vo/GuestbookContent.kt
+++ b/modules/content/guestbook/domain/src/main/kotlin/cloud/luigi99/blog/content/guestbook/domain/vo/GuestbookContent.kt
@@ -1,0 +1,22 @@
+package cloud.luigi99.blog.content.guestbook.domain.vo
+
+import cloud.luigi99.blog.common.domain.ValueObject
+
+/**
+ * 방명록 내용 값 객체
+ *
+ * 방명록에 작성되는 내용을 표현하며, 유효성 검증을 수행합니다.
+ */
+@JvmInline
+value class GuestbookContent(val value: String) : ValueObject {
+    init {
+        require(value.isNotBlank()) { "방명록 내용은 비어있을 수 없습니다" }
+        require(value.length <= MAX_LENGTH) {
+            "방명록 내용은 ${MAX_LENGTH}자를 초과할 수 없습니다 (현재: ${value.length}자)"
+        }
+    }
+
+    companion object {
+        const val MAX_LENGTH = 5000
+    }
+}

--- a/modules/content/guestbook/domain/src/main/kotlin/cloud/luigi99/blog/content/guestbook/domain/vo/GuestbookId.kt
+++ b/modules/content/guestbook/domain/src/main/kotlin/cloud/luigi99/blog/content/guestbook/domain/vo/GuestbookId.kt
@@ -1,0 +1,27 @@
+package cloud.luigi99.blog.content.guestbook.domain.vo
+
+import cloud.luigi99.blog.common.domain.ValueObject
+import java.io.Serializable
+import java.util.UUID
+
+/**
+ * 방명록 식별자 값 객체
+ *
+ * 방명록 엔티티를 고유하게 식별하기 위한 UUID 기반 값 객체입니다.
+ */
+@JvmInline
+value class GuestbookId(val value: UUID) :
+    ValueObject,
+    Serializable {
+    companion object {
+        /**
+         * 새로운 방명록 식별자를 생성합니다.
+         */
+        fun generate(): GuestbookId = GuestbookId(UUID.randomUUID())
+
+        /**
+         * 문자열로부터 방명록 식별자를 복원합니다.
+         */
+        fun from(value: String): GuestbookId = GuestbookId(UUID.fromString(value))
+    }
+}

--- a/modules/content/guestbook/domain/src/test/kotlin/cloud/luigi99/blog/content/guestbook/domain/model/GuestbookTest.kt
+++ b/modules/content/guestbook/domain/src/test/kotlin/cloud/luigi99/blog/content/guestbook/domain/model/GuestbookTest.kt
@@ -1,0 +1,114 @@
+package cloud.luigi99.blog.content.guestbook.domain.model
+
+import cloud.luigi99.blog.common.domain.event.EventManager
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookContent
+import cloud.luigi99.blog.content.guestbook.domain.vo.GuestbookId
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockkObject
+import java.time.LocalDateTime
+
+class GuestbookTest :
+    BehaviorSpec({
+
+        beforeTest {
+            mockkObject(EventManager)
+            every { EventManager.eventContextManager } returns io.mockk.mockk(relaxed = true)
+        }
+
+        Given("회원이 새 방명록 글을 작성하려 할 때") {
+            val authorId = MemberId.generate()
+            val content = GuestbookContent("안녕하세요! 블로그 잘 보고 있습니다.")
+
+            When("방명록을 생성하면") {
+                val guestbook = Guestbook.create(authorId, content)
+
+                Then("고유 식별자가 부여된다") {
+                    guestbook.entityId shouldNotBe null
+                }
+
+                Then("입력한 내용이 저장된다") {
+                    guestbook.content shouldBe content
+                }
+
+                Then("작성자 정보가 저장된다") {
+                    guestbook.authorId shouldBe authorId
+                }
+            }
+        }
+
+        Given("기존 방명록 작성자가 내용을 수정하려 할 때") {
+            val authorId = MemberId.generate()
+            val originalContent = GuestbookContent("원래 내용입니다.")
+            val guestbook = Guestbook.create(authorId, originalContent)
+
+            When("새로운 내용으로 수정하면") {
+                val newContent = GuestbookContent("수정된 내용입니다.")
+                val updatedGuestbook = guestbook.updateContent(newContent)
+
+                Then("원본 방명록은 변경되지 않고 보존된다") {
+                    guestbook.content shouldBe originalContent
+                }
+
+                Then("수정된 내용을 가진 새 인스턴스가 반환된다") {
+                    updatedGuestbook.content shouldBe newContent
+                }
+
+                Then("식별자는 동일하게 유지된다") {
+                    updatedGuestbook.entityId shouldBe guestbook.entityId
+                }
+            }
+        }
+
+        Given("데이터베이스에 저장된 방명록을 불러왔을 때") {
+            val guestbookId = GuestbookId.generate()
+            val authorId = MemberId.generate()
+            val content = GuestbookContent("저장된 방명록 내용")
+            val createdAt = LocalDateTime.now().minusDays(3)
+            val updatedAt = LocalDateTime.now().minusDays(1)
+
+            When("도메인 객체로 재구성하면") {
+                val guestbook =
+                    Guestbook.from(
+                        entityId = guestbookId,
+                        authorId = authorId,
+                        content = content,
+                        createdAt = createdAt,
+                        updatedAt = updatedAt,
+                    )
+
+                Then("모든 속성이 저장된 상태 그대로 복원된다") {
+                    guestbook.entityId shouldBe guestbookId
+                    guestbook.authorId shouldBe authorId
+                    guestbook.content shouldBe content
+                    guestbook.createdAt shouldBe createdAt
+                    guestbook.updatedAt shouldBe updatedAt
+                }
+            }
+        }
+
+        Given("방명록 작성자가 자신의 방명록인지 확인하려 할 때") {
+            val authorId = MemberId.generate()
+            val otherMemberId = MemberId.generate()
+            val guestbook = Guestbook.create(authorId, GuestbookContent("테스트"))
+
+            When("본인 ID로 확인하면") {
+                val isOwner = guestbook.isOwnedBy(authorId)
+
+                Then("소유자임이 확인된다") {
+                    isOwner shouldBe true
+                }
+            }
+
+            When("다른 회원 ID로 확인하면") {
+                val isOwner = guestbook.isOwnedBy(otherMemberId)
+
+                Then("소유자가 아님이 확인된다") {
+                    isOwner shouldBe false
+                }
+            }
+        }
+    })

--- a/modules/content/guestbook/domain/src/test/kotlin/cloud/luigi99/blog/content/guestbook/domain/vo/GuestbookContentTest.kt
+++ b/modules/content/guestbook/domain/src/test/kotlin/cloud/luigi99/blog/content/guestbook/domain/vo/GuestbookContentTest.kt
@@ -1,0 +1,95 @@
+package cloud.luigi99.blog.content.guestbook.domain.vo
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+
+class GuestbookContentTest :
+    BehaviorSpec({
+
+        Given("사용자가 방명록에 올바른 내용을 작성했을 때") {
+            val validContent = "안녕하세요! 블로그 잘 보고 있습니다."
+
+            When("방명록 내용 객체를 생성하면") {
+                val content = GuestbookContent(validContent)
+
+                Then("입력한 내용이 정상적으로 저장된다") {
+                    content.value shouldBe validContent
+                }
+            }
+        }
+
+        Given("사용자가 방명록 내용을 입력하지 않았을 때") {
+            val emptyContent = ""
+
+            When("방명록 내용 객체 생성을 시도하면") {
+                val exception =
+                    shouldThrow<IllegalArgumentException> {
+                        GuestbookContent(emptyContent)
+                    }
+
+                Then("빈 내용은 허용되지 않으므로 생성이 거절된다") {
+                    exception.message shouldContain "방명록 내용"
+                }
+            }
+        }
+
+        Given("사용자가 공백만 입력했을 때") {
+            val blankContent = "   "
+
+            When("방명록 내용 객체 생성을 시도하면") {
+                val exception =
+                    shouldThrow<IllegalArgumentException> {
+                        GuestbookContent(blankContent)
+                    }
+
+                Then("실질적인 내용이 없으므로 생성이 거절된다") {
+                    exception.message shouldContain "방명록 내용"
+                }
+            }
+        }
+
+        Given("사용자가 최대 길이를 초과하는 내용을 입력했을 때") {
+            val tooLongContent = "a".repeat(5001)
+
+            When("방명록 내용 객체 생성을 시도하면") {
+                val exception =
+                    shouldThrow<IllegalArgumentException> {
+                        GuestbookContent(tooLongContent)
+                    }
+
+                Then("최대 길이 초과로 생성이 거절된다") {
+                    exception.message shouldContain "5000"
+                }
+            }
+        }
+
+        Given("사용자가 최대 길이까지 내용을 입력했을 때") {
+            val maxLengthContent = "a".repeat(5000)
+
+            When("방명록 내용 객체를 생성하면") {
+                val content = GuestbookContent(maxLengthContent)
+
+                Then("정상적으로 생성된다") {
+                    content shouldNotBe null
+                    content.value.length shouldBe 5000
+                }
+            }
+        }
+
+        Given("동일한 내용을 가진 두 방명록 내용 객체가 있을 때") {
+            val contentText = "동일한 내용입니다."
+            val content1 = GuestbookContent(contentText)
+            val content2 = GuestbookContent(contentText)
+
+            Then("두 객체는 논리적으로 동일한 것으로 취급한다") {
+                content1 shouldBe content2
+            }
+
+            Then("해시코드도 동일하다") {
+                content1.hashCode() shouldBe content2.hashCode()
+            }
+        }
+    })

--- a/modules/content/guestbook/domain/src/test/kotlin/cloud/luigi99/blog/content/guestbook/domain/vo/GuestbookIdTest.kt
+++ b/modules/content/guestbook/domain/src/test/kotlin/cloud/luigi99/blog/content/guestbook/domain/vo/GuestbookIdTest.kt
@@ -1,0 +1,60 @@
+package cloud.luigi99.blog.content.guestbook.domain.vo
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.util.UUID
+
+class GuestbookIdTest :
+    BehaviorSpec({
+
+        Given("시스템이 새로운 방명록 항목을 생성해야 할 때") {
+            When("새 식별자를 생성하면") {
+                val guestbookId = GuestbookId.generate()
+
+                Then("고유한 UUID 기반 식별자가 생성된다") {
+                    guestbookId shouldNotBe null
+                    guestbookId.value shouldNotBe null
+                }
+            }
+        }
+
+        Given("데이터베이스에 저장된 방명록 ID 문자열이 있을 때") {
+            val uuidString = "123e4567-e89b-12d3-a456-426614174000"
+
+            When("문자열로부터 GuestbookId를 복원하면") {
+                val guestbookId = GuestbookId.from(uuidString)
+
+                Then("동일한 UUID 값을 가진 식별자가 생성된다") {
+                    guestbookId.value.toString() shouldBe uuidString
+                }
+            }
+        }
+
+        Given("잘못된 UUID 형식의 문자열이 주어졌을 때") {
+            val invalidUuidString = "invalid-uuid"
+
+            When("GuestbookId 생성을 시도하면") {
+                Then("예외가 발생한다") {
+                    shouldThrow<IllegalArgumentException> {
+                        GuestbookId.from(invalidUuidString)
+                    }
+                }
+            }
+        }
+
+        Given("동일한 UUID 값을 가진 두 GuestbookId가 있을 때") {
+            val uuid = UUID.randomUUID()
+            val guestbookId1 = GuestbookId(uuid)
+            val guestbookId2 = GuestbookId(uuid)
+
+            Then("두 식별자는 논리적으로 동일한 것으로 취급한다") {
+                guestbookId1 shouldBe guestbookId2
+            }
+
+            Then("해시코드도 동일하다") {
+                guestbookId1.hashCode() shouldBe guestbookId2.hashCode()
+            }
+        }
+    })

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,6 +33,11 @@ include("modules:content:comment:adapter:in:web")
 include("modules:content:comment:adapter:out:persistence:jpa")
 include("modules:content:comment:adapter:out:client:member")
 
+include("modules:content:guestbook:domain")
+include("modules:content:guestbook:application")
+include("modules:content:guestbook:adapter:in:web")
+include("modules:content:guestbook:adapter:out:persistence:jpa")
+
 include("modules:media:domain")
 include("modules:media:application")
 include("modules:media:adapter:in:web")


### PR DESCRIPTION
## 📋 개요
- 방명록(Guestbook) 기능을 위한 도메인, 애플리케이션, JPA 퍼시스턴스, 웹 어댑터 계층을 구현하여 전체적인 기능을 추가하였습니다.
- 작성, 수정, 삭제, 조회(Create, Read, Update, Delete) 등 모든 주요 유스케이스를 포함하며, 적절한 트랜잭션 관리 및 예외 처리 로직을 추가하였습니다.
- 관련 테스트 코드 및 필요한 의존성을 설정하여 기능의 완전성을 검증하였습니다.

## ☑️ 체크리스트
- [ ] 코딩 컨벤션을 준수했나요? (`./gradlew ktlintCheck`)
- [ ] 모든 테스트를 통과했나요? (`./gradlew test`)
- [ ] 불필요한 주석이나 로그는 제거했나요?