### PR TITLE
refactor: Guestbook 모듈 잘못된 어댑터 관련 코드 패키지 경로 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,6 +34,12 @@ dependencies {
     implementation(project(":modules:content:comment:adapter:out:persistence:jpa"))
     implementation(project(":modules:content:comment:adapter:out:client:member"))
 
+    implementation(project(":modules:content:guestbook:domain"))
+    implementation(project(":modules:content:guestbook:application"))
+    implementation(project(":modules:content:guestbook:adapter:in:web"))
+    implementation(project(":modules:content:guestbook:adapter:out:persistence:jpa"))
+    implementation(project(":modules:content:guestbook:adapter:out:client:member"))
+
     implementation(project(":modules:media:domain"))
     implementation(project(":modules:media:application"))
     implementation(project(":modules:media:adapter:in:web"))

--- a/modules/content/guestbook/adapter/out/client/member/build.gradle.kts
+++ b/modules/content/guestbook/adapter/out/client/member/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    springLibraryConventions
+}
+
+dependencies {
+    implementation(project(":libs:common"))
+    implementation(project(":modules:content:guestbook:application"))
+    implementation(project(":modules:member:application"))
+
+    implementation(libs.spring.boot.starter.core)
+}

--- a/modules/content/guestbook/adapter/out/client/member/src/main/kotlin/cloud/luigi99/blog/content/guestbook/adapter/out/client/member/MemberClientAdapter.kt
+++ b/modules/content/guestbook/adapter/out/client/member/src/main/kotlin/cloud/luigi99/blog/content/guestbook/adapter/out/client/member/MemberClientAdapter.kt
@@ -1,4 +1,4 @@
-package cloud.luigi99.blog.content.guestbook.application.adapter
+package cloud.luigi99.blog.content.guestbook.adapter.out.client.member
 
 import cloud.luigi99.blog.content.guestbook.application.port.out.MemberQueryPort
 import cloud.luigi99.blog.member.application.member.port.`in`.query.GetMembersProfileUseCase

--- a/modules/content/guestbook/application/build.gradle.kts
+++ b/modules/content/guestbook/application/build.gradle.kts
@@ -5,8 +5,6 @@ plugins {
 dependencies {
     implementation(project(":libs:common"))
     api(project(":modules:content:guestbook:domain"))
-    implementation(project(":modules:member:application"))
-
     implementation(libs.spring.boot.starter.core)
     implementation(libs.spring.boot.starter.data.jpa)
     testImplementation(libs.bundles.kotlin.test)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,6 +37,7 @@ include("modules:content:guestbook:domain")
 include("modules:content:guestbook:application")
 include("modules:content:guestbook:adapter:in:web")
 include("modules:content:guestbook:adapter:out:persistence:jpa")
+include("modules:content:guestbook:adapter:out:client:member")
 
 include("modules:media:domain")
 include("modules:media:application")


### PR DESCRIPTION
## 📋 개요
- `Guestbook MemberClientAdapter` 모듈을 추가하고, 위치를 재조정하며 관련 빌드 설정을 수정했습니다.
- 세부적으로, `modules:content:guestbook:adapter:out:client:member` 모듈을 새로 추가하였습니다.
- MemberClientAdapter를 `adapter/out/client/member`로 이동하고, Gradle 의존성 설정을 변경했습니다.

## ☑️ 체크리스트
- [ ] 코딩 컨벤션을 준수했나요? (`./gradlew ktlintCheck`)
- [ ] 모든 테스트를 통과했나요? (`./gradlew test`)
- [ ] 불필요한 주석이나 로그는 제거했나요?