### PR TITLE
fix: 댓글 관련 API docs 수정

### DIFF
--- a/modules/content/comment/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/comment/adapter/in/web/CommentApi.kt
+++ b/modules/content/comment/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/comment/adapter/in/web/CommentApi.kt
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RequestParam
 interface CommentApi {
     @Operation(
         summary = "댓글 작성",
-        description = "게시글에 새로운 댓글을 작성합니다.",
+        description = "게시글에 새로운 댓글을 작성합니다. 로그인한 회원만 작성 가능합니다.",
         security = [SecurityRequirement(name = "Bearer Authentication")],
     )
     @ApiResponses(
@@ -151,7 +151,7 @@ interface CommentApi {
 
     @Operation(
         summary = "댓글 수정",
-        description = "작성한 댓글의 내용을 수정합니다.",
+        description = "작성한 댓글의 내용을 수정합니다. 작성자 본인만 수정 가능합니다.",
         security = [SecurityRequirement(name = "Bearer Authentication")],
     )
     @ApiResponses(
@@ -300,7 +300,7 @@ interface CommentApi {
 
     @Operation(
         summary = "댓글 삭제",
-        description = "작성한 댓글을 삭제합니다.",
+        description = "작성한 댓글을 삭제합니다. 작성자 본인만 삭제 가능합니다.",
         security = [SecurityRequirement(name = "Bearer Authentication")],
     )
     @ApiResponses(


### PR DESCRIPTION
## 📋 개요
- 댓글 작성, 수정, 삭제 API의 설명문을 구체화하여 사용성을 개선했습니다. 작성자 본인의 권한 및 로그인 요구사항을 명확히 명시했습니다.

## ☑️ 체크리스트
- [ ] 코딩 컨벤션을 준수했나요? (`./gradlew ktlintCheck`)
- [ ] 모든 테스트를 통과했나요? (`./gradlew test`)
- [ ] 불필요한 주석이나 로그는 제거했나요?