### PR TITLE
feat: OAuth 로그인 시 이메일 nullable 지원

### DIFF
--- a/app/src/main/resources/db/migration/V16__make_email_nullable_add_username_unique.sql
+++ b/app/src/main/resources/db/migration/V16__make_email_nullable_add_username_unique.sql
@@ -1,0 +1,13 @@
+-- 1. 이메일 컬럼을 nullable로 변경
+ALTER TABLE member 
+  ALTER COLUMN email DROP NOT NULL;
+
+-- 2. 이메일 UNIQUE 제약조건 제거
+DROP INDEX IF EXISTS idx_member_email;
+ALTER TABLE member DROP CONSTRAINT IF EXISTS member_email_key;
+
+-- 3. 이메일 일반 인덱스 재생성 (검색 성능용)
+CREATE INDEX idx_member_email ON member(email);
+
+-- 4. Username UNIQUE 제약조건 추가
+ALTER TABLE member ADD CONSTRAINT member_username_unique UNIQUE (username);

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/dto/GitHubOAuth2UserInfo.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/dto/GitHubOAuth2UserInfo.kt
@@ -3,9 +3,7 @@ package cloud.luigi99.blog.auth.credentials.adapter.`in`.web.dto
 import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.oauth2.OAuth2UserInfo
 
 data class GitHubOAuth2UserInfo(private val attributes: Map<String, Any>) : OAuth2UserInfo {
-    override fun getEmail(): String =
-        attributes["email"] as? String
-            ?: throw IllegalStateException("GitHub 사용자 이메일을 찾을 수 없습니다")
+    override fun getEmail(): String? = attributes["email"] as? String
 
     override fun getUsername(): String =
         (attributes["login"] as? String)
@@ -16,7 +14,5 @@ data class GitHubOAuth2UserInfo(private val attributes: Map<String, Any>) : OAut
         attributes["id"]?.toString()
             ?: throw IllegalStateException("GitHub provider ID를 찾을 수 없습니다")
 
-    override fun getProfileImgUrl(): String =
-        attributes["avatar_url"]?.toString()
-            ?: throw IllegalStateException("GitHub 프로필 이미지 URL을 찾을 수 없습니다")
+    override fun getProfileImgUrl(): String? = attributes["avatar_url"]?.toString()
 }

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/oauth2/OAuth2UserInfo.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/oauth2/OAuth2UserInfo.kt
@@ -1,11 +1,11 @@
 package cloud.luigi99.blog.auth.credentials.adapter.`in`.web.oauth2
 
 interface OAuth2UserInfo {
-    fun getEmail(): String
+    fun getEmail(): String?
 
     fun getUsername(): String
 
     fun getProviderId(): String
 
-    fun getProfileImgUrl(): String
+    fun getProfileImgUrl(): String?
 }

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/command/LoginUseCase.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/command/LoginUseCase.kt
@@ -6,7 +6,7 @@ interface LoginUseCase {
     fun execute(command: Command): Response
 
     data class Command(
-        val email: String,
+        val email: String?,
         val username: String,
         val provider: String,
         val providerId: String,
@@ -15,7 +15,7 @@ interface LoginUseCase {
 
     data class Response(
         val memberId: String,
-        val email: String,
+        val email: String?,
         val username: String,
         val role: Role,
         val profileImgUrl: String?,

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/out/MemberClient.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/out/MemberClient.kt
@@ -3,11 +3,11 @@ package cloud.luigi99.blog.auth.credentials.application.port.out
 interface MemberClient {
     fun execute(request: Request): Response
 
-    data class Request(val email: String, val username: String, val profileImgUrl: String?)
+    data class Request(val email: String?, val username: String, val profileImgUrl: String?)
 
     data class Response(
         val memberId: String,
-        val email: String,
+        val email: String?,
         val username: String,
         val profileImgUrl: String?,
     )

--- a/modules/member/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/member/adapter/in/web/member/dto/MemberResponse.kt
+++ b/modules/member/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/member/adapter/in/web/member/dto/MemberResponse.kt
@@ -5,8 +5,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class MemberResponse(
     @field:Schema(description = "회원 ID", example = "123e4567-e89b-12d3-a456-426614174000")
     val memberId: String,
-    @field:Schema(description = "이메일", example = "user@example.com")
-    val email: String,
+    @field:Schema(description = "이메일 (OAuth 제공자에서 미제공 시 null)", example = "user@example.com")
+    val email: String?,
     @field:Schema(description = "사용자 이름", example = "Luigi99")
     val username: String,
 )

--- a/modules/member/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/member/MemberJpaEntity.kt
+++ b/modules/member/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/member/MemberJpaEntity.kt
@@ -20,9 +20,9 @@ class MemberJpaEntity private constructor(
     @Id
     @Column(name = "id")
     val id: UUID,
-    @Column(name = "email", nullable = false, unique = true)
-    val email: String,
-    @Column(name = "username", nullable = false, length = 100)
+    @Column(name = "email", nullable = true)
+    val email: String?,
+    @Column(name = "username", nullable = false, length = 100, unique = true)
     val username: String,
     @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true)
     @JoinColumn(name = "profile_id")
@@ -32,7 +32,7 @@ class MemberJpaEntity private constructor(
         get() = MemberId(id)
 
     companion object {
-        fun from(entityId: UUID, email: String, username: String): MemberJpaEntity =
+        fun from(entityId: UUID, email: String?, username: String): MemberJpaEntity =
             MemberJpaEntity(
                 id = entityId,
                 email = email,

--- a/modules/member/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/member/MemberMapper.kt
+++ b/modules/member/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/member/MemberMapper.kt
@@ -10,7 +10,7 @@ object MemberMapper {
     fun toDomain(entity: MemberJpaEntity): Member =
         Member.from(
             entityId = MemberId(entity.id),
-            email = Email(entity.email),
+            email = entity.email?.let { Email(it) },
             username = Username(entity.username),
             profile = entity.profile?.let { ProfileMapper.toDomain(it) },
             createdAt = entity.createdAt,
@@ -22,7 +22,7 @@ object MemberMapper {
             MemberJpaEntity
                 .from(
                     entityId = member.entityId.value,
-                    email = member.email.value,
+                    email = member.email?.value,
                     username = member.username.value,
                 ).apply {
                     createdAt = member.createdAt

--- a/modules/member/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/member/MemberMapperTest.kt
+++ b/modules/member/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/member/adapter/out/persistence/jpa/member/MemberMapperTest.kt
@@ -92,7 +92,7 @@ class MemberMapperTest :
 
                 Then("모든 필드가 정확하게 매핑되어야 한다") {
                     domain.entityId.value shouldBe entityId
-                    domain.email.value shouldBe "stored@example.com"
+                    domain.email?.value shouldBe "stored@example.com"
                     domain.username.value shouldBe "storeduser"
                     domain.profile shouldBe null
                     domain.createdAt shouldBe LocalDateTime.of(2025, 1, 1, 12, 0)
@@ -161,6 +161,55 @@ class MemberMapperTest :
                     entity2.email shouldBe "user2@example.com"
 
                     entity1.id shouldNotBe entity2.id
+                }
+            }
+        }
+
+        Given("이메일 없이 가입한 OAuth 회원 정보가") {
+            val memberId = MemberId.generate()
+            val member =
+                Member.from(
+                    entityId = memberId,
+                    email = null,
+                    username = Username("github_user"),
+                    profile = null,
+                    createdAt = null,
+                    updatedAt = null,
+                )
+
+            When("데이터베이스에 저장되면") {
+                val entity = MemberMapper.toEntity(member)
+
+                Then("이메일 컬럼은 비어있는 상태로 저장된다") {
+                    entity.email shouldBe null
+                }
+
+                Then("회원 식별 정보는 정상적으로 저장된다") {
+                    entity.id shouldBe memberId.value
+                    entity.username shouldBe "github_user"
+                }
+            }
+        }
+
+        Given("데이터베이스에 이메일 없이 저장된 OAuth 회원 정보가") {
+            val entityId = UUID.randomUUID()
+            val jpaEntity =
+                MemberJpaEntity.from(
+                    entityId = entityId,
+                    email = null,
+                    username = "github_user",
+                )
+
+            When("애플리케이션에서 조회되면") {
+                val domain = MemberMapper.toDomain(jpaEntity)
+
+                Then("이메일은 비어있는 상태로 복원된다") {
+                    domain.email shouldBe null
+                }
+
+                Then("회원 식별 정보는 정상적으로 복원된다") {
+                    domain.entityId.value shouldBe entityId
+                    domain.username.value shouldBe "github_user"
                 }
             }
         }

--- a/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/port/in/command/RegisterMemberUseCase.kt
+++ b/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/port/in/command/RegisterMemberUseCase.kt
@@ -3,11 +3,11 @@ package cloud.luigi99.blog.member.application.member.port.`in`.command
 interface RegisterMemberUseCase {
     fun execute(command: Command): Response
 
-    data class Command(val email: String, val username: String, val profileImgUrl: String?)
+    data class Command(val email: String?, val username: String, val profileImgUrl: String?)
 
     data class Response(
         val memberId: String,
-        val email: String,
+        val email: String?,
         val username: String,
         val profileImgUrl: String?,
     )

--- a/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/port/in/query/GetCurrentMemberUseCase.kt
+++ b/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/port/in/query/GetCurrentMemberUseCase.kt
@@ -5,5 +5,5 @@ interface GetCurrentMemberUseCase {
 
     data class Query(val memberId: String)
 
-    data class Response(val memberId: String, val email: String, val username: String)
+    data class Response(val memberId: String, val email: String?, val username: String)
 }

--- a/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/port/in/query/GetMemberProfileUseCase.kt
+++ b/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/port/in/query/GetMemberProfileUseCase.kt
@@ -7,7 +7,7 @@ interface GetMemberProfileUseCase {
 
     data class Response(
         val memberId: String,
-        val email: String,
+        val email: String?,
         val username: String,
         val profile: ProfileResponse?,
     )

--- a/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/port/in/query/GetMembersProfileUseCase.kt
+++ b/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/port/in/query/GetMembersProfileUseCase.kt
@@ -9,7 +9,7 @@ interface GetMembersProfileUseCase {
 
     data class MemberProfile(
         val memberId: String,
-        val email: String,
+        val email: String?,
         val username: String,
         val profile: ProfileResponse?,
     )

--- a/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/service/command/RegisterMemberService.kt
+++ b/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/service/command/RegisterMemberService.kt
@@ -26,7 +26,7 @@ class RegisterMemberService(private val memberRepository: MemberRepository) : Re
     override fun execute(command: RegisterMemberUseCase.Command): RegisterMemberUseCase.Response {
         log.info { "Registering new member with email: ${command.email}" }
 
-        val email = Email(command.email)
+        val email = command.email?.let { Email(it) }
         val username = Username(command.username)
 
         // 회원 생성
@@ -54,7 +54,7 @@ class RegisterMemberService(private val memberRepository: MemberRepository) : Re
             memberId =
                 savedMember.entityId.value
                     .toString(),
-            email = savedMember.email.value,
+            email = savedMember.email?.value,
             username = savedMember.username.value,
             profileImgUrl =
                 savedMember.profile

--- a/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/service/query/GetCurrentMemberService.kt
+++ b/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/service/query/GetCurrentMemberService.kt
@@ -24,7 +24,7 @@ class GetCurrentMemberService(private val memberRepository: MemberRepository) : 
             memberId =
                 member.entityId.value
                     .toString(),
-            email = member.email.value,
+            email = member.email?.value,
             username = member.username.value,
         )
     }

--- a/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/service/query/GetMemberProfileService.kt
+++ b/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/service/query/GetMemberProfileService.kt
@@ -43,7 +43,7 @@ class GetMemberProfileService(private val memberRepository: MemberRepository) : 
             memberId =
                 member.entityId.value
                     .toString(),
-            email = member.email.value,
+            email = member.email?.value,
             username = member.username.value,
             profile = profileResponse,
         )

--- a/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/service/query/GetMembersProfileService.kt
+++ b/modules/member/application/src/main/kotlin/cloud/luigi99/blog/member/application/member/service/query/GetMembersProfileService.kt
@@ -43,7 +43,7 @@ class GetMembersProfileService(private val memberRepository: MemberRepository) :
                     memberId =
                         member.entityId.value
                             .toString(),
-                    email = member.email.value,
+                    email = member.email?.value,
                     username = member.username.value,
                     profile = profileResponse,
                 )

--- a/modules/member/application/src/test/kotlin/cloud/luigi99/blog/member/application/member/service/command/RegisterMemberServiceTest.kt
+++ b/modules/member/application/src/test/kotlin/cloud/luigi99/blog/member/application/member/service/command/RegisterMemberServiceTest.kt
@@ -185,7 +185,7 @@ class RegisterMemberServiceTest :
 
                 Then("도메인 Email 값 객체가 생성된다") {
                     val member = memberSlot.captured
-                    member.email.value shouldBe "domain@example.com"
+                    member.email?.value shouldBe "domain@example.com"
                 }
 
                 Then("도메인 Username 값 객체가 생성된다") {
@@ -202,6 +202,36 @@ class RegisterMemberServiceTest :
                     val member = memberSlot.captured
                     member.profile shouldNotBe null
                     member.profile?.entityId shouldNotBe null
+                }
+            }
+        }
+
+        Given("OAuth 로그인 시 이메일을 비공개로 설정한 사용자가") {
+            val memberRepository = mockk<MemberRepository>()
+            val service = RegisterMemberService(memberRepository)
+
+            When("회원 가입을 요청하면") {
+                val command =
+                    RegisterMemberUseCase.Command(
+                        email = null,
+                        username = "github_user",
+                        profileImgUrl = "https://example.com/avatar.jpg",
+                    )
+
+                every { memberRepository.save(any()) } answers { firstArg() }
+
+                val response = service.execute(command)
+
+                Then("이메일 없이도 회원 가입이 완료된다") {
+                    response.email shouldBe null
+                }
+
+                Then("회원 고유 식별자가 발급된다") {
+                    response.memberId shouldNotBe null
+                }
+
+                Then("사용자명으로 회원을 식별할 수 있다") {
+                    response.username shouldBe "github_user"
                 }
             }
         }

--- a/modules/member/application/src/test/kotlin/cloud/luigi99/blog/member/application/member/service/query/GetCurrentMemberServiceTest.kt
+++ b/modules/member/application/src/test/kotlin/cloud/luigi99/blog/member/application/member/service/query/GetCurrentMemberServiceTest.kt
@@ -129,4 +129,43 @@ class GetCurrentMemberServiceTest :
                 }
             }
         }
+
+        Given("이메일 없이 가입한 OAuth 회원이") {
+            val memberRepository = mockk<MemberRepository>()
+            val service = GetCurrentMemberService(memberRepository)
+
+            val memberId = MemberId.generate()
+            val member =
+                Member.from(
+                    entityId = memberId,
+                    email = null,
+                    username = Username("github_user"),
+                    profile = null,
+                    createdAt = null,
+                    updatedAt = null,
+                )
+
+            When("내 정보를 조회하면") {
+                val query =
+                    GetCurrentMemberUseCase.Query(
+                        memberId = memberId.toString(),
+                    )
+
+                every { memberRepository.findById(memberId) } returns member
+
+                val response = service.execute(query)
+
+                Then("이메일은 비어있는 상태로 조회된다") {
+                    response.email shouldBe null
+                }
+
+                Then("회원 식별자로 본인 확인이 가능하다") {
+                    response.memberId shouldBe memberId.toString()
+                }
+
+                Then("사용자 이름으로 본인 확인이 가능하다") {
+                    response.username shouldBe "github_user"
+                }
+            }
+        }
     })

--- a/modules/member/domain/src/main/kotlin/cloud/luigi99/blog/member/domain/member/event/MemberRegisteredEvent.kt
+++ b/modules/member/domain/src/main/kotlin/cloud/luigi99/blog/member/domain/member/event/MemberRegisteredEvent.kt
@@ -4,4 +4,4 @@ import cloud.luigi99.blog.common.domain.event.DomainEvent
 import cloud.luigi99.blog.member.domain.member.vo.Email
 import cloud.luigi99.blog.member.domain.member.vo.MemberId
 
-data class MemberRegisteredEvent(val memberId: MemberId, val email: Email) : DomainEvent
+data class MemberRegisteredEvent(val memberId: MemberId, val email: Email?) : DomainEvent

--- a/modules/member/domain/src/main/kotlin/cloud/luigi99/blog/member/domain/member/model/Member.kt
+++ b/modules/member/domain/src/main/kotlin/cloud/luigi99/blog/member/domain/member/model/Member.kt
@@ -23,7 +23,7 @@ import java.time.LocalDateTime
  */
 class Member private constructor(
     override val entityId: MemberId,
-    val email: Email,
+    val email: Email?,
     val username: Username,
     val profile: Profile?,
 ) : AggregateRoot<MemberId>() {
@@ -36,7 +36,7 @@ class Member private constructor(
          * @param profile 프로필 (선택)
          * @return 생성된 회원 엔티티
          */
-        fun register(email: Email, username: Username, profile: Profile? = null): Member {
+        fun register(email: Email?, username: Username, profile: Profile? = null): Member {
             val member =
                 Member(
                     entityId = MemberId.generate(),
@@ -54,7 +54,7 @@ class Member private constructor(
          */
         fun from(
             entityId: MemberId,
-            email: Email,
+            email: Email?,
             username: Username,
             profile: Profile?,
             createdAt: LocalDateTime?,

--- a/modules/member/domain/src/test/kotlin/cloud/luigi99/blog/member/domain/member/model/MemberTest.kt
+++ b/modules/member/domain/src/test/kotlin/cloud/luigi99/blog/member/domain/member/model/MemberTest.kt
@@ -268,4 +268,24 @@ class MemberTest :
                 }
             }
         }
+
+        Given("GitHub OAuth 로그인 시 이메일을 비공개로 설정한 사용자가") {
+            val username = Username("github_user")
+
+            When("회원 가입을 시도하면") {
+                val member = Member.register(email = null, username = username)
+
+                Then("이메일 없이도 정상적으로 회원이 생성된다") {
+                    member.email shouldBe null
+                }
+
+                Then("회원 고유 식별자가 부여된다") {
+                    member.entityId shouldNotBe null
+                }
+
+                Then("사용자 이름으로 회원을 식별할 수 있다") {
+                    member.username shouldBe username
+                }
+            }
+        }
     })


### PR DESCRIPTION
## 📋 개요
OAuth 로그인(GitHub 등) 시 사용자가 이메일을 비공개로 설정한 경우에도 정상적으로 회원 가입 및 로그인이 가능하도록 수정했습니다.

### 주요 변경사항
- OAuth2UserInfo, GitHubOAuth2UserInfo: 이메일 null 반환 허용
- Member 도메인/Application/Adapter: email nullable 처리
- MemberJpaEntity: email nullable, username UNIQUE 추가
- DB 마이그레이션 스크립트 추가 (V16)

## 🔗 관련 이슈
- N/A

## ☑️ 체크리스트
- [x] 코딩 컨벤션을 준수했나요? (\./gradlew ktlintCheck\)
- [x] 모든 테스트를 통과했나요? (\./gradlew test\)
- [x] 불필요한 주석이나 로그는 제거했나요?