### PR TITLE
fix: mutate domain models in place

### DIFF
--- a/modules/content/comment/domain/src/main/kotlin/cloud/luigi99/blog/content/comment/domain/model/Comment.kt
+++ b/modules/content/comment/domain/src/main/kotlin/cloud/luigi99/blog/content/comment/domain/model/Comment.kt
@@ -20,8 +20,11 @@ class Comment private constructor(
     override val entityId: CommentId,
     val postId: PostId,
     val authorId: MemberId,
-    val content: CommentContent,
+    content: CommentContent,
 ) : AggregateRoot<CommentId>() {
+    var content: CommentContent = content
+        private set
+
     companion object {
         /**
          * 새로운 댓글을 생성합니다.
@@ -65,11 +68,9 @@ class Comment private constructor(
         if (!verifyAuthor(requesterId)) {
             throw UnauthorizedCommentAccessException("Only the author can update this comment")
         }
-        val updated = Comment(entityId, postId, authorId, newContent)
-        updated.createdAt = createdAt
-        updated.updatedAt = updatedAt
-        updated.registerEvent(CommentUpdatedEvent(entityId, postId, authorId))
-        return updated
+        this.content = newContent
+        registerEvent(CommentUpdatedEvent(entityId, postId, authorId))
+        return this
     }
 
     /**

--- a/modules/content/comment/domain/src/test/kotlin/cloud/luigi99/blog/content/comment/domain/CommentTest.kt
+++ b/modules/content/comment/domain/src/test/kotlin/cloud/luigi99/blog/content/comment/domain/CommentTest.kt
@@ -10,6 +10,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -53,11 +54,13 @@ class CommentTest :
             When("새로운 내용으로 수정을 요청하면") {
                 val updatedComment = originalComment.updateContent(newContent, authorId)
 
-                Then("원본 댓글은 변경되지 않고 보존된다") {
-                    originalComment.content shouldBe originalContent
+                Then("원본 댓글 객체 자체가 변경된다") {
+                    originalComment.content shouldNotBe originalContent
+                    originalComment.content shouldBe newContent
                 }
 
-                Then("수정된 내용을 가진 새로운 댓글 객체가 반환된다") {
+                Then("수정된 내용을 가진 현재 댓글 객체가 반환된다") {
+                    updatedComment shouldBeSameInstanceAs originalComment
                     updatedComment.content shouldBe newContent
                 }
 

--- a/modules/content/guestbook/domain/src/main/kotlin/cloud/luigi99/blog/content/guestbook/domain/model/Guestbook.kt
+++ b/modules/content/guestbook/domain/src/main/kotlin/cloud/luigi99/blog/content/guestbook/domain/model/Guestbook.kt
@@ -15,8 +15,11 @@ import java.time.LocalDateTime
 class Guestbook private constructor(
     override val entityId: GuestbookId,
     val authorId: MemberId,
-    val content: GuestbookContent,
+    content: GuestbookContent,
 ) : AggregateRoot<GuestbookId>() {
+    var content: GuestbookContent = content
+        private set
+
     companion object {
         /**
          * 새 방명록을 생성합니다.
@@ -53,10 +56,8 @@ class Guestbook private constructor(
      * 방명록 내용을 수정합니다.
      */
     fun updateContent(newContent: GuestbookContent): Guestbook {
-        val updated = Guestbook(entityId, authorId, newContent)
-        updated.createdAt = createdAt
-        updated.updatedAt = updatedAt
-        return updated
+        this.content = newContent
+        return this
     }
 
     /**

--- a/modules/content/guestbook/domain/src/test/kotlin/cloud/luigi99/blog/content/guestbook/domain/model/GuestbookTest.kt
+++ b/modules/content/guestbook/domain/src/test/kotlin/cloud/luigi99/blog/content/guestbook/domain/model/GuestbookTest.kt
@@ -7,6 +7,7 @@ import cloud.luigi99.blog.member.domain.member.vo.MemberId
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.mockk.every
 import io.mockk.mockkObject
 import java.time.LocalDateTime
@@ -49,11 +50,13 @@ class GuestbookTest :
                 val newContent = GuestbookContent("수정된 내용입니다.")
                 val updatedGuestbook = guestbook.updateContent(newContent)
 
-                Then("원본 방명록은 변경되지 않고 보존된다") {
-                    guestbook.content shouldBe originalContent
+                Then("원본 방명록 객체 자체가 변경된다") {
+                    guestbook.content shouldNotBe originalContent
+                    guestbook.content shouldBe newContent
                 }
 
-                Then("수정된 내용을 가진 새 인스턴스가 반환된다") {
+                Then("수정된 내용을 가진 현재 인스턴스가 반환된다") {
+                    updatedGuestbook shouldBeSameInstanceAs guestbook
                     updatedGuestbook.content shouldBe newContent
                 }
 

--- a/modules/content/post/domain/src/main/kotlin/cloud/luigi99/blog/content/post/domain/model/Post.kt
+++ b/modules/content/post/domain/src/main/kotlin/cloud/luigi99/blog/content/post/domain/model/Post.kt
@@ -31,13 +31,25 @@ import java.time.LocalDateTime
 class Post private constructor(
     override val entityId: PostId,
     val memberId: MemberId,
-    val title: Title,
+    title: Title,
     val slug: Slug,
-    val body: Body,
+    body: Body,
     val type: ContentType,
-    val status: PostStatus,
-    val tags: Set<String>,
+    status: PostStatus,
+    tags: Set<String>,
 ) : AggregateRoot<PostId>() {
+    var title: Title = title
+        private set
+
+    var body: Body = body
+        private set
+
+    var status: PostStatus = status
+        private set
+
+    var tags: Set<String> = tags.toSet()
+        private set
+
     companion object {
         /**
          * 새로운 Post를 생성합니다.
@@ -134,22 +146,9 @@ class Post private constructor(
      * @return 발행된 Post
      */
     fun publish(): Post {
-        val published =
-            Post(
-                entityId = entityId,
-                memberId = memberId,
-                title = title,
-                slug = slug,
-                body = body,
-                type = type,
-                status = PostStatus.PUBLISHED,
-                tags = tags,
-            )
-        published.createdAt = createdAt
-        published.updatedAt = updatedAt
-
-        published.registerEvent(PostPublishedEvent(published.entityId, published.slug))
-        return published
+        this.status = PostStatus.PUBLISHED
+        registerEvent(PostPublishedEvent(entityId, slug))
+        return this
     }
 
     /**
@@ -160,22 +159,9 @@ class Post private constructor(
      * @return 아카이빙된 Post
      */
     fun archive(): Post {
-        val archived =
-            Post(
-                entityId = entityId,
-                memberId = memberId,
-                title = title,
-                slug = slug,
-                body = body,
-                type = type,
-                status = PostStatus.ARCHIVED,
-                tags = tags,
-            )
-        archived.createdAt = createdAt
-        archived.updatedAt = updatedAt
-
-        archived.registerEvent(PostArchivedEvent(archived.entityId, archived.slug))
-        return archived
+        this.status = PostStatus.ARCHIVED
+        registerEvent(PostArchivedEvent(entityId, slug))
+        return this
     }
 
     /**
@@ -184,22 +170,8 @@ class Post private constructor(
      * @return 삭제 이벤트가 등록된 Post
      */
     fun delete(): Post {
-        val deleted =
-            Post(
-                entityId = entityId,
-                memberId = memberId,
-                title = title,
-                slug = slug,
-                body = body,
-                type = type,
-                status = status,
-                tags = tags,
-            )
-        deleted.createdAt = createdAt
-        deleted.updatedAt = updatedAt
-
-        deleted.registerEvent(PostDeletedEvent(deleted.entityId, deleted.memberId))
-        return deleted
+        registerEvent(PostDeletedEvent(entityId, memberId))
+        return this
     }
 
     /**
@@ -210,20 +182,9 @@ class Post private constructor(
      * @return 수정된 Post
      */
     fun update(newTitle: Title, newBody: Body): Post {
-        val updated =
-            Post(
-                entityId = entityId,
-                memberId = memberId,
-                title = newTitle,
-                slug = slug,
-                body = newBody,
-                type = type,
-                status = status,
-                tags = tags,
-            )
-        updated.createdAt = createdAt
-        updated.updatedAt = updatedAt
-        return updated
+        this.title = newTitle
+        this.body = newBody
+        return this
     }
 
     /**
@@ -238,22 +199,8 @@ class Post private constructor(
         require(tagName.isNotBlank()) { "Tag name cannot be blank" }
         require(tagName.length <= 50) { "Tag name must not exceed 50 characters" }
 
-        val newTags = tags + tagName
-
-        val withTag =
-            Post(
-                entityId = entityId,
-                memberId = memberId,
-                title = title,
-                slug = slug,
-                body = body,
-                type = type,
-                status = status,
-                tags = newTags,
-            )
-        withTag.createdAt = createdAt
-        withTag.updatedAt = updatedAt
-        return withTag
+        this.tags = tags + tagName
+        return this
     }
 
     /**
@@ -263,21 +210,7 @@ class Post private constructor(
      * @return 태그가 제거된 Post
      */
     fun removeTag(tagName: String): Post {
-        val newTags = tags - tagName
-
-        val withoutTag =
-            Post(
-                entityId = entityId,
-                memberId = memberId,
-                title = title,
-                slug = slug,
-                body = body,
-                type = type,
-                status = status,
-                tags = newTags,
-            )
-        withoutTag.createdAt = createdAt
-        withoutTag.updatedAt = updatedAt
-        return withoutTag
+        this.tags = tags - tagName
+        return this
     }
 }

--- a/modules/content/post/domain/src/test/kotlin/cloud/luigi99/blog/content/post/domain/model/PostTest.kt
+++ b/modules/content/post/domain/src/test/kotlin/cloud/luigi99/blog/content/post/domain/model/PostTest.kt
@@ -16,7 +16,7 @@ import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.kotest.matchers.types.shouldNotBeSameInstanceAs
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -123,8 +123,9 @@ class PostTest :
                     published.status shouldBe PostStatus.PUBLISHED
                 }
 
-                Then("새로운 인스턴스가 반환된다") {
-                    published shouldNotBeSameInstanceAs post
+                Then("현재 인스턴스가 변경되어 반환된다") {
+                    published shouldBeSameInstanceAs post
+                    post.status shouldBe PostStatus.PUBLISHED
                 }
             }
         }
@@ -148,8 +149,9 @@ class PostTest :
                     archived.status shouldBe PostStatus.ARCHIVED
                 }
 
-                Then("새로운 인스턴스가 반환된다") {
-                    archived shouldNotBeSameInstanceAs post
+                Then("현재 인스턴스가 변경되어 반환된다") {
+                    archived shouldBeSameInstanceAs post
+                    post.status shouldBe PostStatus.ARCHIVED
                 }
             }
         }
@@ -176,8 +178,10 @@ class PostTest :
                     updated.body shouldBe newBody
                 }
 
-                Then("새로운 인스턴스가 반환된다") {
-                    updated shouldNotBeSameInstanceAs post
+                Then("현재 인스턴스가 변경되어 반환된다") {
+                    updated shouldBeSameInstanceAs post
+                    post.title shouldBe newTitle
+                    post.body shouldBe newBody
                 }
 
                 Then("slug와 타입은 유지된다") {
@@ -204,8 +208,8 @@ class PostTest :
                     withTag.tags shouldContain "kotlin"
                 }
 
-                Then("새로운 인스턴스가 반환된다") {
-                    withTag shouldNotBeSameInstanceAs post
+                Then("현재 인스턴스가 변경되어 반환된다") {
+                    withTag shouldBeSameInstanceAs post
                 }
             }
 
@@ -266,13 +270,24 @@ class PostTest :
                     removed.tags shouldContain "spring"
                 }
 
-                Then("새로운 인스턴스가 반환된다") {
-                    removed shouldNotBeSameInstanceAs post
+                Then("현재 인스턴스가 변경되어 반환된다") {
+                    removed shouldBeSameInstanceAs post
                 }
             }
 
             When("존재하지 않는 태그를 제거하면") {
-                val removed = post.removeTag("java")
+                val postWithTags =
+                    Post
+                        .create(
+                            MemberId.generate(),
+                            Title("존재하지 않는 태그 제거 테스트"),
+                            Slug("remove-missing-tag-test"),
+                            Body("내용"),
+                            ContentType.BLOG,
+                        ).addTag("kotlin")
+                        .addTag("spring")
+
+                val removed = postWithTags.removeTag("java")
 
                 Then("변경 없이 반환된다") {
                     removed.tags shouldHaveSize 2
@@ -338,8 +353,8 @@ class PostTest :
             When("삭제를 수행하면") {
                 val deleted = post.delete()
 
-                Then("기존 객체와 다른 새로운 인스턴스가 반환된다") {
-                    deleted shouldNotBeSameInstanceAs post
+                Then("현재 인스턴스에 삭제 이벤트가 등록되어 반환된다") {
+                    deleted shouldBeSameInstanceAs post
                 }
             }
         }

--- a/modules/member/domain/src/main/kotlin/cloud/luigi99/blog/member/domain/member/model/Member.kt
+++ b/modules/member/domain/src/main/kotlin/cloud/luigi99/blog/member/domain/member/model/Member.kt
@@ -24,9 +24,15 @@ import java.time.LocalDateTime
 class Member private constructor(
     override val entityId: MemberId,
     val email: Email?,
-    val username: Username,
-    val profile: Profile?,
+    username: Username,
+    profile: Profile?,
 ) : AggregateRoot<MemberId>() {
+    var username: Username = username
+        private set
+
+    var profile: Profile? = profile
+        private set
+
     companion object {
         /**
          * 신규 회원을 등록합니다.
@@ -80,18 +86,9 @@ class Member private constructor(
      * @return 변경된 회원 엔티티
      */
     fun updateUsername(newUsername: Username): Member {
-        val updated =
-            Member(
-                entityId = entityId,
-                email = email,
-                username = newUsername,
-                profile = profile,
-            )
-        updated.createdAt = createdAt
-        updated.updatedAt = updatedAt
-
-        updated.registerEvent(MemberUsernameUpdatedEvent(updated.entityId, updated.username.value))
-        return updated
+        this.username = newUsername
+        registerEvent(MemberUsernameUpdatedEvent(entityId, username.value))
+        return this
     }
 
     /**
@@ -101,18 +98,9 @@ class Member private constructor(
      * @return 변경된 회원 엔티티
      */
     fun updateProfile(newProfile: Profile): Member {
-        val updated =
-            Member(
-                entityId = entityId,
-                email = email,
-                username = username,
-                profile = newProfile,
-            )
-        updated.createdAt = createdAt
-        updated.updatedAt = updatedAt
-
-        updated.registerEvent(MemberProfileUpdatedEvent(updated.entityId))
-        return updated
+        this.profile = newProfile
+        registerEvent(MemberProfileUpdatedEvent(entityId))
+        return this
     }
 
     /**

--- a/modules/member/domain/src/main/kotlin/cloud/luigi99/blog/member/domain/profile/model/Profile.kt
+++ b/modules/member/domain/src/main/kotlin/cloud/luigi99/blog/member/domain/profile/model/Profile.kt
@@ -14,17 +14,47 @@ import java.time.LocalDateTime
 
 class Profile private constructor(
     override val entityId: ProfileId,
-    val nickname: Nickname,
-    val bio: Bio?,
-    val profileImageUrl: Url?,
-    val readme: Readme?,
-    val company: Company?,
-    val location: Location?,
-    val jobTitle: JobTitle?,
-    val githubUrl: Url?,
-    val contactEmail: ContactEmail?,
-    val websiteUrl: Url?,
+    nickname: Nickname,
+    bio: Bio?,
+    profileImageUrl: Url?,
+    readme: Readme?,
+    company: Company?,
+    location: Location?,
+    jobTitle: JobTitle?,
+    githubUrl: Url?,
+    contactEmail: ContactEmail?,
+    websiteUrl: Url?,
 ) : DomainEntity<ProfileId>() {
+    var nickname: Nickname = nickname
+        private set
+
+    var bio: Bio? = bio
+        private set
+
+    var profileImageUrl: Url? = profileImageUrl
+        private set
+
+    var readme: Readme? = readme
+        private set
+
+    var company: Company? = company
+        private set
+
+    var location: Location? = location
+        private set
+
+    var jobTitle: JobTitle? = jobTitle
+        private set
+
+    var githubUrl: Url? = githubUrl
+        private set
+
+    var contactEmail: ContactEmail? = contactEmail
+        private set
+
+    var websiteUrl: Url? = websiteUrl
+        private set
+
     companion object {
         fun create(
             nickname: Nickname,
@@ -99,22 +129,16 @@ class Profile private constructor(
         contactEmail: ContactEmail? = this.contactEmail,
         websiteUrl: Url? = this.websiteUrl,
     ): Profile {
-        val updated =
-            Profile(
-                entityId = this.entityId,
-                nickname = nickname,
-                bio = bio,
-                profileImageUrl = profileImageUrl,
-                readme = readme,
-                company = company,
-                location = location,
-                jobTitle = jobTitle,
-                githubUrl = githubUrl,
-                contactEmail = contactEmail,
-                websiteUrl = websiteUrl,
-            )
-        updated.createdAt = this.createdAt
-        updated.updatedAt = this.updatedAt
-        return updated
+        this.nickname = nickname
+        this.bio = bio
+        this.profileImageUrl = profileImageUrl
+        this.readme = readme
+        this.company = company
+        this.location = location
+        this.jobTitle = jobTitle
+        this.githubUrl = githubUrl
+        this.contactEmail = contactEmail
+        this.websiteUrl = websiteUrl
+        return this
     }
 }

--- a/modules/member/domain/src/test/kotlin/cloud/luigi99/blog/member/domain/member/model/MemberTest.kt
+++ b/modules/member/domain/src/test/kotlin/cloud/luigi99/blog/member/domain/member/model/MemberTest.kt
@@ -9,6 +9,7 @@ import cloud.luigi99.blog.member.domain.profile.vo.Nickname
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -168,7 +169,7 @@ class MemberTest :
             }
         }
 
-        Given("회원의 불변성을 테스트할 때") {
+        Given("회원 업데이트가 현재 인스턴스를 변경하는지 테스트할 때") {
             val originalMember =
                 Member.register(
                     Email("user@example.com"),
@@ -181,12 +182,13 @@ class MemberTest :
             When("사용자 이름을 변경하면") {
                 val updatedMember = originalMember.updateUsername(Username("jane_doe"))
 
-                Then("원본 회원 객체는 변경되지 않는다") {
-                    originalMember.username shouldBe originalUsername
-                    originalMember.username.value shouldBe "john_doe"
+                Then("원본 회원 객체 자체가 변경된다") {
+                    originalMember.username shouldNotBe originalUsername
+                    originalMember.username.value shouldBe "jane_doe"
                 }
 
-                Then("새로운 회원 객체가 반환된다") {
+                Then("현재 회원 객체가 반환된다") {
+                    updatedMember shouldBeSameInstanceAs originalMember
                     updatedMember.username.value shouldBe "jane_doe"
                 }
 

--- a/modules/member/domain/src/test/kotlin/cloud/luigi99/blog/member/domain/profile/model/ProfileTest.kt
+++ b/modules/member/domain/src/test/kotlin/cloud/luigi99/blog/member/domain/profile/model/ProfileTest.kt
@@ -12,6 +12,7 @@ import cloud.luigi99.blog.member.domain.profile.vo.Url
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import java.time.LocalDateTime
 
 class ProfileTest :
@@ -191,7 +192,7 @@ class ProfileTest :
             }
         }
 
-        Given("프로필의 불변성 테스트") {
+        Given("프로필 업데이트가 현재 인스턴스를 변경하는지 테스트") {
             val originalProfile =
                 Profile.create(
                     nickname = Nickname("개발자"),
@@ -206,12 +207,14 @@ class ProfileTest :
                         nickname = Nickname("새 닉네임"),
                     )
 
-                Then("원본 프로필 객체는 변경되지 않는다") {
-                    originalProfile.nickname shouldBe originalNickname
+                Then("원본 프로필 객체 자체가 변경된다") {
+                    originalProfile.nickname shouldNotBe originalNickname
                     originalProfile.bio shouldBe originalBio
+                    originalProfile.nickname.value shouldBe "새 닉네임"
                 }
 
-                Then("새로운 프로필 객체가 반환된다") {
+                Then("현재 프로필 객체가 반환된다") {
+                    updatedProfile shouldBeSameInstanceAs originalProfile
                     updatedProfile.nickname.value shouldBe "새 닉네임"
                 }
 


### PR DESCRIPTION
## Summary
- Refactor Post, Member, Profile, Comment, and Guestbook domain update methods to mutate the current instance instead of allocating replacement entities
- Keep existing return types by returning this for chaining/call-site compatibility
- Update domain tests to assert same-instance mutation behavior

## Test Plan
- ./gradlew :modules:content:post:domain:test :modules:content:comment:domain:test :modules:content:guestbook:domain:test :modules:member:domain:test --continue --stacktrace
- ./gradlew test check :app:bootJar --parallel --build-cache --continue --stacktrace

## Notes
- Conventional commit uses fix so semantic-release should publish a patch release and trigger Docker image build on merge.