### PR TITLE
feat(post): add post discovery APIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,213 @@
+# luigi-log-server AGENTS.md
+
+## 프로젝트
+
+- repo: `kjyy08/luigi-log-server`
+- root project: `blog-server`
+- group: `cloud.luigi99`
+- 역할: luigi-log 블로그 백엔드 REST API
+- stack: Kotlin 2.2.x, JDK 21, Spring Boot 4, Gradle Kotlin DSL, PostgreSQL, Redis, Flyway, Cloudflare R2/S3 호환 스토리지
+- 구조: Gradle multi-module + DDD/Hexagonal 스타일
+
+> 기존 `CLAUDE.md`는 오래된/예제성 컨텍스트가 섞일 수 있으니 신뢰하지 말고, 실제 파일(`settings.gradle.kts`, `buildSrc`, 각 module source, `application*.yml`) 기준으로 판단한다.
+
+## 주요 경로
+
+```txt
+app/
+  src/main/kotlin/cloud/luigi99/blog/app/BlogServerApplication.kt
+  src/main/resources/application.yml
+  src/main/resources/application-{local,dev,prod}.yml
+  src/main/resources/db/migration/V*.sql
+
+libs/common/
+  # AggregateRoot, DomainEntity, ValueObject, DomainEvent, Repository, BusinessException 등 공통 도메인/애플리케이션 원시 타입
+
+libs/adapter/
+  persistence/jpa      # JPA 공통 엔티티/설정
+  persistence/redis    # Redis 공통 엔티티/설정
+  message/spring       # Spring 기반 domain event publisher/context
+  web                  # CommonResponse, GlobalExceptionHandler, Cookie/Swagger 공통
+
+modules/
+  member/
+  auth/token/
+  auth/credentials/
+  content/post/
+  content/comment/
+  content/guestbook/
+  media/
+```
+
+## 모듈 패턴
+
+대부분 bounded context는 아래 계층을 따른다.
+
+```txt
+<context>/
+├── domain/                  # 순수 도메인. Spring/JPA/Redis 의존 금지
+├── application/             # use case, command/query service, port
+└── adapter/
+    ├── in/web/              # controller, request/response DTO, API 인터페이스
+    ├── in/event/            # Spring event listener, 필요 시
+    └── out/
+        ├── persistence/jpa/ # JPA entity/repository/mapper/adapter
+        ├── persistence/redis/
+        ├── client/...       # 다른 context 접근용 client adapter
+        └── storage/r2/      # media storage adapter
+```
+
+## 작업 위치
+
+- 모든 backend 작업은 이 repo 루트에서 한다.
+
+```bash
+cd /home/luigi/.hermes/profiles/boksili/home/workspace/kjyy08/luigi-log/server
+```
+
+- `luigi-log/` 상위 디렉토리는 관리 컨텍스트일 뿐이고 git repo가 아니다.
+- client/API 계약 변경이 있으면 `../client` 영향도 같이 본다.
+- env, DB, Redis, 이미지/포트 변경은 `../gitops` 영향도 같이 본다.
+
+## 명령
+
+```bash
+# 주의: gradlew 실행권한(mode)은 임의로 바꾸지 않는다.
+# 실행권한이 없는 repo 상태면 chmod 대신 bash ./gradlew ... 형태로 실행한다.
+
+# 전체 테스트
+bash ./gradlew test
+
+# 전체 검증
+bash ./gradlew check
+
+# 전체 빌드
+bash ./gradlew clean build
+
+# 실행 JAR 검증
+bash ./gradlew :app:bootJar
+
+# 로컬 실행
+bash ./gradlew :app:bootRun
+
+# 스타일
+bash ./gradlew ktlintCheck
+bash ./gradlew ktlintFormat
+
+# 커버리지
+bash ./gradlew koverHtmlReport
+bash ./gradlew koverVerify
+```
+
+CI 스타일 검증이 필요하면 아래 조합을 우선한다.
+
+```bash
+bash ./gradlew test check :app:bootJar --parallel --build-cache --continue --stacktrace
+```
+
+## 아키텍처 규칙
+
+- package는 기존 `cloud.luigi99.blog` 하위를 유지한다.
+- `app` module은 실행/조립 계층이다. 도메인 로직을 넣지 않는다.
+- `domain` module은 framework 독립을 유지한다.
+  - 허용: Kotlin, `libs/common` 도메인 원시 타입
+  - 금지: Spring annotation, JPA annotation, Redis, HTTP, storage SDK 직접 의존
+- application 계층은 use case와 port 중심으로 둔다.
+  - inbound: `application/port/in/...`
+  - outbound: `application/port/out/...`
+  - 구현: `application/service/...`
+- adapter 계층은 외부 기술을 담당한다.
+  - web controller/API DTO: `adapter/in/web`
+  - event listener: `adapter/in/event`
+  - JPA/Redis/storage/client 구현: `adapter/out/...`
+- 다른 bounded context를 직접 repository/entity로 참조하지 않는다. 필요한 경우 application port + adapter client 패턴을 따른다.
+- 여러 구현체가 있는 adapter bean name은 기존 명시 이름을 유지한다.
+  - 예: `postMemberClientAdapter`, `commentMemberClientAdapter`, `guestbookMemberClientAdapter`, `authMemberClientAdapter`
+- DB schema는 Flyway migration(`app/src/main/resources/db/migration`) 기준이다.
+  - entity 변경 시 migration 추가/수정 여부를 반드시 본다.
+  - Hibernate `ddl-auto: validate` 계열 설정이면 entity와 migration 불일치가 바로 장애가 된다.
+
+## 테스트/검증 기준
+
+- domain 값 객체/엔티티 변경: 해당 `domain/src/test` 추가 또는 수정
+- use case/service 변경: 해당 `application/src/test` 추가 또는 수정
+- controller/mapper/repository adapter 변경: 해당 adapter module 테스트 추가 또는 수정
+- DB/entity 변경: mapper + JPA mapping + Flyway migration + `:app:bootJar` 확인
+- auth/token 변경: Redis/JWT 설정명과 profile별 `application*.yml` 불일치 여부 확인
+
+최소 검증 기준:
+
+```txt
+작은 로직 변경: ./gradlew test
+빌드/설정/모듈 변경: ./gradlew clean build
+API/DB/env 영향 변경: ./gradlew check && ./gradlew :app:bootJar
+```
+
+실행 불가하면 “미실행”으로 넘기지 말고, 왜 못 했는지 로그 핵심을 남긴다.
+
+## 런타임/설정 주의
+
+기본 profile은 `application.yml` 기준 `local`이다. 하지만 local에서도 DB/R2/JWT 등 env가 필요할 수 있다.
+
+중요 env 후보:
+
+```txt
+DATABASE_URL
+DATABASE_USERNAME
+DATABASE_PASSWORD
+JWT_SECRET
+GITHUB_CLIENT_ID
+GITHUB_CLIENT_SECRET
+CLOUDFLARE_R2_ACCOUNT_ID
+CLOUDFLARE_R2_ACCESS_KEY_ID
+CLOUDFLARE_R2_SECRET_ACCESS_KEY
+CLOUDFLARE_R2_BUCKET_NAME
+CLOUDFLARE_R2_PUBLIC_URL
+REDIS_HOST
+REDIS_PORT
+REDIS_PASSWORD
+APP_COOKIE_SECURE
+APP_COOKIE_DOMAIN
+APP_COOKIE_SAME_SITE
+APP_REDIRECT_BASE_URL
+APP_REDIRECT_SUCCESS_END_POINT
+APP_REDIRECT_ERROR_END_POINT
+```
+
+Swagger/OpenAPI 경로 후보:
+
+```txt
+/swagger-ui.html
+/api-docs
+```
+
+## 리스크/금지사항
+
+- 오래된 문서(`CLAUDE.md`, 예전 README 등)만 믿고 구조를 바꾸지 않는다.
+- broad formatting, 대규모 package 이동, module 구조 개편은 명시 지시 없이는 하지 않는다.
+- Secret 값은 코드/문서/gitops에 직접 쓰지 않는다.
+- `kubectl apply`, 원격 배포, production DB 변경은 명시 지시 없이는 하지 않는다.
+- CI가 `app/Dockerfile`을 참조할 수 있으니 Docker 관련 작업 전 실제 파일 존재 여부를 확인한다.
+- docker-compose가 없을 수 있으므로 local DB/Redis는 별도 준비가 필요하다고 가정한다.
+- profile별 `jwt.*` 설정명이 다를 수 있으니 auth 설정 변경 전 실제 properties binding 코드를 확인한다.
+
+## 보고 형식
+
+Discord에서는 표 대신 아래처럼 보고한다.
+
+```txt
+변경 repo: server
+변경 요약:
+- ...
+
+검증:
+- ./gradlew test: PASS/FAIL/미실행(사유)
+- ./gradlew :app:bootJar: PASS/FAIL/미실행(사유)
+
+영향:
+- client: 있음/없음
+- gitops: 있음/없음
+
+리스크:
+- ...
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,41 +69,15 @@ cd /home/luigi/.hermes/profiles/boksili/home/workspace/kjyy08/luigi-log/server
 - client/API 계약 변경이 있으면 `../client` 영향도 같이 본다.
 - env, DB, Redis, 이미지/포트 변경은 `../gitops` 영향도 같이 본다.
 
-## 명령
+## 명령/검증 원칙
 
-```bash
-# 주의: gradlew 실행권한(mode)은 임의로 바꾸지 않는다.
-# 실행권한이 없는 repo 상태면 chmod 대신 bash ./gradlew ... 형태로 실행한다.
-
-# 전체 테스트
-bash ./gradlew test
-
-# 전체 검증
-bash ./gradlew check
-
-# 전체 빌드
-bash ./gradlew clean build
-
-# 실행 JAR 검증
-bash ./gradlew :app:bootJar
-
-# 로컬 실행
-bash ./gradlew :app:bootRun
-
-# 스타일
-bash ./gradlew ktlintCheck
-bash ./gradlew ktlintFormat
-
-# 커버리지
-bash ./gradlew koverHtmlReport
-bash ./gradlew koverVerify
-```
-
-CI 스타일 검증이 필요하면 아래 조합을 우선한다.
-
-```bash
-bash ./gradlew test check :app:bootJar --parallel --build-cache --continue --stacktrace
-```
+- 이 repo에서 서브에이전트는 로컬 Gradle 명령을 실행하지 않는다.
+- `./gradlew`, `bash ./gradlew`, `gradle`, `ktlint`, `bootRun`, `test`, `check`, `build`, `bootJar`, `kover*` 등 Gradle 기반 로컬 검증/실행은 금지한다.
+- 백엔드 검증은 branch push 후 GitHub PR CI 결과로 확인한다.
+- 로컬에서는 가벼운 git/file 확인만 수행한다.
+  - 예: `git status --short`, `git diff --check`, `git diff --stat`, 파일 내용 조회
+- `gradlew` 실행권한(mode)은 임의로 바꾸지 않는다. `chmod +x gradlew` 금지.
+- 사용자가 명시적으로 특정 Gradle 명령 실행을 승인한 경우에만 예외로 실행한다.
 
 ## 아키텍처 규칙
 
@@ -132,18 +106,19 @@ bash ./gradlew test check :app:bootJar --parallel --build-cache --continue --sta
 - domain 값 객체/엔티티 변경: 해당 `domain/src/test` 추가 또는 수정
 - use case/service 변경: 해당 `application/src/test` 추가 또는 수정
 - controller/mapper/repository adapter 변경: 해당 adapter module 테스트 추가 또는 수정
-- DB/entity 변경: mapper + JPA mapping + Flyway migration + `:app:bootJar` 확인
+- DB/entity 변경: mapper + JPA mapping + Flyway migration 정합성을 보고 PR CI에서 bootJar/build 결과를 확인한다.
 - auth/token 변경: Redis/JWT 설정명과 profile별 `application*.yml` 불일치 여부 확인
 
 최소 검증 기준:
 
 ```txt
-작은 로직 변경: ./gradlew test
-빌드/설정/모듈 변경: ./gradlew clean build
-API/DB/env 영향 변경: ./gradlew check && ./gradlew :app:bootJar
+기본: 로컬 Gradle 미실행, PR CI 결과 확인
+작은 로직 변경: 관련 테스트 추가/수정 후 PR CI로 확인
+빌드/설정/모듈 변경: PR CI의 build/test 결과로 확인
+API/DB/env 영향 변경: PR CI와 리뷰에서 migration/config 영향 확인
 ```
 
-실행 불가하면 “미실행”으로 넘기지 말고, 왜 못 했는지 로그 핵심을 남긴다.
+로컬에서 Gradle을 실행하지 못한 것을 단순 누락으로 처리하지 말고, 보고에는 “로컬 Gradle 미실행(리소스 보호 정책), PR CI로 확인”이라고 명시한다.
 
 ## 런타임/설정 주의
 
@@ -201,8 +176,8 @@ Discord에서는 표 대신 아래처럼 보고한다.
 - ...
 
 검증:
-- ./gradlew test: PASS/FAIL/미실행(사유)
-- ./gradlew :app:bootJar: PASS/FAIL/미실행(사유)
+- 로컬 Gradle: 미실행(리소스 보호 정책)
+- GitHub PR CI: PASS/FAIL/대기
 
 영향:
 - client: 있음/없음

--- a/app/src/main/resources/db/migration/V17__add_post_view_count.sql
+++ b/app/src/main/resources/db/migration/V17__add_post_view_count.sql
@@ -1,0 +1,2 @@
+ALTER TABLE post
+    ADD COLUMN view_count BIGINT NOT NULL DEFAULT 0;

--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostApi.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostApi.kt
@@ -2,6 +2,7 @@
 
 import cloud.luigi99.blog.adapter.web.dto.CommonResponse
 import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.CreatePostRequest
+import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.PostContributionsResponse
 import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.PostListResponse
 import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.PostResponse
 import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.UpdatePostRequest
@@ -19,6 +20,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
+import java.time.LocalDate
 
 /**
  * Post API 인터페이스
@@ -452,7 +454,17 @@ interface PostApi {
     fun getPosts(
         @Parameter(description = "상태 필터 (DRAFT, PUBLISHED, ARCHIVED)") @RequestParam(required = false) status: String?,
         @Parameter(description = "타입 필터 (BLOG, PORTFOLIO)") @RequestParam(required = false) type: String?,
+        @Parameter(description = "검색어 (title/body/tags)") @RequestParam(required = false) q: String?,
+        @Parameter(description = "페이지 크기 (기본 20, 최대 50)") @RequestParam(required = false) limit: Int?,
+        @Parameter(description = "커서") @RequestParam(required = false) cursor: String?,
     ): ResponseEntity<CommonResponse<PostListResponse>>
+
+    @Operation(summary = "게시글 잔디", description = "PUBLISHED 글을 created_at 기준 날짜별 count로 집계합니다.")
+    fun getPostContributions(
+        @Parameter(description = "시작일") @RequestParam(required = false) from: LocalDate?,
+        @Parameter(description = "종료일") @RequestParam(required = false) to: LocalDate?,
+        @Parameter(description = "타입 필터 (BLOG, PORTFOLIO)") @RequestParam(required = false) type: String?,
+    ): ResponseEntity<CommonResponse<PostContributionsResponse>>
 
     @Operation(
         summary = "블로그 글 삭제",

--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostController.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostController.kt
@@ -3,6 +3,9 @@
 import cloud.luigi99.blog.adapter.web.dto.CommonResponse
 import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.AuthorResponse
 import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.CreatePostRequest
+import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.PageInfoResponse
+import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.PostContributionDayResponse
+import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.PostContributionsResponse
 import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.PostListResponse
 import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.PostResponse
 import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.PostSummaryResponse
@@ -13,6 +16,7 @@ import cloud.luigi99.blog.content.post.application.port.`in`.command.PostCommand
 import cloud.luigi99.blog.content.post.application.port.`in`.command.UpdatePostUseCase
 import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostByIdUseCase
 import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostBySlugUseCase
+import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostContributionsUseCase
 import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostsUseCase
 import cloud.luigi99.blog.content.post.application.port.`in`.query.PostQueryFacade
 import mu.KotlinLogging
@@ -29,6 +33,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
 
 private val log = KotlinLogging.logger {}
 
@@ -157,6 +162,8 @@ class PostController(private val postQueryFacade: PostQueryFacade, private val p
                     type = response.type,
                     status = response.status,
                     tags = response.tags,
+                    viewCount = response.viewCount,
+                    commentCount = response.commentCount,
                     createdAt = response.createdAt,
                     updatedAt = response.updatedAt,
                 ),
@@ -191,6 +198,8 @@ class PostController(private val postQueryFacade: PostQueryFacade, private val p
                     type = response.type,
                     status = response.status,
                     tags = response.tags,
+                    viewCount = response.viewCount,
+                    commentCount = response.commentCount,
                     createdAt = response.createdAt,
                     updatedAt = response.updatedAt,
                 ),
@@ -202,10 +211,13 @@ class PostController(private val postQueryFacade: PostQueryFacade, private val p
     override fun getPosts(
         @RequestParam(required = false) status: String?,
         @RequestParam(required = false) type: String?,
+        @RequestParam(required = false) q: String?,
+        @RequestParam(required = false) limit: Int?,
+        @RequestParam(required = false) cursor: String?,
     ): ResponseEntity<CommonResponse<PostListResponse>> {
         log.info { "Listing posts with filters - status: $status, type: $type" }
 
-        val query = GetPostsUseCase.Query(status = status, type = type)
+        val query = GetPostsUseCase.Query(status = status, type = type, q = q, limit = limit, cursor = cursor)
         val response = postQueryFacade.getPosts().execute(query)
 
         val summaries =
@@ -224,6 +236,8 @@ class PostController(private val postQueryFacade: PostQueryFacade, private val p
                     type = post.type,
                     status = post.status,
                     tags = post.tags,
+                    viewCount = post.viewCount,
+                    commentCount = post.commentCount,
                     createdAt = post.createdAt,
                 )
             }
@@ -233,6 +247,35 @@ class PostController(private val postQueryFacade: PostQueryFacade, private val p
                 PostListResponse(
                     posts = summaries,
                     total = summaries.size,
+                    pageInfo =
+                        PageInfoResponse(
+                            response.pageInfo.limit,
+                            response.pageInfo.hasNext,
+                            response.pageInfo.nextCursor,
+                        ),
+                ),
+            ),
+        )
+    }
+
+    @GetMapping("/contributions")
+    override fun getPostContributions(
+        @RequestParam(required = false) from: LocalDate?,
+        @RequestParam(required = false) to: LocalDate?,
+        @RequestParam(required = false) type: String?,
+    ): ResponseEntity<CommonResponse<PostContributionsResponse>> {
+        val response =
+            postQueryFacade
+                .getPostContributions()
+                .execute(GetPostContributionsUseCase.Query(from = from, to = to, type = type))
+
+        return ResponseEntity.ok(
+            CommonResponse.success(
+                PostContributionsResponse(
+                    from = response.from,
+                    to = response.to,
+                    totalCount = response.totalCount,
+                    days = response.days.map { PostContributionDayResponse(it.date, it.count) },
                 ),
             ),
         )

--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/dto/PostContributionsResponse.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/dto/PostContributionsResponse.kt
@@ -1,0 +1,21 @@
+package cloud.luigi99.blog.content.post.adapter.`in`.web.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class PostContributionsResponse(
+    @field:Schema(description = "조회 시작일", example = "2025-01-01")
+    val from: String,
+    @field:Schema(description = "조회 종료일", example = "2025-12-31")
+    val to: String,
+    @field:Schema(description = "기간 내 발행 글 총 수", example = "42")
+    val totalCount: Int,
+    @field:Schema(description = "날짜별 발행 글 수")
+    val days: List<PostContributionDayResponse>,
+)
+
+data class PostContributionDayResponse(
+    @field:Schema(description = "날짜", example = "2025-01-01")
+    val date: String,
+    @field:Schema(description = "발행 글 수", example = "1")
+    val count: Int,
+)

--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/dto/PostListResponse.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/dto/PostListResponse.kt
@@ -10,4 +10,15 @@ data class PostListResponse(
     val posts: List<PostSummaryResponse>,
     @field:Schema(description = "총 개수", example = "42")
     val total: Int,
+    @field:Schema(description = "페이지 정보")
+    val pageInfo: PageInfoResponse = PageInfoResponse(limit = posts.size, hasNext = false, nextCursor = null),
+)
+
+data class PageInfoResponse(
+    @field:Schema(description = "요청/적용된 페이지 크기", example = "20")
+    val limit: Int,
+    @field:Schema(description = "다음 페이지 존재 여부", example = "true")
+    val hasNext: Boolean,
+    @field:Schema(description = "다음 페이지 커서")
+    val nextCursor: String?,
 )

--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/dto/PostResponse.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/dto/PostResponse.kt
@@ -23,6 +23,10 @@ data class PostResponse(
     val status: String,
     @field:Schema(description = "태그 목록", example = "[\"Kotlin\", \"DDD\"]")
     val tags: Set<String>,
+    @field:Schema(description = "조회수", example = "42")
+    val viewCount: Long = 0,
+    @field:Schema(description = "댓글 수", example = "3")
+    val commentCount: Long = 0,
     @field:Schema(description = "생성 시간", example = "2025-01-01T12:00:00")
     val createdAt: LocalDateTime?,
     @field:Schema(description = "수정 시간", example = "2025-01-01T13:00:00")

--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/dto/PostSummaryResponse.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/dto/PostSummaryResponse.kt
@@ -21,6 +21,10 @@ data class PostSummaryResponse(
     val status: String,
     @field:Schema(description = "태그 목록", example = "[\"Kotlin\", \"DDD\"]")
     val tags: Set<String>,
+    @field:Schema(description = "조회수", example = "42")
+    val viewCount: Long = 0,
+    @field:Schema(description = "댓글 수", example = "3")
+    val commentCount: Long = 0,
     @field:Schema(description = "생성 시간", example = "2025-01-01T12:00:00")
     val createdAt: LocalDateTime?,
 )

--- a/modules/content/post/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostControllerTest.kt
+++ b/modules/content/post/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostControllerTest.kt
@@ -240,6 +240,8 @@ class PostControllerTest :
                         type = "BLOG",
                         status = "PUBLISHED",
                         tags = setOf("Tag1"),
+                        viewCount = 0,
+                        commentCount = 0,
                         createdAt = LocalDateTime.now(),
                         updatedAt = LocalDateTime.now(),
                     )
@@ -287,6 +289,8 @@ class PostControllerTest :
                         type = "BLOG",
                         status = "PUBLISHED",
                         tags = setOf("Tag1"),
+                        viewCount = 0,
+                        commentCount = 0,
                         createdAt = LocalDateTime.now(),
                         updatedAt = LocalDateTime.now(),
                     )

--- a/modules/content/post/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostJpaEntity.kt
+++ b/modules/content/post/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostJpaEntity.kt
@@ -42,6 +42,8 @@ class PostJpaEntity private constructor(
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 50)
     var status: PostStatus,
+    @Column(name = "view_count", nullable = false)
+    val viewCount: Long = 0,
     @ElementCollection
     @CollectionTable(
         name = "post_tag",
@@ -65,6 +67,7 @@ class PostJpaEntity private constructor(
             body: String,
             type: ContentType,
             status: PostStatus,
+            viewCount: Long = 0,
         ): PostJpaEntity =
             PostJpaEntity(
                 id = entityId,
@@ -74,6 +77,7 @@ class PostJpaEntity private constructor(
                 body = body,
                 type = type,
                 status = status,
+                viewCount = viewCount,
             )
     }
 }

--- a/modules/content/post/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostJpaRepository.kt
+++ b/modules/content/post/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostJpaRepository.kt
@@ -3,9 +3,12 @@
 import cloud.luigi99.blog.content.post.domain.vo.ContentType
 import cloud.luigi99.blog.content.post.domain.vo.PostStatus
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.UUID
 
 /**
@@ -77,4 +80,84 @@ interface PostJpaRepository : JpaRepository<PostJpaEntity, UUID> {
         @Param("username") username: String,
         @Param("slug") slug: String,
     ): PostJpaEntity?
+
+    @Query(
+        """
+        SELECT DISTINCT p.* FROM post p
+        WHERE (:status IS NULL OR p.status = CAST(:status AS varchar))
+          AND (:type IS NULL OR p.type = CAST(:type AS varchar))
+          AND (:q IS NULL OR :q = '' OR lower(p.title) LIKE lower(concat('%', :q, '%'))
+            OR lower(p.body) LIKE lower(concat('%', :q, '%'))
+            OR EXISTS (SELECT 1 FROM post_tag pt WHERE pt.post_id = p.id AND lower(pt.tag_name) LIKE lower(concat('%', :q, '%'))))
+          AND (:cursorCreatedAt IS NULL OR p.created_at < :cursorCreatedAt OR (p.created_at = :cursorCreatedAt AND p.id < :cursorPostId))
+        ORDER BY p.created_at DESC, p.id DESC
+        LIMIT :limit
+        """,
+        nativeQuery = true,
+    )
+    fun search(
+        @Param("status") status: String?,
+        @Param("type") type: String?,
+        @Param("q") q: String?,
+        @Param("cursorCreatedAt") cursorCreatedAt: LocalDateTime?,
+        @Param("cursorPostId") cursorPostId: UUID?,
+        @Param("limit") limit: Int,
+    ): List<PostJpaEntity>
+
+    @Query(
+        """
+        SELECT c.post_id AS postId, COUNT(*) AS count
+        FROM comment c
+        WHERE c.post_id IN (:postIds)
+        GROUP BY c.post_id
+        """,
+        nativeQuery = true,
+    )
+    fun countCommentsByPostIds(
+        @Param("postIds") postIds: Collection<UUID>,
+    ): List<CommentCountRow>
+
+    @Query(
+        """
+        SELECT CAST(p.created_at AS date) AS date, COUNT(*) AS count
+        FROM post p
+        WHERE p.status = 'PUBLISHED'
+          AND p.created_at >= :fromDate
+          AND p.created_at < :toExclusive
+          AND (:type IS NULL OR p.type = CAST(:type AS varchar))
+        GROUP BY CAST(p.created_at AS date)
+        ORDER BY CAST(p.created_at AS date)
+        """,
+        nativeQuery = true,
+    )
+    fun contributions(
+        @Param("fromDate") fromDate: LocalDateTime,
+        @Param("toExclusive") toExclusive: LocalDateTime,
+        @Param("type") type: String?,
+    ): List<ContributionRow>
+
+    @Modifying(clearAutomatically = false, flushAutomatically = false)
+    @Query(
+        """
+        UPDATE post
+        SET view_count = view_count + 1
+        WHERE id = :postId
+        """,
+        nativeQuery = true,
+    )
+    fun incrementViewCount(
+        @Param("postId") postId: UUID,
+    ): Int
+
+    interface CommentCountRow {
+        fun getPostId(): UUID
+
+        fun getCount(): Long
+    }
+
+    interface ContributionRow {
+        fun getDate(): LocalDate
+
+        fun getCount(): Long
+    }
 }

--- a/modules/content/post/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostMapper.kt
+++ b/modules/content/post/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostMapper.kt
@@ -26,6 +26,7 @@ object PostMapper {
             type = entity.type,
             status = entity.status,
             tags = entity.tags.toSet(),
+            viewCount = entity.viewCount,
             createdAt = entity.createdAt,
             updatedAt = entity.updatedAt,
         )
@@ -44,6 +45,7 @@ object PostMapper {
                     body = post.body.value,
                     type = post.type,
                     status = post.status,
+                    viewCount = post.viewCount,
                 ).apply {
                     createdAt = post.createdAt
                     updatedAt = post.updatedAt

--- a/modules/content/post/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostRepositoryAdapter.kt
+++ b/modules/content/post/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostRepositoryAdapter.kt
@@ -11,6 +11,7 @@ import cloud.luigi99.blog.content.post.domain.vo.Slug
 import cloud.luigi99.blog.member.domain.member.vo.MemberId
 import mu.KotlinLogging
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
 
 private val log = KotlinLogging.logger {}
 
@@ -124,6 +125,43 @@ class PostRepositoryAdapter(
         log.debug { "Finding all posts" }
         return jpaRepository.findAll().map { PostMapper.toDomain(it) }
     }
+
+    override fun search(
+        status: PostStatus?,
+        type: ContentType?,
+        q: String?,
+        limit: Int,
+        cursor: PostRepository.PostCursor?,
+    ): PostRepository.PostListResult {
+        val rows =
+            jpaRepository.search(
+                status = status?.name,
+                type = type?.name,
+                q = q?.trim()?.takeIf { it.isNotEmpty() },
+                cursorCreatedAt = cursor?.createdAt,
+                cursorPostId = cursor?.postId?.value,
+                limit = limit + 1,
+            )
+        return PostRepository.PostListResult(rows.take(limit).map { PostMapper.toDomain(it) }, rows.size > limit)
+    }
+
+    override fun countCommentsByPostIds(postIds: Collection<PostId>): Map<PostId, Long> {
+        if (postIds.isEmpty()) return emptyMap()
+        return jpaRepository
+            .countCommentsByPostIds(postIds.map { it.value })
+            .associate { PostId(it.getPostId()) to it.getCount() }
+    }
+
+    override fun contributions(
+        from: LocalDate,
+        to: LocalDate,
+        type: ContentType?,
+    ): List<PostRepository.PostContribution> =
+        jpaRepository
+            .contributions(from.atStartOfDay(), to.plusDays(1).atStartOfDay(), type?.name)
+            .map { PostRepository.PostContribution(it.getDate(), it.getCount().toInt()) }
+
+    override fun incrementViewCount(postId: PostId): Int = jpaRepository.incrementViewCount(postId.value)
 
     /**
      * ID로 Post를 삭제합니다.

--- a/modules/content/post/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostRepositoryAdapterTest.kt
+++ b/modules/content/post/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostRepositoryAdapterTest.kt
@@ -209,6 +209,25 @@ class PostRepositoryAdapterTest :
             }
         }
 
+        Given("조회수를 증가시킬 때") {
+            val jpaRepository = mockk<PostJpaRepository>()
+            val eventContextManager = mockk<EventContextManager>()
+            val domainEventPublisher = mockk<DomainEventPublisher>()
+            val adapter = PostRepositoryAdapter(jpaRepository, eventContextManager, domainEventPublisher)
+            val postId = PostId.generate()
+
+            When("조회수 증가를 요청하면") {
+                every { jpaRepository.incrementViewCount(postId.value) } returns 1
+
+                val updatedRows = adapter.incrementViewCount(postId)
+
+                Then("JPA atomic update를 호출하고 업데이트 row 수를 반환한다") {
+                    updatedRows shouldBe 1
+                    verify(exactly = 1) { jpaRepository.incrementViewCount(postId.value) }
+                }
+            }
+        }
+
         Given("상태별로 Post 목록을 조회할 때") {
             val jpaRepository = mockk<PostJpaRepository>()
             val eventContextManager = mockk<EventContextManager>()

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/in/query/GetPostByIdUseCase.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/in/query/GetPostByIdUseCase.kt
@@ -46,6 +46,8 @@ interface GetPostByIdUseCase {
         val type: String,
         val status: String,
         val tags: Set<String>,
+        val viewCount: Long,
+        val commentCount: Long,
         val createdAt: LocalDateTime?,
         val updatedAt: LocalDateTime?,
     )

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/in/query/GetPostBySlugUseCase.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/in/query/GetPostBySlugUseCase.kt
@@ -47,6 +47,8 @@ interface GetPostBySlugUseCase {
         val type: String,
         val status: String,
         val tags: Set<String>,
+        val viewCount: Long,
+        val commentCount: Long,
         val createdAt: LocalDateTime?,
         val updatedAt: LocalDateTime?,
     )

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/in/query/GetPostContributionsUseCase.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/in/query/GetPostContributionsUseCase.kt
@@ -1,0 +1,18 @@
+package cloud.luigi99.blog.content.post.application.port.`in`.query
+
+import java.time.LocalDate
+
+interface GetPostContributionsUseCase {
+    fun execute(query: Query): Response
+
+    data class Query(val from: LocalDate? = null, val to: LocalDate? = null, val type: String? = null)
+
+    data class Response(
+        val from: String,
+        val to: String,
+        val totalCount: Int,
+        val days: List<Day>,
+    )
+
+    data class Day(val date: String, val count: Int)
+}

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/in/query/GetPostsUseCase.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/in/query/GetPostsUseCase.kt
@@ -22,14 +22,22 @@ interface GetPostsUseCase {
      * @property status 상태 필터 (null이면 전체)
      * @property type 컨텐츠 타입 필터 (null이면 전체)
      */
-    data class Query(val status: String? = null, val type: String? = null)
+    data class Query(
+        val status: String? = null,
+        val type: String? = null,
+        val q: String? = null,
+        val limit: Int? = null,
+        val cursor: String? = null,
+    )
 
     /**
      * Post 목록 조회 응답
      *
      * @property posts Post 목록
      */
-    data class Response(val posts: List<PostSummary>)
+    data class Response(val posts: List<PostSummary>, val pageInfo: PageInfo)
+
+    data class PageInfo(val limit: Int, val hasNext: Boolean, val nextCursor: String?)
 
     /**
      * Post 요약 정보
@@ -51,6 +59,8 @@ interface GetPostsUseCase {
         val type: String,
         val status: String,
         val tags: Set<String>,
+        val viewCount: Long,
+        val commentCount: Long,
         val createdAt: LocalDateTime?,
     )
 

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/in/query/PostQueryFacade.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/in/query/PostQueryFacade.kt
@@ -20,4 +20,6 @@ interface PostQueryFacade {
      * Post 목록 조회 UseCase를 반환합니다.
      */
     fun getPosts(): GetPostsUseCase
+
+    fun getPostContributions(): GetPostContributionsUseCase
 }

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/out/PostRepository.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/out/PostRepository.kt
@@ -7,6 +7,8 @@ import cloud.luigi99.blog.content.post.domain.vo.PostId
 import cloud.luigi99.blog.content.post.domain.vo.PostStatus
 import cloud.luigi99.blog.content.post.domain.vo.Slug
 import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 /**
  * Post Repository Port
@@ -79,4 +81,24 @@ interface PostRepository : Repository<Post, PostId> {
      * @return Post 목록
      */
     fun findAll(): List<Post>
+
+    fun search(
+        status: PostStatus?,
+        type: ContentType?,
+        q: String?,
+        limit: Int,
+        cursor: PostCursor?,
+    ): PostListResult
+
+    fun countCommentsByPostIds(postIds: Collection<PostId>): Map<PostId, Long>
+
+    fun contributions(from: LocalDate, to: LocalDate, type: ContentType?): List<PostContribution>
+
+    fun incrementViewCount(postId: PostId): Int
+
+    data class PostCursor(val createdAt: LocalDateTime, val postId: PostId)
+
+    data class PostListResult(val posts: List<Post>, val hasNext: Boolean)
+
+    data class PostContribution(val date: LocalDate, val count: Int)
 }

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostByIdService.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostByIdService.kt
@@ -20,7 +20,7 @@ private val log = KotlinLogging.logger {}
 @Service
 class GetPostByIdService(private val postRepository: PostRepository, private val memberClient: MemberClient) :
     GetPostByIdUseCase {
-    @Transactional(readOnly = true)
+    @Transactional
     override fun execute(query: GetPostByIdUseCase.Query): GetPostByIdUseCase.Response {
         log.info { "Getting post by id: ${query.postId}" }
 
@@ -28,6 +28,9 @@ class GetPostByIdService(private val postRepository: PostRepository, private val
         val post =
             postRepository.findById(postId)
                 ?: throw PostNotFoundException("Post ID ${query.postId}를 찾을 수 없습니다")
+        postRepository.incrementViewCount(post.entityId)
+        post.incrementViewCount()
+        val commentCount = postRepository.countCommentsByPostIds(listOf(post.entityId))[post.entityId] ?: 0
 
         val author =
             memberClient.getAuthor(
@@ -52,6 +55,8 @@ class GetPostByIdService(private val postRepository: PostRepository, private val
             type = post.type.name,
             status = post.status.name,
             tags = post.tags,
+            viewCount = post.viewCount,
+            commentCount = commentCount,
             createdAt = post.createdAt,
             updatedAt = post.updatedAt,
         )

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugService.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugService.kt
@@ -19,7 +19,7 @@ private val log = KotlinLogging.logger {}
 @Service
 class GetPostBySlugService(private val postRepository: PostRepository, private val memberClient: MemberClient) :
     GetPostBySlugUseCase {
-    @Transactional(readOnly = true)
+    @Transactional
     override fun execute(query: GetPostBySlugUseCase.Query): GetPostBySlugUseCase.Response {
         log.info { "Getting post by username: ${query.username}, slug: ${query.slug}" }
 
@@ -29,6 +29,9 @@ class GetPostBySlugService(private val postRepository: PostRepository, private v
                 ?: throw PostNotFoundException(
                     "사용자 '${query.username}'의 Slug '${query.slug}'에 해당하는 Post를 찾을 수 없습니다",
                 )
+        postRepository.incrementViewCount(post.entityId)
+        post.incrementViewCount()
+        val commentCount = postRepository.countCommentsByPostIds(listOf(post.entityId))[post.entityId] ?: 0
 
         val author =
             memberClient.getAuthor(
@@ -53,6 +56,8 @@ class GetPostBySlugService(private val postRepository: PostRepository, private v
             type = post.type.name,
             status = post.status.name,
             tags = post.tags,
+            viewCount = post.viewCount,
+            commentCount = commentCount,
             createdAt = post.createdAt,
             updatedAt = post.updatedAt,
         )

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostContributionsService.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostContributionsService.kt
@@ -1,0 +1,50 @@
+package cloud.luigi99.blog.content.post.application.service.query
+
+import cloud.luigi99.blog.common.exception.BusinessException
+import cloud.luigi99.blog.common.exception.ErrorCode
+import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostContributionsUseCase
+import cloud.luigi99.blog.content.post.application.port.out.PostRepository
+import cloud.luigi99.blog.content.post.domain.vo.ContentType
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Service
+class GetPostContributionsService(private val postRepository: PostRepository) : GetPostContributionsUseCase {
+    @Transactional(readOnly = true)
+    override fun execute(query: GetPostContributionsUseCase.Query): GetPostContributionsUseCase.Response {
+        val to = query.to ?: LocalDate.now()
+        val from = query.from ?: to.minusDays(364)
+        if (from.isAfter(to)) {
+            throw InvalidPostContributionsQueryException("from must be before or equal to to")
+        }
+
+        val type = query.type?.let { parseContentType(it) }
+        val counts = postRepository.contributions(from, to, type).associate { it.date to it.count }
+        val days =
+            generateSequence(from) { date -> date.plusDays(1).takeIf { !it.isAfter(to) } }
+                .map { date -> GetPostContributionsUseCase.Day(date.toString(), counts[date] ?: 0) }
+                .toList()
+
+        return GetPostContributionsUseCase.Response(
+            from = from.toString(),
+            to = to.toString(),
+            totalCount = days.sumOf { it.count },
+            days = days,
+        )
+    }
+
+    private fun parseContentType(value: String): ContentType =
+        try {
+            ContentType.valueOf(value)
+        } catch (e: IllegalArgumentException) {
+            throw InvalidPostContributionsQueryException("Invalid type: $value", e)
+        }
+}
+
+private class InvalidPostContributionsQueryException(message: String, cause: Throwable? = null) :
+    BusinessException(ErrorCode.INVALID_INPUT, message) {
+    init {
+        if (cause != null) initCause(cause)
+    }
+}

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostsService.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostsService.kt
@@ -1,53 +1,40 @@
-﻿package cloud.luigi99.blog.content.post.application.service.query
+package cloud.luigi99.blog.content.post.application.service.query
 
+import cloud.luigi99.blog.common.exception.BusinessException
+import cloud.luigi99.blog.common.exception.ErrorCode
 import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostsUseCase
 import cloud.luigi99.blog.content.post.application.port.out.MemberClient
 import cloud.luigi99.blog.content.post.application.port.out.PostRepository
 import cloud.luigi99.blog.content.post.domain.vo.ContentType
+import cloud.luigi99.blog.content.post.domain.vo.PostId
 import cloud.luigi99.blog.content.post.domain.vo.PostStatus
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.nio.charset.StandardCharsets
+import java.time.LocalDateTime
+import java.util.Base64
+import java.util.UUID
 
 private val log = KotlinLogging.logger {}
 
-/**
- * Post 목록 조회 유스케이스 구현체
- *
- * 필터링 조건에 따라 Post 목록을 조회합니다.
- */
 @Service
 class GetPostsService(private val postRepository: PostRepository, private val memberClient: MemberClient) :
     GetPostsUseCase {
     @Transactional(readOnly = true)
     override fun execute(query: GetPostsUseCase.Query): GetPostsUseCase.Response {
-        log.info { "Listing posts with filters - status: ${query.status}, type: ${query.type}" }
+        val limit = query.limit?.coerceIn(1, 50) ?: 20
+        val status = query.status?.let { parseEnum<PostStatus>(it, "status") }
+        val type = query.type?.let { parseEnum<ContentType>(it, "type") }
+        val cursor = query.cursor?.let { decodeCursor(it) }
 
-        val posts =
-            when {
-                query.status != null && query.type != null -> {
-                    val status = PostStatus.valueOf(query.status)
-                    val type = ContentType.valueOf(query.type)
-                    postRepository
-                        .findAllByStatus(status)
-                        .filter { it.type == type }
-                }
+        log.info {
+            "Listing posts with filters - status: ${query.status}, type: ${query.type}, q: ${query.q}, limit: $limit"
+        }
 
-                query.status != null -> {
-                    val status = PostStatus.valueOf(query.status)
-                    postRepository.findAllByStatus(status)
-                }
-
-                query.type != null -> {
-                    val type = ContentType.valueOf(query.type)
-                    postRepository.findAllByContentType(type)
-                }
-
-                else -> {
-                    postRepository.findAll()
-                }
-            }
-
+        val result = postRepository.search(status, type, query.q, limit, cursor)
+        val posts = result.posts
+        val commentCounts = postRepository.countCommentsByPostIds(posts.map { it.entityId })
         val memberIds =
             posts
                 .map {
@@ -79,12 +66,59 @@ class GetPostsService(private val postRepository: PostRepository, private val me
                     type = post.type.name,
                     status = post.status.name,
                     tags = post.tags,
+                    viewCount = post.viewCount,
+                    commentCount = commentCounts[post.entityId] ?: 0,
                     createdAt = post.createdAt,
                 )
             }
 
-        log.info { "Found ${summaries.size} posts" }
+        return GetPostsUseCase.Response(
+            posts = summaries,
+            pageInfo =
+                GetPostsUseCase.PageInfo(
+                    limit = limit,
+                    hasNext = result.hasNext,
+                    nextCursor =
+                        summaries.lastOrNull()?.takeIf { result.hasNext }?.let {
+                            encodeCursor(
+                                it.createdAt,
+                                it.postId,
+                            )
+                        },
+                ),
+        )
+    }
 
-        return GetPostsUseCase.Response(posts = summaries)
+    private fun encodeCursor(createdAt: LocalDateTime?, postId: String): String? {
+        if (createdAt == null) return null
+        val raw = "$createdAt|$postId"
+        return Base64
+            .getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(raw.toByteArray(StandardCharsets.UTF_8))
+    }
+
+    private inline fun <reified T : Enum<T>> parseEnum(value: String, fieldName: String): T =
+        try {
+            enumValueOf<T>(value)
+        } catch (e: IllegalArgumentException) {
+            throw InvalidPostQueryException("Invalid $fieldName: $value", e)
+        }
+
+    private fun decodeCursor(cursor: String): PostRepository.PostCursor =
+        try {
+            val raw = String(Base64.getUrlDecoder().decode(cursor), StandardCharsets.UTF_8)
+            val parts = raw.split("|", limit = 2)
+            require(parts.size == 2) { "Invalid cursor" }
+            PostRepository.PostCursor(LocalDateTime.parse(parts[0]), PostId(UUID.fromString(parts[1])))
+        } catch (e: RuntimeException) {
+            throw InvalidPostQueryException("Invalid cursor", e)
+        }
+}
+
+private class InvalidPostQueryException(message: String, cause: Throwable? = null) :
+    BusinessException(ErrorCode.INVALID_INPUT, message) {
+    init {
+        if (cause != null) initCause(cause)
     }
 }

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/query/PostQueryService.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/query/PostQueryService.kt
@@ -2,6 +2,7 @@
 
 import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostByIdUseCase
 import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostBySlugUseCase
+import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostContributionsUseCase
 import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostsUseCase
 import cloud.luigi99.blog.content.post.application.port.`in`.query.PostQueryFacade
 import org.springframework.stereotype.Service
@@ -16,10 +17,13 @@ class PostQueryService(
     private val getPostBySlugUseCase: GetPostBySlugUseCase,
     private val getPostByIdUseCase: GetPostByIdUseCase,
     private val getPostsUseCase: GetPostsUseCase,
+    private val getPostContributionsUseCase: GetPostContributionsUseCase,
 ) : PostQueryFacade {
     override fun getPostBySlug(): GetPostBySlugUseCase = getPostBySlugUseCase
 
     override fun getPostById(): GetPostByIdUseCase = getPostByIdUseCase
 
     override fun getPosts(): GetPostsUseCase = getPostsUseCase
+
+    override fun getPostContributions(): GetPostContributionsUseCase = getPostContributionsUseCase
 }

--- a/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostByIdServiceTest.kt
+++ b/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostByIdServiceTest.kt
@@ -18,6 +18,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.verify
 import java.util.UUID
 
 /**
@@ -37,9 +38,6 @@ class GetPostByIdServiceTest :
             val service = GetPostByIdService(postRepository, memberClient)
 
             When("존재하는 Post ID로 조회하면") {
-                val postId = PostId.generate()
-                val query = GetPostByIdUseCase.Query(postId = postId.value.toString())
-
                 val post =
                     Post.create(
                         memberId = MemberId.generate(),
@@ -48,8 +46,13 @@ class GetPostByIdServiceTest :
                         body = Body("테스트 내용"),
                         type = ContentType.BLOG,
                     )
+                val postId = post.entityId
+                val query = GetPostByIdUseCase.Query(postId = postId.value.toString())
 
                 every { postRepository.findById(postId) } returns post
+
+                every { postRepository.incrementViewCount(postId) } returns 1
+                every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
                 every { memberClient.getAuthor(any()) } returns
                     MemberClient.Author(
                         memberId =
@@ -68,6 +71,12 @@ class GetPostByIdServiceTest :
 
                 Then("본문이 반환된다") {
                     response.body shouldBe "테스트 내용"
+                }
+
+                Then("조회수는 full aggregate save 없이 atomic increment로 증가한다") {
+                    response.viewCount shouldBe 1
+                    verify(exactly = 1) { postRepository.incrementViewCount(postId) }
+                    verify(exactly = 0) { postRepository.save(any()) }
                 }
             }
         }

--- a/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugServiceTest.kt
+++ b/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugServiceTest.kt
@@ -17,6 +17,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.verify
 
 /**
  * GetPostBySlugService 테스트
@@ -51,6 +52,8 @@ class GetPostBySlugServiceTest :
                 // MemberClient 호출 모킹 제거
                 // findByUsernameAndSlug 모킹 추가
                 every { postRepository.findByUsernameAndSlug("testuser", Slug("test-post")) } returns post
+                every { postRepository.incrementViewCount(post.entityId) } returns 1
+                every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
                 every { memberClient.getAuthor(any()) } returns
                     MemberClient.Author(
                         memberId = memberId.value.toString(),
@@ -71,6 +74,12 @@ class GetPostBySlugServiceTest :
 
                 Then("본문이 반환된다") {
                     response.body shouldBe "테스트 내용"
+                }
+
+                Then("조회수는 full aggregate save 없이 atomic increment로 증가한다") {
+                    response.viewCount shouldBe 1
+                    verify(exactly = 1) { postRepository.incrementViewCount(post.entityId) }
+                    verify(exactly = 0) { postRepository.save(any()) }
                 }
             }
         }

--- a/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostContributionsServiceTest.kt
+++ b/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostContributionsServiceTest.kt
@@ -1,0 +1,44 @@
+package cloud.luigi99.blog.content.post.application.service.query
+
+import cloud.luigi99.blog.common.exception.BusinessException
+import cloud.luigi99.blog.common.exception.ErrorCode
+import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostContributionsUseCase
+import cloud.luigi99.blog.content.post.application.port.out.PostRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import java.time.LocalDate
+
+class GetPostContributionsServiceTest :
+    BehaviorSpec({
+        Given("잘못된 기여도 조회 파라미터로 조회할 때") {
+            val postRepository = mockk<PostRepository>(relaxed = true)
+            val service = GetPostContributionsService(postRepository)
+
+            When("from이 to보다 늦으면") {
+                Then("INVALID_INPUT BusinessException이 발생한다") {
+                    val exception =
+                        shouldThrow<BusinessException> {
+                            service.execute(
+                                GetPostContributionsUseCase.Query(
+                                    from = LocalDate.parse("2026-04-24"),
+                                    to = LocalDate.parse("2026-04-01"),
+                                ),
+                            )
+                        }
+                    exception.errorCode shouldBe ErrorCode.INVALID_INPUT
+                }
+            }
+
+            When("존재하지 않는 type 값이면") {
+                Then("INVALID_INPUT BusinessException이 발생한다") {
+                    val exception =
+                        shouldThrow<BusinessException> {
+                            service.execute(GetPostContributionsUseCase.Query(type = "INVALID"))
+                        }
+                    exception.errorCode shouldBe ErrorCode.INVALID_INPUT
+                }
+            }
+        }
+    })

--- a/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostsServiceTest.kt
+++ b/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostsServiceTest.kt
@@ -1,6 +1,8 @@
 ﻿package cloud.luigi99.blog.content.post.application.service.query
 
 import cloud.luigi99.blog.common.domain.event.EventManager
+import cloud.luigi99.blog.common.exception.BusinessException
+import cloud.luigi99.blog.common.exception.ErrorCode
 import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostsUseCase
 import cloud.luigi99.blog.content.post.application.port.out.MemberClient
 import cloud.luigi99.blog.content.post.application.port.out.PostRepository
@@ -11,6 +13,7 @@ import cloud.luigi99.blog.content.post.domain.vo.PostStatus
 import cloud.luigi99.blog.content.post.domain.vo.Slug
 import cloud.luigi99.blog.content.post.domain.vo.Title
 import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -55,6 +58,9 @@ class GetPostsServiceTest :
                     )
 
                 every { postRepository.findAll() } returns posts
+                every { postRepository.search(null, null, null, 20, null) } returns
+                    PostRepository.PostListResult(posts, false)
+                every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
                 every { memberClient.getAuthors(any()) } returns emptyMap()
 
                 val response = service.execute(query)
@@ -92,6 +98,9 @@ class GetPostsServiceTest :
                     )
 
                 every { postRepository.findAllByStatus(PostStatus.PUBLISHED) } returns publishedPosts
+                every { postRepository.search(PostStatus.PUBLISHED, null, null, 20, null) } returns
+                    PostRepository.PostListResult(publishedPosts, false)
+                every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
                 every { memberClient.getAuthors(any()) } returns emptyMap()
 
                 val response = service.execute(query)
@@ -122,12 +131,50 @@ class GetPostsServiceTest :
                     )
 
                 every { postRepository.findAllByContentType(ContentType.PORTFOLIO) } returns portfolioPosts
+                every { postRepository.search(null, ContentType.PORTFOLIO, null, 20, null) } returns
+                    PostRepository.PostListResult(portfolioPosts, false)
+                every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
                 every { memberClient.getAuthors(any()) } returns emptyMap()
 
                 val response = service.execute(query)
 
                 Then("PORTFOLIO 글만 반환된다") {
                     response.posts.size shouldBe 1
+                }
+            }
+        }
+        Given("잘못된 목록 조회 파라미터로 글 목록을 조회할 때") {
+            val postRepository = mockk<PostRepository>(relaxed = true)
+            val memberClient = mockk<MemberClient>(relaxed = true)
+            val service = GetPostsService(postRepository, memberClient)
+
+            When("존재하지 않는 status 값이면") {
+                Then("INVALID_INPUT BusinessException이 발생한다") {
+                    val exception =
+                        shouldThrow<BusinessException> {
+                            service.execute(GetPostsUseCase.Query(status = "INVALID"))
+                        }
+                    exception.errorCode shouldBe ErrorCode.INVALID_INPUT
+                }
+            }
+
+            When("존재하지 않는 type 값이면") {
+                Then("INVALID_INPUT BusinessException이 발생한다") {
+                    val exception =
+                        shouldThrow<BusinessException> {
+                            service.execute(GetPostsUseCase.Query(type = "INVALID"))
+                        }
+                    exception.errorCode shouldBe ErrorCode.INVALID_INPUT
+                }
+            }
+
+            When("디코딩할 수 없는 cursor 값이면") {
+                Then("INVALID_INPUT BusinessException이 발생한다") {
+                    val exception =
+                        shouldThrow<BusinessException> {
+                            service.execute(GetPostsUseCase.Query(cursor = "not-a-valid-cursor"))
+                        }
+                    exception.errorCode shouldBe ErrorCode.INVALID_INPUT
                 }
             }
         }

--- a/modules/content/post/domain/src/main/kotlin/cloud/luigi99/blog/content/post/domain/model/Post.kt
+++ b/modules/content/post/domain/src/main/kotlin/cloud/luigi99/blog/content/post/domain/model/Post.kt
@@ -37,6 +37,7 @@ class Post private constructor(
     val type: ContentType,
     status: PostStatus,
     tags: Set<String>,
+    viewCount: Long,
 ) : AggregateRoot<PostId>() {
     var title: Title = title
         private set
@@ -48,6 +49,9 @@ class Post private constructor(
         private set
 
     var tags: Set<String> = tags.toSet()
+        private set
+
+    var viewCount: Long = viewCount
         private set
 
     companion object {
@@ -80,6 +84,7 @@ class Post private constructor(
                     type = type,
                     status = PostStatus.DRAFT,
                     tags = emptySet(),
+                    viewCount = 0,
                 )
 
             post.registerEvent(PostCreatedEvent(post.entityId, post.slug))
@@ -110,6 +115,7 @@ class Post private constructor(
             type: ContentType,
             status: PostStatus,
             tags: Set<String>,
+            viewCount: Long = 0,
             createdAt: LocalDateTime?,
             updatedAt: LocalDateTime?,
         ): Post {
@@ -123,6 +129,7 @@ class Post private constructor(
                     type = type,
                     status = status,
                     tags = tags,
+                    viewCount = viewCount,
                 )
             post.createdAt = createdAt
             post.updatedAt = updatedAt
@@ -184,6 +191,11 @@ class Post private constructor(
     fun update(newTitle: Title, newBody: Body): Post {
         this.title = newTitle
         this.body = newBody
+        return this
+    }
+
+    fun incrementViewCount(): Post {
+        this.viewCount += 1
         return this
     }
 

--- a/modules/content/post/domain/src/test/kotlin/cloud/luigi99/blog/content/post/domain/model/PostTest.kt
+++ b/modules/content/post/domain/src/test/kotlin/cloud/luigi99/blog/content/post/domain/model/PostTest.kt
@@ -339,6 +339,32 @@ class PostTest :
             }
         }
 
+        Given("조회수가 있는 Post가 주어졌을 때") {
+            val post =
+                Post.from(
+                    entityId = PostId.generate(),
+                    memberId = MemberId.generate(),
+                    title = Title("조회수 테스트"),
+                    slug = Slug("view-count-test"),
+                    body = Body("내용"),
+                    type = ContentType.BLOG,
+                    status = PostStatus.PUBLISHED,
+                    tags = emptySet(),
+                    viewCount = 41,
+                    createdAt = LocalDateTime.now(),
+                    updatedAt = LocalDateTime.now(),
+                )
+
+            When("조회수를 증가시키면") {
+                val viewed = post.incrementViewCount()
+
+                Then("조회수가 1 증가하고 현재 인스턴스가 반환된다") {
+                    viewed shouldBeSameInstanceAs post
+                    viewed.viewCount shouldBe 42
+                }
+            }
+        }
+
         Given("작성자가 게시글을 삭제하려는 상황에서") {
             val post =
                 Post.create(


### PR DESCRIPTION
## 📋 개요
- 공개 포스트 탐색 API를 추가했어.
- 포스트 목록 검색/필터, 기여도 조회, 조회수 증가 필드를 백엔드 계약에 반영했어.
- `post.view_count` 마이그레이션과 관련 persistence/application/domain 테스트를 추가했어.
- `AGENTS.md`를 포함했고, 로컬 `gradlew` 권한 변경을 남기지 않도록 `bash ./gradlew ...` 가이드를 반영했어.

## 🔗 관련 이슈
- Closes #

## ☑️ 체크리스트
- [x] 코딩 컨벤션을 준수했나요? (`./gradlew ktlintCheck`) — 로컬 Gradle 미실행, CI에서 확인 예정
- [x] 모든 테스트를 통과했나요? (`./gradlew test`) — 로컬 Gradle 미실행, CI에서 확인 예정
- [x] 불필요한 주석이나 로그는 제거했나요?

## 🧪 확인
- 로컬 Gradle 실행 안 함. 머신 리소스 이슈 때문에 PR CI 결과로 확인.
- 로컬에서는 `git diff --check`만 확인.
