### PR TITLE
fix(post): 게시글 목록 조회 null 바인딩 오류 수정

### DIFF
--- a/modules/content/post/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostJpaRepository.kt
+++ b/modules/content/post/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostJpaRepository.kt
@@ -84,12 +84,20 @@ interface PostJpaRepository : JpaRepository<PostJpaEntity, UUID> {
     @Query(
         """
         SELECT DISTINCT p.* FROM post p
-        WHERE (:status IS NULL OR p.status = CAST(:status AS varchar))
-          AND (:type IS NULL OR p.type = CAST(:type AS varchar))
-          AND (:q IS NULL OR :q = '' OR lower(p.title) LIKE lower(concat('%', :q, '%'))
-            OR lower(p.body) LIKE lower(concat('%', :q, '%'))
-            OR EXISTS (SELECT 1 FROM post_tag pt WHERE pt.post_id = p.id AND lower(pt.tag_name) LIKE lower(concat('%', :q, '%'))))
-          AND (:cursorCreatedAt IS NULL OR p.created_at < :cursorCreatedAt OR (p.created_at = :cursorCreatedAt AND p.id < :cursorPostId))
+        WHERE (:statusFilterEnabled = false OR p.status = CAST(:status AS varchar))
+          AND (:typeFilterEnabled = false OR p.type = CAST(:type AS varchar))
+          AND (:qFilterEnabled = false OR lower(p.title) LIKE lower(concat('%', CAST(:q AS varchar), '%'))
+            OR lower(p.body) LIKE lower(concat('%', CAST(:q AS varchar), '%'))
+            OR EXISTS (
+                SELECT 1 FROM post_tag pt
+                WHERE pt.post_id = p.id
+                  AND lower(pt.tag_name) LIKE lower(concat('%', CAST(:q AS varchar), '%'))
+            ))
+          AND (
+            :cursorFilterEnabled = false
+            OR p.created_at < :cursorCreatedAt
+            OR (p.created_at = :cursorCreatedAt AND p.id < :cursorPostId)
+          )
         ORDER BY p.created_at DESC, p.id DESC
         LIMIT :limit
         """,
@@ -101,6 +109,10 @@ interface PostJpaRepository : JpaRepository<PostJpaEntity, UUID> {
         @Param("q") q: String?,
         @Param("cursorCreatedAt") cursorCreatedAt: LocalDateTime?,
         @Param("cursorPostId") cursorPostId: UUID?,
+        @Param("statusFilterEnabled") statusFilterEnabled: Boolean,
+        @Param("typeFilterEnabled") typeFilterEnabled: Boolean,
+        @Param("qFilterEnabled") qFilterEnabled: Boolean,
+        @Param("cursorFilterEnabled") cursorFilterEnabled: Boolean,
         @Param("limit") limit: Int,
     ): List<PostJpaEntity>
 

--- a/modules/content/post/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostRepositoryAdapter.kt
+++ b/modules/content/post/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostRepositoryAdapter.kt
@@ -133,13 +133,18 @@ class PostRepositoryAdapter(
         limit: Int,
         cursor: PostRepository.PostCursor?,
     ): PostRepository.PostListResult {
+        val trimmedQuery = q?.trim()?.takeIf { it.isNotEmpty() }
         val rows =
             jpaRepository.search(
                 status = status?.name,
                 type = type?.name,
-                q = q?.trim()?.takeIf { it.isNotEmpty() },
+                q = trimmedQuery,
                 cursorCreatedAt = cursor?.createdAt,
                 cursorPostId = cursor?.postId?.value,
+                statusFilterEnabled = status != null,
+                typeFilterEnabled = type != null,
+                qFilterEnabled = trimmedQuery != null,
+                cursorFilterEnabled = cursor != null,
                 limit = limit + 1,
             )
         return PostRepository.PostListResult(rows.take(limit).map { PostMapper.toDomain(it) }, rows.size > limit)

--- a/modules/content/post/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostRepositoryAdapterTest.kt
+++ b/modules/content/post/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostRepositoryAdapterTest.kt
@@ -209,6 +209,87 @@ class PostRepositoryAdapterTest :
             }
         }
 
+        Given("게시글 목록을 cursor pagination으로 검색할 때") {
+            val jpaRepository = mockk<PostJpaRepository>()
+            val eventContextManager = mockk<EventContextManager>()
+            val domainEventPublisher = mockk<DomainEventPublisher>()
+            val adapter = PostRepositoryAdapter(jpaRepository, eventContextManager, domainEventPublisher)
+
+            When("필터와 커서가 모두 없으면") {
+                every {
+                    jpaRepository.search(
+                        status = null,
+                        type = null,
+                        q = null,
+                        cursorCreatedAt = null,
+                        cursorPostId = null,
+                        statusFilterEnabled = false,
+                        typeFilterEnabled = false,
+                        qFilterEnabled = false,
+                        cursorFilterEnabled = false,
+                        limit = 7,
+                    )
+                } returns emptyList()
+
+                val result = adapter.search(null, null, null, 6, null)
+
+                Then("nullable 파라미터 IS NULL 조건 대신 명시적 필터 플래그를 비활성화한다") {
+                    result.posts shouldBe emptyList()
+                    result.hasNext shouldBe false
+                    verify(exactly = 1) {
+                        jpaRepository.search(
+                            status = null,
+                            type = null,
+                            q = null,
+                            cursorCreatedAt = null,
+                            cursorPostId = null,
+                            statusFilterEnabled = false,
+                            typeFilterEnabled = false,
+                            qFilterEnabled = false,
+                            cursorFilterEnabled = false,
+                            limit = 7,
+                        )
+                    }
+                }
+            }
+
+            When("상태 필터만 있으면") {
+                every {
+                    jpaRepository.search(
+                        status = PostStatus.PUBLISHED.name,
+                        type = null,
+                        q = null,
+                        cursorCreatedAt = null,
+                        cursorPostId = null,
+                        statusFilterEnabled = true,
+                        typeFilterEnabled = false,
+                        qFilterEnabled = false,
+                        cursorFilterEnabled = false,
+                        limit = 2,
+                    )
+                } returns emptyList()
+
+                adapter.search(PostStatus.PUBLISHED, null, null, 1, null)
+
+                Then("상태 필터만 활성화하고 나머지 nullable 필터는 비활성화한다") {
+                    verify(exactly = 1) {
+                        jpaRepository.search(
+                            status = PostStatus.PUBLISHED.name,
+                            type = null,
+                            q = null,
+                            cursorCreatedAt = null,
+                            cursorPostId = null,
+                            statusFilterEnabled = true,
+                            typeFilterEnabled = false,
+                            qFilterEnabled = false,
+                            cursorFilterEnabled = false,
+                            limit = 2,
+                        )
+                    }
+                }
+            }
+        }
+
         Given("조회수를 증가시킬 때") {
             val jpaRepository = mockk<PostJpaRepository>()
             val eventContextManager = mockk<EventContextManager>()


### PR DESCRIPTION
## 요약

- `/api/v1/posts` 커서 페이지네이션 native query에서 nullable `:param IS NULL` 조건을 명시적인 필터 활성화 플래그로 교체했다.
- `LIKE` 검색에 사용되는 nullable 키워드 파라미터는 `CAST(:q AS varchar)`로 타입 추론이 가능하도록 정리했다.
- 필터 없음 / 상태 필터만 있는 게시글 목록 검색 회귀 테스트를 추가했다.

## 원인

커서 페이지네이션 도입 과정에서 PostgreSQL이 native query의 반복 nullable 파라미터 타입을 추론하지 못했다. 특히 `:q IS NULL`, cursor null predicate처럼 실제 요청에서 `q`/`cursor`가 없는 경우 SQL 파라미터 바인딩 오류가 발생했고, 이 예외가 `COMMON_002` 500으로 노출됐다.

## 변경 내용

- `PostJpaRepository.search`
  - `:status IS NULL`, `:type IS NULL`, `:q IS NULL`, `:cursorCreatedAt IS NULL` 조건 제거
  - `statusFilterEnabled`, `typeFilterEnabled`, `qFilterEnabled`, `cursorFilterEnabled` 추가
- `PostRepositoryAdapter.search`
  - 검색어 trim 결과를 기준으로 q 필터 활성화 여부 계산
  - cursor 존재 여부를 별도 flag로 전달
- `PostRepositoryAdapterTest`
  - 필터가 없는 목록 조회
  - `status=PUBLISHED`만 있는 목록 조회

## 검증

- 로컬 Gradle: 미실행 — 주엽 로컬 리소스 보호 정책 및 `AGENTS.md` 준수
- 로컬 확인: `git diff --check` 통과
- PR CI: `Test & Build` 통과
- QA 리뷰: APPROVED

## 영향

- client: API 계약 변경 없음
- DB/Flyway: 스키마 변경 없음
- gitops: 이미지 빌드 완료 후 버전 반영 필요
