### PR TITLE
feat(post): 조회수 중복 증가 방지

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation(project(":modules:content:post:application"))
     implementation(project(":modules:content:post:adapter:in:web"))
     implementation(project(":modules:content:post:adapter:out:persistence:jpa"))
+    implementation(project(":modules:content:post:adapter:out:persistence:redis"))
     implementation(project(":modules:content:post:adapter:out:client:member"))
 
     implementation(project(":modules:content:comment:domain"))

--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostApi.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostApi.kt
@@ -6,7 +6,6 @@ import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.PostContributionsRes
 import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.PostListResponse
 import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.PostResponse
 import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.UpdatePostRequest
-import jakarta.servlet.http.HttpServletRequest
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
@@ -16,6 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PathVariable

--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostApi.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostApi.kt
@@ -6,6 +6,7 @@ import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.PostContributionsRes
 import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.PostListResponse
 import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.PostResponse
 import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.UpdatePostRequest
+import jakarta.servlet.http.HttpServletRequest
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
@@ -324,6 +325,8 @@ interface PostApi {
     )
     fun getPostById(
         @Parameter(description = "Post ID") @PathVariable postId: String,
+        @Parameter(hidden = true)
+        request: HttpServletRequest,
     ): ResponseEntity<CommonResponse<PostResponse>>
 
     @Operation(
@@ -400,6 +403,8 @@ interface PostApi {
     fun getPostByUsernameAndSlug(
         @Parameter(description = "사용자 이름") @PathVariable username: String,
         @Parameter(description = "URL Slug") @PathVariable slug: String,
+        @Parameter(hidden = true)
+        request: HttpServletRequest,
     ): ResponseEntity<CommonResponse<PostResponse>>
 
     @Operation(

--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostController.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostController.kt
@@ -304,12 +304,17 @@ class PostController(private val postQueryFacade: PostQueryFacade, private val p
         val authentication = SecurityContextHolder.getContext().authentication
         val principal = authentication?.principal
 
-        if (authentication?.isAuthenticated == true && principal is String && principal.isNotBlank() && principal != "anonymousUser") {
+        if (authentication?.isAuthenticated == true &&
+            principal is String &&
+            principal.isNotBlank() &&
+            principal != "anonymousUser"
+        ) {
             return "member:$principal"
         }
 
         val ip =
-            request.getHeader("X-Forwarded-For")
+            request
+                .getHeader("X-Forwarded-For")
                 ?.split(",")
                 ?.firstOrNull()
                 ?.trim()
@@ -324,7 +329,8 @@ class PostController(private val postQueryFacade: PostQueryFacade, private val p
     }
 
     private fun sha256(value: String): String =
-        MessageDigest.getInstance("SHA-256")
+        MessageDigest
+            .getInstance("SHA-256")
             .digest(value.toByteArray())
             .joinToString("") { byte -> "%02x".format(byte) }
 }

--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostController.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostController.kt
@@ -19,11 +19,13 @@ import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostBySlug
 import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostContributionsUseCase
 import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostsUseCase
 import cloud.luigi99.blog.content.post.application.port.`in`.query.PostQueryFacade
+import jakarta.servlet.http.HttpServletRequest
 import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -33,6 +35,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.security.MessageDigest
 import java.time.LocalDate
 
 private val log = KotlinLogging.logger {}
@@ -139,10 +142,11 @@ class PostController(private val postQueryFacade: PostQueryFacade, private val p
     @GetMapping("/{postId}")
     override fun getPostById(
         @PathVariable postId: String,
+        request: HttpServletRequest,
     ): ResponseEntity<CommonResponse<PostResponse>> {
         log.info { "Getting post by ID: $postId" }
 
-        val query = GetPostByIdUseCase.Query(postId = postId)
+        val query = GetPostByIdUseCase.Query(postId = postId, visitorKey = createVisitorKey(request))
         val response = postQueryFacade.getPostById().execute(query)
 
         return ResponseEntity.ok(
@@ -175,10 +179,11 @@ class PostController(private val postQueryFacade: PostQueryFacade, private val p
     override fun getPostByUsernameAndSlug(
         @PathVariable username: String,
         @PathVariable slug: String,
+        request: HttpServletRequest,
     ): ResponseEntity<CommonResponse<PostResponse>> {
         log.info { "Getting post by username: $username, slug: $slug" }
 
-        val query = GetPostBySlugUseCase.Query(username = username, slug = slug)
+        val query = GetPostBySlugUseCase.Query(username = username, slug = slug, visitorKey = createVisitorKey(request))
         val response = postQueryFacade.getPostBySlug().execute(query)
 
         return ResponseEntity.ok(
@@ -294,4 +299,32 @@ class PostController(private val postQueryFacade: PostQueryFacade, private val p
 
         return ResponseEntity.noContent().build()
     }
+
+    private fun createVisitorKey(request: HttpServletRequest): String {
+        val authentication = SecurityContextHolder.getContext().authentication
+        val principal = authentication?.principal
+
+        if (authentication?.isAuthenticated == true && principal is String && principal.isNotBlank() && principal != "anonymousUser") {
+            return "member:$principal"
+        }
+
+        val ip =
+            request.getHeader("X-Forwarded-For")
+                ?.split(",")
+                ?.firstOrNull()
+                ?.trim()
+                ?.takeIf { it.isNotBlank() }
+                ?: request.getHeader("X-Real-IP")
+                ?: request.remoteAddr.orEmpty()
+        val userAgent = request.getHeader("User-Agent").orEmpty()
+        val acceptLanguage = request.getHeader("Accept-Language").orEmpty()
+        val fingerprint = "$ip|$userAgent|$acceptLanguage"
+
+        return "anonymous:${sha256(fingerprint)}"
+    }
+
+    private fun sha256(value: String): String =
+        MessageDigest.getInstance("SHA-256")
+            .digest(value.toByteArray())
+            .joinToString("") { byte -> "%02x".format(byte) }
 }

--- a/modules/content/post/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostControllerTest.kt
+++ b/modules/content/post/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostControllerTest.kt
@@ -16,6 +16,7 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpStatus
 import java.time.LocalDateTime
 import java.util.UUID
@@ -247,8 +248,9 @@ class PostControllerTest :
                     )
 
                 every { getPostByIdUseCase.execute(any()) } returns expectedResponse
+                val request = mockVisitorRequest()
 
-                val response = controller.getPostById(postId)
+                val response = controller.getPostById(postId, request)
 
                 Then("200 OK 응답이 반환되어야 한다") {
                     response.statusCode shouldBe HttpStatus.OK
@@ -296,8 +298,9 @@ class PostControllerTest :
                     )
 
                 every { getPostBySlugUseCase.execute(any()) } returns expectedResponse
+                val request = mockVisitorRequest()
 
-                val response = controller.getPostByUsernameAndSlug(username, slug)
+                val response = controller.getPostByUsernameAndSlug(username, slug, request)
 
                 Then("200 OK 응답이 반환되어야 한다") {
                     response.statusCode shouldBe HttpStatus.OK
@@ -338,3 +341,13 @@ class PostControllerTest :
             }
         }
     })
+
+private fun mockVisitorRequest(): HttpServletRequest {
+    val request = mockk<HttpServletRequest>()
+    every { request.getHeader("X-Forwarded-For") } returns null
+    every { request.getHeader("X-Real-IP") } returns null
+    every { request.getHeader("User-Agent") } returns "test-agent"
+    every { request.getHeader("Accept-Language") } returns "ko-KR"
+    every { request.remoteAddr } returns "127.0.0.1"
+    return request
+}

--- a/modules/content/post/adapter/out/persistence/redis/build.gradle.kts
+++ b/modules/content/post/adapter/out/persistence/redis/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    springBootConventions
+}
+
+dependencies {
+    implementation(project(":modules:content:post:domain"))
+    implementation(project(":modules:content:post:application"))
+    implementation(project(":libs:adapter:persistence:redis"))
+
+    implementation(libs.spring.boot.starter.data.redis)
+
+    testImplementation(libs.bundles.kotlin.test)
+}

--- a/modules/content/post/adapter/out/persistence/redis/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/redis/RedisPostViewCountDeduplicationAdapter.kt
+++ b/modules/content/post/adapter/out/persistence/redis/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/redis/RedisPostViewCountDeduplicationAdapter.kt
@@ -11,9 +11,8 @@ import java.time.Duration
  * Redis SET NX EX 기반 게시글 조회수 중복 방지 어댑터.
  */
 @Component
-class RedisPostViewCountDeduplicationAdapter(
-    private val redisTemplate: StringRedisTemplate,
-) : PostViewCountDeduplicationPort {
+class RedisPostViewCountDeduplicationAdapter(private val redisTemplate: StringRedisTemplate) :
+    PostViewCountDeduplicationPort {
     override fun isUniqueView(postId: PostId, visitorKey: String): Boolean {
         val key = "post:view:dedupe:${postId.value}:${sha256(visitorKey)}"
 

--- a/modules/content/post/adapter/out/persistence/redis/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/redis/RedisPostViewCountDeduplicationAdapter.kt
+++ b/modules/content/post/adapter/out/persistence/redis/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/redis/RedisPostViewCountDeduplicationAdapter.kt
@@ -11,8 +11,9 @@ import java.time.Duration
  * Redis SET NX EX 기반 게시글 조회수 중복 방지 어댑터.
  */
 @Component
-class RedisPostViewCountDeduplicationAdapter(private val redisTemplate: StringRedisTemplate) :
-    PostViewCountDeduplicationPort {
+class RedisPostViewCountDeduplicationAdapter(
+    private val redisTemplate: StringRedisTemplate,
+) : PostViewCountDeduplicationPort {
     override fun isUniqueView(postId: PostId, visitorKey: String): Boolean {
         val key = "post:view:dedupe:${postId.value}:${sha256(visitorKey)}"
 

--- a/modules/content/post/adapter/out/persistence/redis/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/redis/RedisPostViewCountDeduplicationAdapter.kt
+++ b/modules/content/post/adapter/out/persistence/redis/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/redis/RedisPostViewCountDeduplicationAdapter.kt
@@ -11,9 +11,7 @@ import java.time.Duration
  * Redis SET NX EX 기반 게시글 조회수 중복 방지 어댑터.
  */
 @Component
-class RedisPostViewCountDeduplicationAdapter(
-    private val redisTemplate: StringRedisTemplate,
-) :
+class RedisPostViewCountDeduplicationAdapter(private val redisTemplate: StringRedisTemplate) :
     PostViewCountDeduplicationPort {
     override fun isUniqueView(postId: PostId, visitorKey: String): Boolean {
         val key = "post:view:dedupe:${postId.value}:${sha256(visitorKey)}"

--- a/modules/content/post/adapter/out/persistence/redis/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/redis/RedisPostViewCountDeduplicationAdapter.kt
+++ b/modules/content/post/adapter/out/persistence/redis/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/redis/RedisPostViewCountDeduplicationAdapter.kt
@@ -13,7 +13,8 @@ import java.time.Duration
 @Component
 class RedisPostViewCountDeduplicationAdapter(
     private val redisTemplate: StringRedisTemplate,
-) : PostViewCountDeduplicationPort {
+) :
+    PostViewCountDeduplicationPort {
     override fun isUniqueView(postId: PostId, visitorKey: String): Boolean {
         val key = "post:view:dedupe:${postId.value}:${sha256(visitorKey)}"
 
@@ -23,7 +24,8 @@ class RedisPostViewCountDeduplicationAdapter(
     }
 
     private fun sha256(value: String): String =
-        MessageDigest.getInstance("SHA-256")
+        MessageDigest
+            .getInstance("SHA-256")
             .digest(value.toByteArray())
             .joinToString("") { byte -> "%02x".format(byte) }
 

--- a/modules/content/post/adapter/out/persistence/redis/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/redis/RedisPostViewCountDeduplicationAdapter.kt
+++ b/modules/content/post/adapter/out/persistence/redis/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/redis/RedisPostViewCountDeduplicationAdapter.kt
@@ -1,0 +1,33 @@
+package cloud.luigi99.blog.content.post.adapter.out.persistence.redis
+
+import cloud.luigi99.blog.content.post.application.port.out.PostViewCountDeduplicationPort
+import cloud.luigi99.blog.content.post.domain.vo.PostId
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+import java.security.MessageDigest
+import java.time.Duration
+
+/**
+ * Redis SET NX EX 기반 게시글 조회수 중복 방지 어댑터.
+ */
+@Component
+class RedisPostViewCountDeduplicationAdapter(
+    private val redisTemplate: StringRedisTemplate,
+) : PostViewCountDeduplicationPort {
+    override fun isUniqueView(postId: PostId, visitorKey: String): Boolean {
+        val key = "post:view:dedupe:${postId.value}:${sha256(visitorKey)}"
+
+        return redisTemplate
+            .opsForValue()
+            .setIfAbsent(key, "1", VIEW_DEDUPE_TTL) == true
+    }
+
+    private fun sha256(value: String): String =
+        MessageDigest.getInstance("SHA-256")
+            .digest(value.toByteArray())
+            .joinToString("") { byte -> "%02x".format(byte) }
+
+    companion object {
+        private val VIEW_DEDUPE_TTL: Duration = Duration.ofHours(24)
+    }
+}

--- a/modules/content/post/adapter/out/persistence/redis/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/redis/RedisPostViewCountDeduplicationAdapterTest.kt
+++ b/modules/content/post/adapter/out/persistence/redis/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/redis/RedisPostViewCountDeduplicationAdapterTest.kt
@@ -1,0 +1,63 @@
+package cloud.luigi99.blog.content.post.adapter.out.persistence.redis
+
+import cloud.luigi99.blog.content.post.domain.vo.PostId
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import java.time.Duration
+
+class RedisPostViewCountDeduplicationAdapterTest :
+    BehaviorSpec({
+        val redisTemplate = mockk<StringRedisTemplate>()
+        val valueOperations = mockk<ValueOperations<String, String>>()
+        val adapter = RedisPostViewCountDeduplicationAdapter(redisTemplate)
+        val postId = PostId.generate()
+        val visitorKey = "anonymous:visitor-key"
+
+        Given("Redis dedupe key가 없을 때") {
+            every { redisTemplate.opsForValue() } returns valueOperations
+            every { valueOperations.setIfAbsent(any(), "1", Duration.ofHours(24)) } returns true
+
+            When("고유 조회 여부를 확인하면") {
+                val result = adapter.isUniqueView(postId, visitorKey)
+
+                Then("true를 반환하고 24시간 TTL로 SET NX를 호출한다") {
+                    result shouldBe true
+                    verify(exactly = 1) {
+                        valueOperations.setIfAbsent(
+                            match { it.startsWith("post:view:dedupe:${postId.value}:") },
+                            "1",
+                            Duration.ofHours(24),
+                        )
+                    }
+                }
+            }
+        }
+
+        Given("Redis dedupe key가 이미 있을 때") {
+            every { redisTemplate.opsForValue() } returns valueOperations
+            every { valueOperations.setIfAbsent(any(), "1", Duration.ofHours(24)) } returns false
+
+            When("고유 조회 여부를 확인하면") {
+                val result = adapter.isUniqueView(postId, visitorKey)
+
+                Then("false를 반환한다") {
+                    result shouldBe false
+                }
+            }
+        }
+
+        Given("Redis가 예외를 던질 때") {
+            every { redisTemplate.opsForValue() } throws IllegalStateException("redis down")
+
+            Then("예외를 그대로 전파해 application service에서 조회 성공 우선 정책으로 처리하게 한다") {
+                io.kotest.assertions.throwables.shouldThrow<IllegalStateException> {
+                    adapter.isUniqueView(postId, visitorKey)
+                }
+            }
+        }
+    })

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/in/query/GetPostByIdUseCase.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/in/query/GetPostByIdUseCase.kt
@@ -21,7 +21,7 @@ interface GetPostByIdUseCase {
      *
      * @property postId Post ID
      */
-    data class Query(val postId: String)
+    data class Query(val postId: String, val visitorKey: String)
 
     /**
      * Post 조회 응답

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/in/query/GetPostBySlugUseCase.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/in/query/GetPostBySlugUseCase.kt
@@ -22,7 +22,7 @@ interface GetPostBySlugUseCase {
      * @property username 사용자 이름
      * @property slug URL slug
      */
-    data class Query(val username: String, val slug: String)
+    data class Query(val username: String, val slug: String, val visitorKey: String)
 
     /**
      * Post 조회 응답

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/out/PostViewCountDeduplicationPort.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/out/PostViewCountDeduplicationPort.kt
@@ -1,0 +1,13 @@
+package cloud.luigi99.blog.content.post.application.port.out
+
+import cloud.luigi99.blog.content.post.domain.vo.PostId
+
+/**
+ * 게시글 조회수 중복 증가 방지 포트.
+ */
+interface PostViewCountDeduplicationPort {
+    /**
+     * 같은 방문자의 같은 게시글 조회가 TTL 내 최초 조회이면 true를 반환한다.
+     */
+    fun isUniqueView(postId: PostId, visitorKey: String): Boolean
+}

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostByIdService.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostByIdService.kt
@@ -24,8 +24,7 @@ class GetPostByIdService(
     private val postRepository: PostRepository,
     private val memberClient: MemberClient,
     private val postViewCountDeduplicationPort: PostViewCountDeduplicationPort,
-) :
-    GetPostByIdUseCase {
+) : GetPostByIdUseCase {
     @Transactional
     override fun execute(query: GetPostByIdUseCase.Query): GetPostByIdUseCase.Response {
         log.info { "Getting post by id: ${query.postId}" }

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostByIdService.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostByIdService.kt
@@ -3,8 +3,10 @@
 import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostByIdUseCase
 import cloud.luigi99.blog.content.post.application.port.out.MemberClient
 import cloud.luigi99.blog.content.post.application.port.out.PostRepository
+import cloud.luigi99.blog.content.post.application.port.out.PostViewCountDeduplicationPort
 import cloud.luigi99.blog.content.post.domain.exception.PostNotFoundException
 import cloud.luigi99.blog.content.post.domain.vo.PostId
+import cloud.luigi99.blog.content.post.domain.vo.PostStatus
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -18,7 +20,11 @@ private val log = KotlinLogging.logger {}
  * Post ID를 사용하여 Post를 조회합니다.
  */
 @Service
-class GetPostByIdService(private val postRepository: PostRepository, private val memberClient: MemberClient) :
+class GetPostByIdService(
+    private val postRepository: PostRepository,
+    private val memberClient: MemberClient,
+    private val postViewCountDeduplicationPort: PostViewCountDeduplicationPort,
+) :
     GetPostByIdUseCase {
     @Transactional
     override fun execute(query: GetPostByIdUseCase.Query): GetPostByIdUseCase.Response {
@@ -28,8 +34,12 @@ class GetPostByIdService(private val postRepository: PostRepository, private val
         val post =
             postRepository.findById(postId)
                 ?: throw PostNotFoundException("Post ID ${query.postId}를 찾을 수 없습니다")
-        postRepository.incrementViewCount(post.entityId)
-        post.incrementViewCount()
+        if (post.status == PostStatus.PUBLISHED && isUniqueView(post.entityId, query.visitorKey)) {
+            val updatedRows = postRepository.incrementViewCount(post.entityId)
+            if (updatedRows > 0) {
+                post.incrementViewCount()
+            }
+        }
         val commentCount = postRepository.countCommentsByPostIds(listOf(post.entityId))[post.entityId] ?: 0
 
         val author =
@@ -61,4 +71,9 @@ class GetPostByIdService(private val postRepository: PostRepository, private val
             updatedAt = post.updatedAt,
         )
     }
+
+    private fun isUniqueView(postId: PostId, visitorKey: String): Boolean =
+        runCatching { postViewCountDeduplicationPort.isUniqueView(postId, visitorKey) }
+            .onFailure { e -> log.warn(e) { "Failed to deduplicate post view count. postId=$postId" } }
+            .getOrDefault(false)
 }

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugService.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugService.kt
@@ -3,7 +3,10 @@
 import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostBySlugUseCase
 import cloud.luigi99.blog.content.post.application.port.out.MemberClient
 import cloud.luigi99.blog.content.post.application.port.out.PostRepository
+import cloud.luigi99.blog.content.post.application.port.out.PostViewCountDeduplicationPort
 import cloud.luigi99.blog.content.post.domain.exception.PostNotFoundException
+import cloud.luigi99.blog.content.post.domain.vo.PostId
+import cloud.luigi99.blog.content.post.domain.vo.PostStatus
 import cloud.luigi99.blog.content.post.domain.vo.Slug
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
@@ -17,7 +20,11 @@ private val log = KotlinLogging.logger {}
  * 사용자 이름과 URL slug를 사용하여 Post를 조회합니다.
  */
 @Service
-class GetPostBySlugService(private val postRepository: PostRepository, private val memberClient: MemberClient) :
+class GetPostBySlugService(
+    private val postRepository: PostRepository,
+    private val memberClient: MemberClient,
+    private val postViewCountDeduplicationPort: PostViewCountDeduplicationPort,
+) :
     GetPostBySlugUseCase {
     @Transactional
     override fun execute(query: GetPostBySlugUseCase.Query): GetPostBySlugUseCase.Response {
@@ -29,8 +36,12 @@ class GetPostBySlugService(private val postRepository: PostRepository, private v
                 ?: throw PostNotFoundException(
                     "사용자 '${query.username}'의 Slug '${query.slug}'에 해당하는 Post를 찾을 수 없습니다",
                 )
-        postRepository.incrementViewCount(post.entityId)
-        post.incrementViewCount()
+        if (post.status == PostStatus.PUBLISHED && isUniqueView(post.entityId, query.visitorKey)) {
+            val updatedRows = postRepository.incrementViewCount(post.entityId)
+            if (updatedRows > 0) {
+                post.incrementViewCount()
+            }
+        }
         val commentCount = postRepository.countCommentsByPostIds(listOf(post.entityId))[post.entityId] ?: 0
 
         val author =
@@ -62,4 +73,9 @@ class GetPostBySlugService(private val postRepository: PostRepository, private v
             updatedAt = post.updatedAt,
         )
     }
+
+    private fun isUniqueView(postId: PostId, visitorKey: String): Boolean =
+        runCatching { postViewCountDeduplicationPort.isUniqueView(postId, visitorKey) }
+            .onFailure { e -> log.warn(e) { "Failed to deduplicate post view count. postId=$postId" } }
+            .getOrDefault(false)
 }

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugService.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugService.kt
@@ -24,8 +24,7 @@ class GetPostBySlugService(
     private val postRepository: PostRepository,
     private val memberClient: MemberClient,
     private val postViewCountDeduplicationPort: PostViewCountDeduplicationPort,
-) :
-    GetPostBySlugUseCase {
+) : GetPostBySlugUseCase {
     @Transactional
     override fun execute(query: GetPostBySlugUseCase.Query): GetPostBySlugUseCase.Response {
         log.info { "Getting post by username: ${query.username}, slug: ${query.slug}" }

--- a/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostByIdServiceTest.kt
+++ b/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostByIdServiceTest.kt
@@ -137,8 +137,7 @@ private fun publishedPost(): Post =
             slug = Slug("test-post"),
             body = Body("테스트 내용"),
             type = ContentType.BLOG,
-        )
-        .publish()
+        ).publish()
 
 private fun authorOf(post: Post): MemberClient.Author =
     MemberClient.Author(

--- a/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostByIdServiceTest.kt
+++ b/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostByIdServiceTest.kt
@@ -136,11 +136,14 @@ private fun publishedPost(): Post =
         slug = Slug("test-post"),
         body = Body("테스트 내용"),
         type = ContentType.BLOG,
-    ).publish()
+    )
+        .publish()
 
 private fun authorOf(post: Post): MemberClient.Author =
     MemberClient.Author(
-        memberId = post.memberId.value.toString(),
+        memberId =
+            post.memberId.value
+                .toString(),
         nickname = "TestUser",
         profileImageUrl = null,
         username = "test_user",

--- a/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostByIdServiceTest.kt
+++ b/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostByIdServiceTest.kt
@@ -1,9 +1,10 @@
-﻿package cloud.luigi99.blog.content.post.application.service.query
+package cloud.luigi99.blog.content.post.application.service.query
 
 import cloud.luigi99.blog.common.domain.event.EventManager
 import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostByIdUseCase
 import cloud.luigi99.blog.content.post.application.port.out.MemberClient
 import cloud.luigi99.blog.content.post.application.port.out.PostRepository
+import cloud.luigi99.blog.content.post.application.port.out.PostViewCountDeduplicationPort
 import cloud.luigi99.blog.content.post.domain.exception.PostNotFoundException
 import cloud.luigi99.blog.content.post.domain.model.Post
 import cloud.luigi99.blog.content.post.domain.vo.Body
@@ -26,54 +27,31 @@ import java.util.UUID
  */
 class GetPostByIdServiceTest :
     BehaviorSpec({
-
         beforeTest {
             mockkObject(EventManager)
             every { EventManager.eventContextManager } returns mockk(relaxed = true)
         }
 
-        Given("ID로 글을 조회할 때") {
+        Given("ID로 발행 글을 조회할 때") {
             val postRepository = mockk<PostRepository>()
             val memberClient = mockk<MemberClient>()
-            val service = GetPostByIdService(postRepository, memberClient)
+            val deduplicationPort = mockk<PostViewCountDeduplicationPort>()
+            val service = GetPostByIdService(postRepository, memberClient, deduplicationPort)
+            val post = publishedPost()
+            val postId = post.entityId
+            val query = GetPostByIdUseCase.Query(postId = postId.value.toString(), visitorKey = "visitor-key")
 
-            When("존재하는 Post ID로 조회하면") {
-                val post =
-                    Post.create(
-                        memberId = MemberId.generate(),
-                        title = Title("테스트 글"),
-                        slug = Slug("test-post"),
-                        body = Body("테스트 내용"),
-                        type = ContentType.BLOG,
-                    )
-                val postId = post.entityId
-                val query = GetPostByIdUseCase.Query(postId = postId.value.toString())
+            every { postRepository.findById(postId) } returns post
+            every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
+            every { memberClient.getAuthor(any()) } returns authorOf(post)
 
-                every { postRepository.findById(postId) } returns post
-
+            When("Redis dedupe가 최초 조회로 판단하면") {
+                every { deduplicationPort.isUniqueView(postId, "visitor-key") } returns true
                 every { postRepository.incrementViewCount(postId) } returns 1
-                every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
-                every { memberClient.getAuthor(any()) } returns
-                    MemberClient.Author(
-                        memberId =
-                            post.memberId.value
-                                .toString(),
-                        nickname = "TestUser",
-                        profileImageUrl = null,
-                        username = "test_user",
-                    )
 
                 val response = service.execute(query)
 
-                Then("제목이 반환된다") {
-                    response.title shouldBe "테스트 글"
-                }
-
-                Then("본문이 반환된다") {
-                    response.body shouldBe "테스트 내용"
-                }
-
-                Then("조회수는 full aggregate save 없이 atomic increment로 증가한다") {
+                Then("조회수를 atomic increment하고 응답 조회수를 1 보정한다") {
                     response.viewCount shouldBe 1
                     verify(exactly = 1) { postRepository.incrementViewCount(postId) }
                     verify(exactly = 0) { postRepository.save(any()) }
@@ -81,14 +59,64 @@ class GetPostByIdServiceTest :
             }
         }
 
+        Given("ID로 발행 글을 중복 조회할 때") {
+            val postRepository = mockk<PostRepository>()
+            val memberClient = mockk<MemberClient>()
+            val deduplicationPort = mockk<PostViewCountDeduplicationPort>()
+            val service = GetPostByIdService(postRepository, memberClient, deduplicationPort)
+            val post = publishedPost()
+            val postId = post.entityId
+            val query = GetPostByIdUseCase.Query(postId = postId.value.toString(), visitorKey = "visitor-key")
+
+            every { postRepository.findById(postId) } returns post
+            every { deduplicationPort.isUniqueView(postId, "visitor-key") } returns false
+            every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
+            every { memberClient.getAuthor(any()) } returns authorOf(post)
+
+            When("Redis dedupe가 중복 조회로 판단하면") {
+                val response = service.execute(query)
+
+                Then("조회수를 증가하지 않고 기존 DB 조회수를 반환한다") {
+                    response.viewCount shouldBe 0
+                    verify(exactly = 0) { postRepository.incrementViewCount(any()) }
+                }
+            }
+        }
+
+        Given("조회수 dedupe 저장소 장애가 발생할 때") {
+            val postRepository = mockk<PostRepository>()
+            val memberClient = mockk<MemberClient>()
+            val deduplicationPort = mockk<PostViewCountDeduplicationPort>()
+            val service = GetPostByIdService(postRepository, memberClient, deduplicationPort)
+            val post = publishedPost()
+            val postId = post.entityId
+            val query = GetPostByIdUseCase.Query(postId = postId.value.toString(), visitorKey = "visitor-key")
+
+            every { postRepository.findById(postId) } returns post
+            every { deduplicationPort.isUniqueView(postId, "visitor-key") } throws IllegalStateException("redis down")
+            every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
+            every { memberClient.getAuthor(any()) } returns authorOf(post)
+
+            When("상세 글을 조회하면") {
+                val response = service.execute(query)
+
+                Then("조회는 성공하고 조회수 증가는 skip한다") {
+                    response.title shouldBe "테스트 글"
+                    response.viewCount shouldBe 0
+                    verify(exactly = 0) { postRepository.incrementViewCount(any()) }
+                }
+            }
+        }
+
         Given("존재하지 않는 ID로 조회할 때") {
             val postRepository = mockk<PostRepository>()
             val memberClient = mockk<MemberClient>()
-            val service = GetPostByIdService(postRepository, memberClient)
+            val deduplicationPort = mockk<PostViewCountDeduplicationPort>()
+            val service = GetPostByIdService(postRepository, memberClient, deduplicationPort)
 
             When("없는 Post ID로 조회하면") {
                 val postId = UUID.randomUUID()
-                val query = GetPostByIdUseCase.Query(postId = postId.toString())
+                val query = GetPostByIdUseCase.Query(postId = postId.toString(), visitorKey = "visitor-key")
 
                 every { postRepository.findById(PostId(postId)) } returns null
 
@@ -100,3 +128,20 @@ class GetPostByIdServiceTest :
             }
         }
     })
+
+private fun publishedPost(): Post =
+    Post.create(
+        memberId = MemberId.generate(),
+        title = Title("테스트 글"),
+        slug = Slug("test-post"),
+        body = Body("테스트 내용"),
+        type = ContentType.BLOG,
+    ).publish()
+
+private fun authorOf(post: Post): MemberClient.Author =
+    MemberClient.Author(
+        memberId = post.memberId.value.toString(),
+        nickname = "TestUser",
+        profileImageUrl = null,
+        username = "test_user",
+    )

--- a/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostByIdServiceTest.kt
+++ b/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostByIdServiceTest.kt
@@ -130,13 +130,15 @@ class GetPostByIdServiceTest :
     })
 
 private fun publishedPost(): Post =
-    Post.create(
-        memberId = MemberId.generate(),
-        title = Title("테스트 글"),
-        slug = Slug("test-post"),
-        body = Body("테스트 내용"),
-        type = ContentType.BLOG,
-    ).publish()
+    Post
+        .create(
+            memberId = MemberId.generate(),
+            title = Title("테스트 글"),
+            slug = Slug("test-post"),
+            body = Body("테스트 내용"),
+            type = ContentType.BLOG,
+        )
+        .publish()
 
 private fun authorOf(post: Post): MemberClient.Author =
     MemberClient.Author(

--- a/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostByIdServiceTest.kt
+++ b/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostByIdServiceTest.kt
@@ -130,14 +130,13 @@ class GetPostByIdServiceTest :
     })
 
 private fun publishedPost(): Post =
-    Post
-        .create(
-            memberId = MemberId.generate(),
-            title = Title("테스트 글"),
-            slug = Slug("test-post"),
-            body = Body("테스트 내용"),
-            type = ContentType.BLOG,
-        ).publish()
+    Post.create(
+        memberId = MemberId.generate(),
+        title = Title("테스트 글"),
+        slug = Slug("test-post"),
+        body = Body("테스트 내용"),
+        type = ContentType.BLOG,
+    ).publish()
 
 private fun authorOf(post: Post): MemberClient.Author =
     MemberClient.Author(

--- a/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostByIdServiceTest.kt
+++ b/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostByIdServiceTest.kt
@@ -130,14 +130,14 @@ class GetPostByIdServiceTest :
     })
 
 private fun publishedPost(): Post =
-    Post.create(
-        memberId = MemberId.generate(),
-        title = Title("테스트 글"),
-        slug = Slug("test-post"),
-        body = Body("테스트 내용"),
-        type = ContentType.BLOG,
-    )
-        .publish()
+    Post
+        .create(
+            memberId = MemberId.generate(),
+            title = Title("테스트 글"),
+            slug = Slug("test-post"),
+            body = Body("테스트 내용"),
+            type = ContentType.BLOG,
+        ).publish()
 
 private fun authorOf(post: Post): MemberClient.Author =
     MemberClient.Author(

--- a/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugServiceTest.kt
+++ b/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugServiceTest.kt
@@ -180,8 +180,7 @@ private fun publishedSlugPost(memberId: MemberId): Post =
             slug = Slug("test-post"),
             body = Body("테스트 내용"),
             type = ContentType.BLOG,
-        )
-        .publish()
+        ).publish()
 
 private fun authorOfSlugPost(post: Post): MemberClient.Author =
     MemberClient.Author(

--- a/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugServiceTest.kt
+++ b/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugServiceTest.kt
@@ -173,14 +173,14 @@ class GetPostBySlugServiceTest :
     })
 
 private fun publishedSlugPost(memberId: MemberId): Post =
-    Post.create(
-        memberId = memberId,
-        title = Title("테스트 글"),
-        slug = Slug("test-post"),
-        body = Body("테스트 내용"),
-        type = ContentType.BLOG,
-    )
-        .publish()
+    Post
+        .create(
+            memberId = memberId,
+            title = Title("테스트 글"),
+            slug = Slug("test-post"),
+            body = Body("테스트 내용"),
+            type = ContentType.BLOG,
+        ).publish()
 
 private fun authorOfSlugPost(post: Post): MemberClient.Author =
     MemberClient.Author(

--- a/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugServiceTest.kt
+++ b/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugServiceTest.kt
@@ -173,13 +173,15 @@ class GetPostBySlugServiceTest :
     })
 
 private fun publishedSlugPost(memberId: MemberId): Post =
-    Post.create(
-        memberId = memberId,
-        title = Title("테스트 글"),
-        slug = Slug("test-post"),
-        body = Body("테스트 내용"),
-        type = ContentType.BLOG,
-    ).publish()
+    Post
+        .create(
+            memberId = memberId,
+            title = Title("테스트 글"),
+            slug = Slug("test-post"),
+            body = Body("테스트 내용"),
+            type = ContentType.BLOG,
+        )
+        .publish()
 
 private fun authorOfSlugPost(post: Post): MemberClient.Author =
     MemberClient.Author(

--- a/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugServiceTest.kt
+++ b/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugServiceTest.kt
@@ -173,14 +173,13 @@ class GetPostBySlugServiceTest :
     })
 
 private fun publishedSlugPost(memberId: MemberId): Post =
-    Post
-        .create(
-            memberId = memberId,
-            title = Title("테스트 글"),
-            slug = Slug("test-post"),
-            body = Body("테스트 내용"),
-            type = ContentType.BLOG,
-        ).publish()
+    Post.create(
+        memberId = memberId,
+        title = Title("테스트 글"),
+        slug = Slug("test-post"),
+        body = Body("테스트 내용"),
+        type = ContentType.BLOG,
+    ).publish()
 
 private fun authorOfSlugPost(post: Post): MemberClient.Author =
     MemberClient.Author(

--- a/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugServiceTest.kt
+++ b/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugServiceTest.kt
@@ -1,9 +1,10 @@
-﻿package cloud.luigi99.blog.content.post.application.service.query
+package cloud.luigi99.blog.content.post.application.service.query
 
 import cloud.luigi99.blog.common.domain.event.EventManager
 import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostBySlugUseCase
 import cloud.luigi99.blog.content.post.application.port.out.MemberClient
 import cloud.luigi99.blog.content.post.application.port.out.PostRepository
+import cloud.luigi99.blog.content.post.application.port.out.PostViewCountDeduplicationPort
 import cloud.luigi99.blog.content.post.domain.exception.PostNotFoundException
 import cloud.luigi99.blog.content.post.domain.model.Post
 import cloud.luigi99.blog.content.post.domain.vo.Body
@@ -24,59 +25,33 @@ import io.mockk.verify
  */
 class GetPostBySlugServiceTest :
     BehaviorSpec({
-
         beforeTest {
             mockkObject(EventManager)
             every { EventManager.eventContextManager } returns mockk(relaxed = true)
         }
 
-        Given("Username과 Slug로 글을 조회할 때") {
+        Given("Username과 Slug로 발행 글을 조회할 때") {
             val postRepository = mockk<PostRepository>()
             val memberClient = mockk<MemberClient>()
-            // MemberClient 제거됨
-            val service = GetPostBySlugService(postRepository, memberClient)
+            val deduplicationPort = mockk<PostViewCountDeduplicationPort>()
+            val service = GetPostBySlugService(postRepository, memberClient, deduplicationPort)
+            val memberId = MemberId.generate()
+            val post = publishedSlugPost(memberId)
+            val query = GetPostBySlugUseCase.Query(username = "testuser", slug = "test-post", visitorKey = "visitor-key")
 
-            When("존재하는 Username과 Slug로 조회하면") {
-                val memberId = MemberId.generate()
-                val query = GetPostBySlugUseCase.Query(username = "testuser", slug = "test-post")
+            every { postRepository.findByUsernameAndSlug("testuser", Slug("test-post")) } returns post
+            every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
+            every { memberClient.getAuthor(any()) } returns authorOfSlugPost(post)
 
-                val post =
-                    Post.create(
-                        memberId = memberId,
-                        title = Title("테스트 글"),
-                        slug = Slug("test-post"),
-                        body = Body("테스트 내용"),
-                        type = ContentType.BLOG,
-                    )
-
-                // MemberClient 호출 모킹 제거
-                // findByUsernameAndSlug 모킹 추가
-                every { postRepository.findByUsernameAndSlug("testuser", Slug("test-post")) } returns post
+            When("Redis dedupe가 최초 조회로 판단하면") {
+                every { deduplicationPort.isUniqueView(post.entityId, "visitor-key") } returns true
                 every { postRepository.incrementViewCount(post.entityId) } returns 1
-                every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
-                every { memberClient.getAuthor(any()) } returns
-                    MemberClient.Author(
-                        memberId = memberId.value.toString(),
-                        nickname = "TestUser",
-                        profileImageUrl = null,
-                        username = "test_user",
-                    )
 
                 val response = service.execute(query)
 
-                Then("제목이 반환된다") {
+                Then("조회수를 atomic increment하고 응답 조회수를 1 보정한다") {
                     response.title shouldBe "테스트 글"
-                }
-
-                Then("Slug가 반환된다") {
                     response.slug shouldBe "test-post"
-                }
-
-                Then("본문이 반환된다") {
-                    response.body shouldBe "테스트 내용"
-                }
-
-                Then("조회수는 full aggregate save 없이 atomic increment로 증가한다") {
                     response.viewCount shouldBe 1
                     verify(exactly = 1) { postRepository.incrementViewCount(post.entityId) }
                     verify(exactly = 0) { postRepository.save(any()) }
@@ -84,13 +59,61 @@ class GetPostBySlugServiceTest :
             }
         }
 
+        Given("Username과 Slug로 발행 글을 중복 조회할 때") {
+            val postRepository = mockk<PostRepository>()
+            val memberClient = mockk<MemberClient>()
+            val deduplicationPort = mockk<PostViewCountDeduplicationPort>()
+            val service = GetPostBySlugService(postRepository, memberClient, deduplicationPort)
+            val post = publishedSlugPost(MemberId.generate())
+            val query = GetPostBySlugUseCase.Query(username = "testuser", slug = "test-post", visitorKey = "visitor-key")
+
+            every { postRepository.findByUsernameAndSlug("testuser", Slug("test-post")) } returns post
+            every { deduplicationPort.isUniqueView(post.entityId, "visitor-key") } returns false
+            every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
+            every { memberClient.getAuthor(any()) } returns authorOfSlugPost(post)
+
+            When("Redis dedupe가 중복 조회로 판단하면") {
+                val response = service.execute(query)
+
+                Then("조회수를 증가하지 않고 기존 DB 조회수를 반환한다") {
+                    response.viewCount shouldBe 0
+                    verify(exactly = 0) { postRepository.incrementViewCount(any()) }
+                }
+            }
+        }
+
+        Given("조회수 dedupe 저장소 장애가 발생할 때") {
+            val postRepository = mockk<PostRepository>()
+            val memberClient = mockk<MemberClient>()
+            val deduplicationPort = mockk<PostViewCountDeduplicationPort>()
+            val service = GetPostBySlugService(postRepository, memberClient, deduplicationPort)
+            val post = publishedSlugPost(MemberId.generate())
+            val query = GetPostBySlugUseCase.Query(username = "testuser", slug = "test-post", visitorKey = "visitor-key")
+
+            every { postRepository.findByUsernameAndSlug("testuser", Slug("test-post")) } returns post
+            every { deduplicationPort.isUniqueView(post.entityId, "visitor-key") } throws IllegalStateException("redis down")
+            every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
+            every { memberClient.getAuthor(any()) } returns authorOfSlugPost(post)
+
+            When("상세 글을 조회하면") {
+                val response = service.execute(query)
+
+                Then("조회는 성공하고 조회수 증가는 skip한다") {
+                    response.body shouldBe "테스트 내용"
+                    response.viewCount shouldBe 0
+                    verify(exactly = 0) { postRepository.incrementViewCount(any()) }
+                }
+            }
+        }
+
         Given("존재하지 않는 Username으로 조회할 때") {
             val postRepository = mockk<PostRepository>()
             val memberClient = mockk<MemberClient>()
-            val service = GetPostBySlugService(postRepository, memberClient)
+            val deduplicationPort = mockk<PostViewCountDeduplicationPort>()
+            val service = GetPostBySlugService(postRepository, memberClient, deduplicationPort)
 
             When("존재하지 않는 Username으로 조회하면") {
-                val query = GetPostBySlugUseCase.Query(username = "nonexistent", slug = "test-post")
+                val query = GetPostBySlugUseCase.Query(username = "nonexistent", slug = "test-post", visitorKey = "visitor-key")
 
                 every { postRepository.findByUsernameAndSlug("nonexistent", Slug("test-post")) } returns null
 
@@ -105,10 +128,11 @@ class GetPostBySlugServiceTest :
         Given("존재하지 않는 Slug로 조회할 때") {
             val postRepository = mockk<PostRepository>()
             val memberClient = mockk<MemberClient>()
-            val service = GetPostBySlugService(postRepository, memberClient)
+            val deduplicationPort = mockk<PostViewCountDeduplicationPort>()
+            val service = GetPostBySlugService(postRepository, memberClient, deduplicationPort)
 
             When("존재하는 Username이지만 없는 Slug로 조회하면") {
-                val query = GetPostBySlugUseCase.Query(username = "testuser", slug = "non-existent")
+                val query = GetPostBySlugUseCase.Query(username = "testuser", slug = "non-existent", visitorKey = "visitor-key")
 
                 every { postRepository.findByUsernameAndSlug("testuser", Slug("non-existent")) } returns null
 
@@ -120,3 +144,20 @@ class GetPostBySlugServiceTest :
             }
         }
     })
+
+private fun publishedSlugPost(memberId: MemberId): Post =
+    Post.create(
+        memberId = memberId,
+        title = Title("테스트 글"),
+        slug = Slug("test-post"),
+        body = Body("테스트 내용"),
+        type = ContentType.BLOG,
+    ).publish()
+
+private fun authorOfSlugPost(post: Post): MemberClient.Author =
+    MemberClient.Author(
+        memberId = post.memberId.value.toString(),
+        nickname = "TestUser",
+        profileImageUrl = null,
+        username = "test_user",
+    )

--- a/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugServiceTest.kt
+++ b/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugServiceTest.kt
@@ -37,7 +37,12 @@ class GetPostBySlugServiceTest :
             val service = GetPostBySlugService(postRepository, memberClient, deduplicationPort)
             val memberId = MemberId.generate()
             val post = publishedSlugPost(memberId)
-            val query = GetPostBySlugUseCase.Query(username = "testuser", slug = "test-post", visitorKey = "visitor-key")
+            val query =
+                GetPostBySlugUseCase.Query(
+                    username = "testuser",
+                    slug = "test-post",
+                    visitorKey = "visitor-key",
+                )
 
             every { postRepository.findByUsernameAndSlug("testuser", Slug("test-post")) } returns post
             every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
@@ -65,7 +70,12 @@ class GetPostBySlugServiceTest :
             val deduplicationPort = mockk<PostViewCountDeduplicationPort>()
             val service = GetPostBySlugService(postRepository, memberClient, deduplicationPort)
             val post = publishedSlugPost(MemberId.generate())
-            val query = GetPostBySlugUseCase.Query(username = "testuser", slug = "test-post", visitorKey = "visitor-key")
+            val query =
+                GetPostBySlugUseCase.Query(
+                    username = "testuser",
+                    slug = "test-post",
+                    visitorKey = "visitor-key",
+                )
 
             every { postRepository.findByUsernameAndSlug("testuser", Slug("test-post")) } returns post
             every { deduplicationPort.isUniqueView(post.entityId, "visitor-key") } returns false
@@ -88,10 +98,17 @@ class GetPostBySlugServiceTest :
             val deduplicationPort = mockk<PostViewCountDeduplicationPort>()
             val service = GetPostBySlugService(postRepository, memberClient, deduplicationPort)
             val post = publishedSlugPost(MemberId.generate())
-            val query = GetPostBySlugUseCase.Query(username = "testuser", slug = "test-post", visitorKey = "visitor-key")
+            val query =
+                GetPostBySlugUseCase.Query(
+                    username = "testuser",
+                    slug = "test-post",
+                    visitorKey = "visitor-key",
+                )
 
             every { postRepository.findByUsernameAndSlug("testuser", Slug("test-post")) } returns post
-            every { deduplicationPort.isUniqueView(post.entityId, "visitor-key") } throws IllegalStateException("redis down")
+            every {
+                deduplicationPort.isUniqueView(post.entityId, "visitor-key")
+            } throws IllegalStateException("redis down")
             every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
             every { memberClient.getAuthor(any()) } returns authorOfSlugPost(post)
 
@@ -113,7 +130,12 @@ class GetPostBySlugServiceTest :
             val service = GetPostBySlugService(postRepository, memberClient, deduplicationPort)
 
             When("존재하지 않는 Username으로 조회하면") {
-                val query = GetPostBySlugUseCase.Query(username = "nonexistent", slug = "test-post", visitorKey = "visitor-key")
+                val query =
+                    GetPostBySlugUseCase.Query(
+                        username = "nonexistent",
+                        slug = "test-post",
+                        visitorKey = "visitor-key",
+                    )
 
                 every { postRepository.findByUsernameAndSlug("nonexistent", Slug("test-post")) } returns null
 
@@ -132,7 +154,12 @@ class GetPostBySlugServiceTest :
             val service = GetPostBySlugService(postRepository, memberClient, deduplicationPort)
 
             When("존재하는 Username이지만 없는 Slug로 조회하면") {
-                val query = GetPostBySlugUseCase.Query(username = "testuser", slug = "non-existent", visitorKey = "visitor-key")
+                val query =
+                    GetPostBySlugUseCase.Query(
+                        username = "testuser",
+                        slug = "non-existent",
+                        visitorKey = "visitor-key",
+                    )
 
                 every { postRepository.findByUsernameAndSlug("testuser", Slug("non-existent")) } returns null
 
@@ -152,11 +179,14 @@ private fun publishedSlugPost(memberId: MemberId): Post =
         slug = Slug("test-post"),
         body = Body("테스트 내용"),
         type = ContentType.BLOG,
-    ).publish()
+    )
+        .publish()
 
 private fun authorOfSlugPost(post: Post): MemberClient.Author =
     MemberClient.Author(
-        memberId = post.memberId.value.toString(),
+        memberId =
+            post.memberId.value
+                .toString(),
         nickname = "TestUser",
         profileImageUrl = null,
         username = "test_user",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,6 +25,7 @@ include("modules:content:post:domain")
 include("modules:content:post:application")
 include("modules:content:post:adapter:in:web")
 include("modules:content:post:adapter:out:persistence:jpa")
+include("modules:content:post:adapter:out:persistence:redis")
 include("modules:content:post:adapter:out:client:member")
 
 include("modules:content:comment:domain")


### PR DESCRIPTION
## 📋 개요
- 게시글 상세 조회 시 같은 방문자가 반복 조회해도 24시간 내 조회수가 1회만 증가하도록 Redis 기반 dedupe를 추가했습니다.
- Redis `SET NX + TTL`에 해당하는 `setIfAbsent(..., Duration.ofHours(24))` 성공 시에만 기존 DB atomic increment를 수행하도록 변경했습니다.
- Redis/dedupe 예외가 발생해도 게시글 상세 조회 API는 실패하지 않고 조회수 증가만 건너뛰도록 처리했습니다.
- 방문자 식별 키는 원문 IP/User-Agent를 Redis에 저장하지 않도록 hash 기반으로 처리했습니다.
- ID/slug 상세 조회 서비스와 web controller 관련 테스트를 갱신했습니다.

## 🔗 관련 이슈
- Closes #
- 사용자 요청: 조회수 기능이 새로고침/반복 조회마다 증가하는 문제 개선

## ☑️ 체크리스트
- [x] 코딩 컨벤션을 준수했나요? (`git diff --check`, GitHub Actions `Test & Build` 통과)
- [x] 모든 테스트를 통과했나요? (`./gradlew test`)
  - 로컬 Gradle/ktlint/build/test는 AGENTS.md 리소스 보호 정책에 따라 실행하지 않았습니다.
  - GitHub Actions `Test & Build`에서 `./gradlew test check :app:bootJar` 통과로 검증했습니다.
- [x] 불필요한 주석이나 로그는 제거했나요?

## 검증
- `git diff --check`: PASS
- 로컬 Gradle/ktlint/build/test: 미실행(AGENTS.md 리소스 보호 정책)
- GitHub Actions `Test & Build`: PASS

## 영향
- client: API 응답 스키마 변경 없음
- gitops: 설정 변경 없음(기존 Redis 연결 사용)
- DB/Flyway: 변경 없음

## 리스크 / 확인 필요
- Redis 장애 시 조회수 증가는 skip되지만 게시글 조회 성공을 우선합니다.
- 서버 변경이므로 merge 후 Docker Build & Push/release 결과와 운영 API 동작 확인이 필요합니다.
