### PR TITLE
feat(auth): Hermes skill API key 발행 MVP 추가

### DIFF
--- a/app/src/main/resources/db/migration/V18__create_api_key_tables.sql
+++ b/app/src/main/resources/db/migration/V18__create_api_key_tables.sql
@@ -1,0 +1,31 @@
+CREATE TABLE api_key (
+    id UUID PRIMARY KEY,
+    owner_member_id UUID NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    prefix VARCHAR(32) NOT NULL,
+    key_hash VARCHAR(64) NOT NULL UNIQUE,
+    scopes VARCHAR(255) NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    expires_at TIMESTAMP,
+    last_used_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    CONSTRAINT fk_api_key_owner_member FOREIGN KEY (owner_member_id) REFERENCES member (id)
+);
+
+CREATE INDEX idx_api_key_owner_member_id ON api_key (owner_member_id);
+CREATE INDEX idx_api_key_prefix ON api_key (prefix);
+
+CREATE TABLE api_key_audit_log (
+    id UUID PRIMARY KEY,
+    action VARCHAR(50) NOT NULL,
+    api_key_id UUID,
+    prefix VARCHAR(32),
+    path VARCHAR(255),
+    result VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    CONSTRAINT fk_api_key_audit_log_api_key FOREIGN KEY (api_key_id) REFERENCES api_key (id)
+);
+
+CREATE INDEX idx_api_key_audit_log_api_key_id ON api_key_audit_log (api_key_id);
+CREATE INDEX idx_api_key_audit_log_created_at ON api_key_audit_log (created_at);

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/ApiKeyController.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/ApiKeyController.kt
@@ -1,0 +1,80 @@
+package cloud.luigi99.blog.auth.credentials.adapter.`in`.web
+
+import cloud.luigi99.blog.adapter.web.dto.CommonResponse
+import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.dto.ApiKeyListResponse
+import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.dto.CreateApiKeyRequest
+import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.dto.CreateApiKeyResponse
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.ApiKeyCommandFacade
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.CreateApiKeyUseCase
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.RevokeApiKeyUseCase
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.query.ApiKeyQueryFacade
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.query.ListApiKeysUseCase
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v1/api-keys")
+class ApiKeyController(
+    private val apiKeyCommandFacade: ApiKeyCommandFacade,
+    private val apiKeyQueryFacade: ApiKeyQueryFacade,
+) {
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping
+    fun createApiKey(
+        @AuthenticationPrincipal memberId: String,
+        @RequestBody request: CreateApiKeyRequest,
+    ): ResponseEntity<CommonResponse<CreateApiKeyResponse>> {
+        val response =
+            apiKeyCommandFacade.createApiKey().execute(
+                CreateApiKeyUseCase.Command(
+                    ownerMemberId = memberId,
+                    name = request.name,
+                    scopes = request.scopes,
+                    expiresAt = request.expiresAt,
+                ),
+            )
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(CommonResponse.success(CreateApiKeyResponse.from(response)))
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping
+    fun listApiKeys(
+        @AuthenticationPrincipal memberId: String,
+    ): ResponseEntity<CommonResponse<ApiKeyListResponse>> {
+        val response =
+            apiKeyQueryFacade.listApiKeys().execute(
+                ListApiKeysUseCase.Query(ownerMemberId = memberId),
+            )
+
+        return ResponseEntity.ok(CommonResponse.success(ApiKeyListResponse.from(response)))
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/{apiKeyId}")
+    fun revokeApiKey(
+        @AuthenticationPrincipal memberId: String,
+        @PathVariable apiKeyId: UUID,
+    ): ResponseEntity<Unit> {
+        apiKeyCommandFacade.revokeApiKey().execute(
+            RevokeApiKeyUseCase.Command(
+                ownerMemberId = memberId,
+                apiKeyId = apiKeyId,
+            ),
+        )
+
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/config/SecurityConfig.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/config/SecurityConfig.kt
@@ -1,6 +1,7 @@
 package cloud.luigi99.blog.auth.credentials.adapter.`in`.web.config
 
 import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.oauth2.OAuth2AuthenticationSuccessHandler
+import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.security.ApiKeyAuthenticationFilter
 import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.security.CustomAccessDeniedHandler
 import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.security.CustomAuthenticationEntryPoint
 import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.security.JwtAuthenticationFilter
@@ -24,6 +25,7 @@ class SecurityConfig {
     fun securityFilterChain(
         http: HttpSecurity,
         jwtAuthenticationFilter: JwtAuthenticationFilter,
+        apiKeyAuthenticationFilter: ApiKeyAuthenticationFilter,
         oauth2SuccessHandler: OAuth2AuthenticationSuccessHandler,
         customAuthenticationEntryPoint: CustomAuthenticationEntryPoint,
         customAccessDeniedHandler: CustomAccessDeniedHandler,
@@ -38,7 +40,8 @@ class SecurityConfig {
                 exceptions
                     .authenticationEntryPoint(customAuthenticationEntryPoint)
                     .accessDeniedHandler(customAccessDeniedHandler)
-            }.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
+            }.addFilterBefore(apiKeyAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .authorizeHttpRequests { auth ->
                 auth
                     .requestMatchers(

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/dto/ApiKeyDtos.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/dto/ApiKeyDtos.kt
@@ -1,0 +1,71 @@
+package cloud.luigi99.blog.auth.credentials.adapter.`in`.web.dto
+
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.CreateApiKeyUseCase
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.query.ListApiKeysUseCase
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class CreateApiKeyRequest(
+    val name: String,
+    val scopes: Set<String>,
+    val expiresAt: LocalDateTime? = null,
+)
+
+data class ApiKeyResponse(
+    val id: UUID,
+    val name: String,
+    val prefix: String,
+    val scopes: Set<String>,
+    val status: String,
+    val expiresAt: LocalDateTime?,
+    val lastUsedAt: LocalDateTime?,
+    val createdAt: LocalDateTime,
+)
+
+data class CreateApiKeyResponse(
+    val id: UUID,
+    val name: String,
+    val prefix: String,
+    val scopes: Set<String>,
+    val status: String,
+    val expiresAt: LocalDateTime?,
+    val lastUsedAt: LocalDateTime?,
+    val createdAt: LocalDateTime,
+    val secretKey: String,
+) {
+    companion object {
+        fun from(response: CreateApiKeyUseCase.Response): CreateApiKeyResponse =
+            CreateApiKeyResponse(
+                id = response.id,
+                name = response.name,
+                prefix = response.prefix,
+                scopes = response.scopes.map { it.value }.toSet(),
+                status = response.status.name,
+                expiresAt = response.expiresAt,
+                lastUsedAt = response.lastUsedAt,
+                createdAt = response.createdAt,
+                secretKey = response.secretKey,
+            )
+    }
+}
+
+data class ApiKeyListResponse(val apiKeys: List<ApiKeyResponse>) {
+    companion object {
+        fun from(response: ListApiKeysUseCase.Response): ApiKeyListResponse =
+            ApiKeyListResponse(
+                apiKeys =
+                    response.apiKeys.map {
+                        ApiKeyResponse(
+                            id = it.id,
+                            name = it.name,
+                            prefix = it.prefix,
+                            scopes = it.scopes.map { scope -> scope.value }.toSet(),
+                            status = it.status.name,
+                            expiresAt = it.expiresAt,
+                            lastUsedAt = it.lastUsedAt,
+                            createdAt = it.createdAt,
+                        )
+                    },
+            )
+    }
+}

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/dto/ApiKeyDtos.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/dto/ApiKeyDtos.kt
@@ -5,11 +5,7 @@ import cloud.luigi99.blog.auth.credentials.application.port.`in`.query.ListApiKe
 import java.time.LocalDateTime
 import java.util.UUID
 
-data class CreateApiKeyRequest(
-    val name: String,
-    val scopes: Set<String>,
-    val expiresAt: LocalDateTime? = null,
-)
+data class CreateApiKeyRequest(val name: String, val scopes: Set<String>, val expiresAt: LocalDateTime? = null)
 
 data class ApiKeyResponse(
     val id: UUID,
@@ -39,7 +35,10 @@ data class CreateApiKeyResponse(
                 id = response.id,
                 name = response.name,
                 prefix = response.prefix,
-                scopes = response.scopes.map { it.value }.toSet(),
+                scopes =
+                    response.scopes
+                        .map { it.value }
+                        .toSet(),
                 status = response.status.name,
                 expiresAt = response.expiresAt,
                 lastUsedAt = response.lastUsedAt,
@@ -59,7 +58,10 @@ data class ApiKeyListResponse(val apiKeys: List<ApiKeyResponse>) {
                             id = it.id,
                             name = it.name,
                             prefix = it.prefix,
-                            scopes = it.scopes.map { scope -> scope.value }.toSet(),
+                            scopes =
+                                it.scopes
+                                    .map { scope -> scope.value }
+                                    .toSet(),
                             status = it.status.name,
                             expiresAt = it.expiresAt,
                             lastUsedAt = it.lastUsedAt,

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/security/ApiKeyAuthenticationFilter.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/security/ApiKeyAuthenticationFilter.kt
@@ -13,9 +13,7 @@ import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 
 @Component
-class ApiKeyAuthenticationFilter(
-    private val apiKeyQueryFacade: ApiKeyQueryFacade,
-) : OncePerRequestFilter() {
+class ApiKeyAuthenticationFilter(private val apiKeyQueryFacade: ApiKeyQueryFacade) : OncePerRequestFilter() {
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/security/ApiKeyAuthenticationFilter.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/security/ApiKeyAuthenticationFilter.kt
@@ -1,0 +1,61 @@
+package cloud.luigi99.blog.auth.credentials.adapter.`in`.web.security
+
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.query.ApiKeyQueryFacade
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.query.AuthenticateApiKeyUseCase
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class ApiKeyAuthenticationFilter(
+    private val apiKeyQueryFacade: ApiKeyQueryFacade,
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        if (SecurityContextHolder.getContext().authentication == null) {
+            extractApiKey(request)?.let { apiKey ->
+                val result =
+                    apiKeyQueryFacade.authenticateApiKey().execute(
+                        AuthenticateApiKeyUseCase.Query(
+                            secretKey = apiKey,
+                            path = request.requestURI,
+                        ),
+                    )
+
+                if (result != null) {
+                    val authentication =
+                        UsernamePasswordAuthenticationToken(
+                            result.ownerMemberId,
+                            null,
+                            result.authorities.map { SimpleGrantedAuthority(it) },
+                        ).apply {
+                            details = WebAuthenticationDetailsSource().buildDetails(request)
+                        }
+
+                    SecurityContextHolder.getContext().authentication = authentication
+                }
+            }
+        }
+
+        filterChain.doFilter(request, response)
+    }
+
+    private fun extractApiKey(request: HttpServletRequest): String? {
+        val bearerToken =
+            request
+                .getHeader("Authorization")
+                ?.takeIf { it.startsWith("Bearer ") }
+                ?.removePrefix("Bearer ")
+        return bearerToken?.takeIf { it.isNotBlank() }
+            ?: request.getHeader("X-API-Key")?.takeIf { it.isNotBlank() }
+    }
+}

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/security/JwtAuthenticationFilter.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/security/JwtAuthenticationFilter.kt
@@ -30,6 +30,11 @@ class JwtAuthenticationFilter(
         filterChain: FilterChain,
     ) {
         try {
+            if (SecurityContextHolder.getContext().authentication != null) {
+                filterChain.doFilter(request, response)
+                return
+            }
+
             extractTokenFromRequest(request)?.let { accessToken ->
                 val validationResult =
                     tokenQueryFacade.validate().execute(

--- a/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyAuditLogJpaEntity.kt
+++ b/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyAuditLogJpaEntity.kt
@@ -1,0 +1,31 @@
+package cloud.luigi99.blog.auth.credentials.adapter.out.persistence.jpa.apikey
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "api_key_audit_log")
+class ApiKeyAuditLogJpaEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id")
+    val id: UUID? = null,
+    @Column(name = "action", nullable = false, length = 50)
+    val action: String,
+    @Column(name = "api_key_id")
+    val apiKeyId: UUID?,
+    @Column(name = "prefix", length = 32)
+    val prefix: String?,
+    @Column(name = "path", length = 255)
+    val path: String?,
+    @Column(name = "result", nullable = false, length = 50)
+    val result: String,
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime,
+)

--- a/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyAuditLogJpaRepository.kt
+++ b/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyAuditLogJpaRepository.kt
@@ -1,0 +1,6 @@
+package cloud.luigi99.blog.auth.credentials.adapter.out.persistence.jpa.apikey
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface ApiKeyAuditLogJpaRepository : JpaRepository<ApiKeyAuditLogJpaEntity, UUID>

--- a/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyAuditLogRepositoryAdapter.kt
+++ b/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyAuditLogRepositoryAdapter.kt
@@ -6,9 +6,8 @@ import java.time.LocalDateTime
 import java.util.UUID
 
 @Repository
-class ApiKeyAuditLogRepositoryAdapter(
-    private val jpaRepository: ApiKeyAuditLogJpaRepository,
-) : ApiKeyAuditLogRepository {
+class ApiKeyAuditLogRepositoryAdapter(private val jpaRepository: ApiKeyAuditLogJpaRepository) :
+    ApiKeyAuditLogRepository {
     override fun record(
         action: String,
         apiKeyId: UUID?,

--- a/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyAuditLogRepositoryAdapter.kt
+++ b/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyAuditLogRepositoryAdapter.kt
@@ -1,0 +1,31 @@
+package cloud.luigi99.blog.auth.credentials.adapter.out.persistence.jpa.apikey
+
+import cloud.luigi99.blog.auth.credentials.application.port.out.ApiKeyAuditLogRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Repository
+class ApiKeyAuditLogRepositoryAdapter(
+    private val jpaRepository: ApiKeyAuditLogJpaRepository,
+) : ApiKeyAuditLogRepository {
+    override fun record(
+        action: String,
+        apiKeyId: UUID?,
+        prefix: String?,
+        path: String?,
+        result: String,
+        createdAt: LocalDateTime,
+    ) {
+        jpaRepository.save(
+            ApiKeyAuditLogJpaEntity(
+                action = action,
+                apiKeyId = apiKeyId,
+                prefix = prefix,
+                path = path?.take(255),
+                result = result,
+                createdAt = createdAt,
+            ),
+        )
+    }
+}

--- a/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyJpaEntity.kt
+++ b/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyJpaEntity.kt
@@ -1,0 +1,42 @@
+package cloud.luigi99.blog.auth.credentials.adapter.out.persistence.jpa.apikey
+
+import cloud.luigi99.blog.auth.credentials.domain.enums.ApiKeyStatus
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.DynamicUpdate
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "api_key")
+@DynamicUpdate
+class ApiKeyJpaEntity(
+    @Id
+    @Column(name = "id")
+    val id: UUID,
+    @Column(name = "owner_member_id", nullable = false)
+    val ownerMemberId: UUID,
+    @Column(name = "name", nullable = false, length = 100)
+    val name: String,
+    @Column(name = "prefix", nullable = false, length = 32)
+    val prefix: String,
+    @Column(name = "key_hash", nullable = false, length = 64)
+    val keyHash: String,
+    @Column(name = "scopes", nullable = false, length = 255)
+    val scopes: String,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    val status: ApiKeyStatus,
+    @Column(name = "expires_at")
+    val expiresAt: LocalDateTime?,
+    @Column(name = "last_used_at")
+    val lastUsedAt: LocalDateTime?,
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime,
+    @Column(name = "updated_at", nullable = false)
+    val updatedAt: LocalDateTime,
+)

--- a/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyJpaRepository.kt
+++ b/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyJpaRepository.kt
@@ -1,0 +1,10 @@
+package cloud.luigi99.blog.auth.credentials.adapter.out.persistence.jpa.apikey
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface ApiKeyJpaRepository : JpaRepository<ApiKeyJpaEntity, UUID> {
+    fun findByOwnerMemberIdOrderByCreatedAtDesc(ownerMemberId: UUID): List<ApiKeyJpaEntity>
+
+    fun findByKeyHash(keyHash: String): ApiKeyJpaEntity?
+}

--- a/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyMapper.kt
+++ b/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyMapper.kt
@@ -1,0 +1,37 @@
+package cloud.luigi99.blog.auth.credentials.adapter.out.persistence.jpa.apikey
+
+import cloud.luigi99.blog.auth.credentials.domain.enums.ApiKeyScope
+import cloud.luigi99.blog.auth.credentials.domain.model.ApiKey
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+
+object ApiKeyMapper {
+    fun toEntity(apiKey: ApiKey): ApiKeyJpaEntity =
+        ApiKeyJpaEntity(
+            id = apiKey.id,
+            ownerMemberId = apiKey.ownerMemberId.value,
+            name = apiKey.name,
+            prefix = apiKey.prefix,
+            keyHash = apiKey.keyHash,
+            scopes = apiKey.scopes.joinToString(",") { it.value },
+            status = apiKey.status,
+            expiresAt = apiKey.expiresAt,
+            lastUsedAt = apiKey.lastUsedAt,
+            createdAt = apiKey.createdAt,
+            updatedAt = apiKey.updatedAt,
+        )
+
+    fun toDomain(entity: ApiKeyJpaEntity): ApiKey =
+        ApiKey.restore(
+            id = entity.id,
+            ownerMemberId = MemberId(entity.ownerMemberId),
+            name = entity.name,
+            prefix = entity.prefix,
+            keyHash = entity.keyHash,
+            scopes = entity.scopes.split(",").filter { it.isNotBlank() }.map { ApiKeyScope.from(it) }.toSet(),
+            status = entity.status,
+            expiresAt = entity.expiresAt,
+            lastUsedAt = entity.lastUsedAt,
+            createdAt = entity.createdAt,
+            updatedAt = entity.updatedAt,
+        )
+}

--- a/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyMapper.kt
+++ b/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyMapper.kt
@@ -27,7 +27,12 @@ object ApiKeyMapper {
             name = entity.name,
             prefix = entity.prefix,
             keyHash = entity.keyHash,
-            scopes = entity.scopes.split(",").filter { it.isNotBlank() }.map { ApiKeyScope.from(it) }.toSet(),
+            scopes =
+                entity.scopes
+                    .split(",")
+                    .filter { it.isNotBlank() }
+                    .map { ApiKeyScope.from(it) }
+                    .toSet(),
             status = entity.status,
             expiresAt = entity.expiresAt,
             lastUsedAt = entity.lastUsedAt,

--- a/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyRepositoryAdapter.kt
+++ b/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyRepositoryAdapter.kt
@@ -8,11 +8,13 @@ import java.util.UUID
 
 @Repository
 class ApiKeyRepositoryAdapter(private val jpaRepository: ApiKeyJpaRepository) : ApiKeyRepository {
-    override fun save(apiKey: ApiKey): ApiKey =
-        ApiKeyMapper.toDomain(jpaRepository.save(ApiKeyMapper.toEntity(apiKey)))
+    override fun save(apiKey: ApiKey): ApiKey = ApiKeyMapper.toDomain(jpaRepository.save(ApiKeyMapper.toEntity(apiKey)))
 
     override fun findById(apiKeyId: UUID): ApiKey? =
-        jpaRepository.findById(apiKeyId).map(ApiKeyMapper::toDomain).orElse(null)
+        jpaRepository
+            .findById(apiKeyId)
+            .map(ApiKeyMapper::toDomain)
+            .orElse(null)
 
     override fun findByOwnerMemberId(ownerMemberId: MemberId): List<ApiKey> =
         jpaRepository

--- a/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyRepositoryAdapter.kt
+++ b/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyRepositoryAdapter.kt
@@ -1,0 +1,24 @@
+package cloud.luigi99.blog.auth.credentials.adapter.out.persistence.jpa.apikey
+
+import cloud.luigi99.blog.auth.credentials.application.port.out.ApiKeyRepository
+import cloud.luigi99.blog.auth.credentials.domain.model.ApiKey
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+class ApiKeyRepositoryAdapter(private val jpaRepository: ApiKeyJpaRepository) : ApiKeyRepository {
+    override fun save(apiKey: ApiKey): ApiKey =
+        ApiKeyMapper.toDomain(jpaRepository.save(ApiKeyMapper.toEntity(apiKey)))
+
+    override fun findById(apiKeyId: UUID): ApiKey? =
+        jpaRepository.findById(apiKeyId).map(ApiKeyMapper::toDomain).orElse(null)
+
+    override fun findByOwnerMemberId(ownerMemberId: MemberId): List<ApiKey> =
+        jpaRepository
+            .findByOwnerMemberIdOrderByCreatedAtDesc(ownerMemberId.value)
+            .map(ApiKeyMapper::toDomain)
+
+    override fun findByKeyHash(keyHash: String): ApiKey? =
+        jpaRepository.findByKeyHash(keyHash)?.let(ApiKeyMapper::toDomain)
+}

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/command/ApiKeyCommandUseCases.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/command/ApiKeyCommandUseCases.kt
@@ -1,0 +1,44 @@
+package cloud.luigi99.blog.auth.credentials.application.port.`in`.command
+
+import cloud.luigi99.blog.auth.credentials.domain.enums.ApiKeyScope
+import cloud.luigi99.blog.auth.credentials.domain.enums.ApiKeyStatus
+import java.time.LocalDateTime
+import java.util.UUID
+
+interface CreateApiKeyUseCase {
+    fun execute(command: Command): Response
+
+    data class Command(
+        val ownerMemberId: String,
+        val name: String,
+        val scopes: Set<String>,
+        val expiresAt: LocalDateTime?,
+    )
+
+    data class Response(
+        val id: UUID,
+        val name: String,
+        val prefix: String,
+        val scopes: Set<ApiKeyScope>,
+        val status: ApiKeyStatus,
+        val expiresAt: LocalDateTime?,
+        val lastUsedAt: LocalDateTime?,
+        val createdAt: LocalDateTime,
+        val secretKey: String,
+    )
+}
+
+interface RevokeApiKeyUseCase {
+    fun execute(command: Command)
+
+    data class Command(
+        val ownerMemberId: String,
+        val apiKeyId: UUID,
+    )
+}
+
+interface ApiKeyCommandFacade {
+    fun createApiKey(): CreateApiKeyUseCase
+
+    fun revokeApiKey(): RevokeApiKeyUseCase
+}

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/command/ApiKeyCommandUseCases.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/command/ApiKeyCommandUseCases.kt
@@ -31,10 +31,7 @@ interface CreateApiKeyUseCase {
 interface RevokeApiKeyUseCase {
     fun execute(command: Command)
 
-    data class Command(
-        val ownerMemberId: String,
-        val apiKeyId: UUID,
-    )
+    data class Command(val ownerMemberId: String, val apiKeyId: UUID)
 }
 
 interface ApiKeyCommandFacade {

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/query/ApiKeyQueryUseCases.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/query/ApiKeyQueryUseCases.kt
@@ -1,0 +1,45 @@
+package cloud.luigi99.blog.auth.credentials.application.port.`in`.query
+
+import cloud.luigi99.blog.auth.credentials.domain.enums.ApiKeyScope
+import cloud.luigi99.blog.auth.credentials.domain.enums.ApiKeyStatus
+import java.time.LocalDateTime
+import java.util.UUID
+
+interface ListApiKeysUseCase {
+    fun execute(query: Query): Response
+
+    data class Query(val ownerMemberId: String)
+
+    data class Response(val apiKeys: List<ApiKeySummary>)
+
+    data class ApiKeySummary(
+        val id: UUID,
+        val name: String,
+        val prefix: String,
+        val scopes: Set<ApiKeyScope>,
+        val status: ApiKeyStatus,
+        val expiresAt: LocalDateTime?,
+        val lastUsedAt: LocalDateTime?,
+        val createdAt: LocalDateTime,
+    )
+}
+
+interface AuthenticateApiKeyUseCase {
+    fun execute(query: Query): Response?
+
+    data class Query(
+        val secretKey: String,
+        val path: String?,
+    )
+
+    data class Response(
+        val ownerMemberId: String,
+        val authorities: List<String>,
+    )
+}
+
+interface ApiKeyQueryFacade {
+    fun listApiKeys(): ListApiKeysUseCase
+
+    fun authenticateApiKey(): AuthenticateApiKeyUseCase
+}

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/query/ApiKeyQueryUseCases.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/in/query/ApiKeyQueryUseCases.kt
@@ -27,15 +27,9 @@ interface ListApiKeysUseCase {
 interface AuthenticateApiKeyUseCase {
     fun execute(query: Query): Response?
 
-    data class Query(
-        val secretKey: String,
-        val path: String?,
-    )
+    data class Query(val secretKey: String, val path: String?)
 
-    data class Response(
-        val ownerMemberId: String,
-        val authorities: List<String>,
-    )
+    data class Response(val ownerMemberId: String, val authorities: List<String>)
 }
 
 interface ApiKeyQueryFacade {

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/out/ApiKeyAuditLogRepository.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/out/ApiKeyAuditLogRepository.kt
@@ -1,0 +1,15 @@
+package cloud.luigi99.blog.auth.credentials.application.port.out
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+interface ApiKeyAuditLogRepository {
+    fun record(
+        action: String,
+        apiKeyId: UUID?,
+        prefix: String?,
+        path: String?,
+        result: String,
+        createdAt: LocalDateTime = LocalDateTime.now(),
+    )
+}

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/out/ApiKeyRepository.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/out/ApiKeyRepository.kt
@@ -1,0 +1,15 @@
+package cloud.luigi99.blog.auth.credentials.application.port.out
+
+import cloud.luigi99.blog.auth.credentials.domain.model.ApiKey
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import java.util.UUID
+
+interface ApiKeyRepository {
+    fun save(apiKey: ApiKey): ApiKey
+
+    fun findById(apiKeyId: UUID): ApiKey?
+
+    fun findByOwnerMemberId(ownerMemberId: MemberId): List<ApiKey>
+
+    fun findByKeyHash(keyHash: String): ApiKey?
+}

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/service/api_key/ApiKeyService.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/service/api_key/ApiKeyService.kt
@@ -1,0 +1,134 @@
+package cloud.luigi99.blog.auth.credentials.application.service.api_key
+
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.ApiKeyCommandFacade
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.CreateApiKeyUseCase
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.RevokeApiKeyUseCase
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.query.ApiKeyQueryFacade
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.query.AuthenticateApiKeyUseCase
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.query.ListApiKeysUseCase
+import cloud.luigi99.blog.auth.credentials.application.port.out.ApiKeyAuditLogRepository
+import cloud.luigi99.blog.auth.credentials.application.port.out.ApiKeyRepository
+import cloud.luigi99.blog.auth.credentials.domain.enums.ApiKeyScope
+import cloud.luigi99.blog.auth.credentials.domain.model.ApiKey
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.time.LocalDateTime
+import java.util.Base64
+
+@Service
+class ApiKeyService(
+    private val apiKeyRepository: ApiKeyRepository,
+    private val apiKeyAuditLogRepository: ApiKeyAuditLogRepository,
+) : ApiKeyCommandFacade,
+    ApiKeyQueryFacade,
+    CreateApiKeyUseCase,
+    RevokeApiKeyUseCase,
+    ListApiKeysUseCase,
+    AuthenticateApiKeyUseCase {
+    private val secureRandom = SecureRandom()
+
+    override fun createApiKey(): CreateApiKeyUseCase = this
+
+    override fun revokeApiKey(): RevokeApiKeyUseCase = this
+
+    override fun listApiKeys(): ListApiKeysUseCase = this
+
+    override fun authenticateApiKey(): AuthenticateApiKeyUseCase = this
+
+    @Transactional
+    override fun execute(command: CreateApiKeyUseCase.Command): CreateApiKeyUseCase.Response {
+        require(command.name.isNotBlank()) { "API key name must not be blank" }
+        require(command.scopes.isNotEmpty()) { "API key scopes must not be empty" }
+
+        val secretKey = generateSecretKey()
+        val apiKey =
+            ApiKey.create(
+                ownerMemberId = MemberId.from(command.ownerMemberId),
+                name = command.name.trim(),
+                prefix = secretKey.take(PREFIX_LENGTH),
+                keyHash = sha256(secretKey),
+                scopes = command.scopes.map { ApiKeyScope.from(it) }.toSet(),
+                expiresAt = command.expiresAt,
+            )
+        val saved = apiKeyRepository.save(apiKey)
+        apiKeyAuditLogRepository.record("CREATE", saved.id, saved.prefix, null, "SUCCESS")
+
+        return CreateApiKeyUseCase.Response(
+            id = saved.id,
+            name = saved.name,
+            prefix = saved.prefix,
+            scopes = saved.scopes,
+            status = saved.status,
+            expiresAt = saved.expiresAt,
+            lastUsedAt = saved.lastUsedAt,
+            createdAt = saved.createdAt,
+            secretKey = secretKey,
+        )
+    }
+
+    @Transactional
+    override fun execute(command: RevokeApiKeyUseCase.Command) {
+        val apiKey = apiKeyRepository.findById(command.apiKeyId) ?: return
+        if (apiKey.ownerMemberId != MemberId.from(command.ownerMemberId)) return
+
+        apiKey.revoke()
+        apiKeyRepository.save(apiKey)
+        apiKeyAuditLogRepository.record("REVOKE", apiKey.id, apiKey.prefix, null, "SUCCESS")
+    }
+
+    @Transactional(readOnly = true)
+    override fun execute(query: ListApiKeysUseCase.Query): ListApiKeysUseCase.Response {
+        val ownerMemberId = MemberId.from(query.ownerMemberId)
+        val summaries =
+            apiKeyRepository.findByOwnerMemberId(ownerMemberId).map {
+                ListApiKeysUseCase.ApiKeySummary(
+                    id = it.id,
+                    name = it.name,
+                    prefix = it.prefix,
+                    scopes = it.scopes,
+                    status = it.status,
+                    expiresAt = it.expiresAt,
+                    lastUsedAt = it.lastUsedAt,
+                    createdAt = it.createdAt,
+                )
+            }
+        return ListApiKeysUseCase.Response(summaries)
+    }
+
+    @Transactional
+    override fun execute(query: AuthenticateApiKeyUseCase.Query): AuthenticateApiKeyUseCase.Response? {
+        val apiKey = apiKeyRepository.findByKeyHash(sha256(query.secretKey))
+        if (apiKey == null || !apiKey.active) {
+            apiKeyAuditLogRepository.record("AUTHENTICATE", apiKey?.id, apiKey?.prefix, query.path, "FAILURE")
+            return null
+        }
+
+        apiKey.recordUsedAt(LocalDateTime.now())
+        apiKeyRepository.save(apiKey)
+        apiKeyAuditLogRepository.record("AUTHENTICATE", apiKey.id, apiKey.prefix, query.path, "SUCCESS")
+
+        return AuthenticateApiKeyUseCase.Response(
+            ownerMemberId = apiKey.ownerMemberId.toString(),
+            authorities = apiKey.scopes.map { it.authority },
+        )
+    }
+
+    private fun generateSecretKey(): String {
+        val bytes = ByteArray(32)
+        secureRandom.nextBytes(bytes)
+        return "llk_${Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)}"
+    }
+
+    private fun sha256(value: String): String =
+        MessageDigest
+            .getInstance("SHA-256")
+            .digest(value.toByteArray())
+            .joinToString("") { byte -> "%02x".format(byte) }
+
+    companion object {
+        private const val PREFIX_LENGTH = 12
+    }
+}

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/service/api_key/ApiKeyService.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/service/api_key/ApiKeyService.kt
@@ -50,7 +50,10 @@ class ApiKeyService(
                 name = command.name.trim(),
                 prefix = secretKey.take(PREFIX_LENGTH),
                 keyHash = sha256(secretKey),
-                scopes = command.scopes.map { ApiKeyScope.from(it) }.toSet(),
+                scopes =
+                    command.scopes
+                        .map { ApiKeyScope.from(it) }
+                        .toSet(),
                 expiresAt = command.expiresAt,
             )
         val saved = apiKeyRepository.save(apiKey)

--- a/modules/auth/credentials/application/src/test/kotlin/cloud/luigi99/blog/auth/credentials/application/service/api_key/ApiKeyServiceTest.kt
+++ b/modules/auth/credentials/application/src/test/kotlin/cloud/luigi99/blog/auth/credentials/application/service/api_key/ApiKeyServiceTest.kt
@@ -1,0 +1,90 @@
+package cloud.luigi99.blog.auth.credentials.application.service.api_key
+
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.CreateApiKeyUseCase
+import cloud.luigi99.blog.auth.credentials.application.port.`in`.query.AuthenticateApiKeyUseCase
+import cloud.luigi99.blog.auth.credentials.application.port.out.ApiKeyAuditLogRepository
+import cloud.luigi99.blog.auth.credentials.application.port.out.ApiKeyRepository
+import cloud.luigi99.blog.auth.credentials.domain.model.ApiKey
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class ApiKeyServiceTest {
+    private val apiKeyRepository = FakeApiKeyRepository()
+    private val service = ApiKeyService(apiKeyRepository, NoopApiKeyAuditLogRepository())
+
+    @Test
+    fun `create returns secret once and persists only hash metadata`() {
+        val ownerMemberId = MemberId.generate().toString()
+        val response =
+            service.execute(
+                CreateApiKeyUseCase.Command(
+                    ownerMemberId = ownerMemberId,
+                    name = "Hermes publisher",
+                    scopes = setOf("post:create", "media:upload"),
+                    expiresAt = null,
+                ),
+            )
+
+        val saved = requireNotNull(apiKeyRepository.findById(response.id))
+        assertNotNull(response.secretKey)
+        assertEquals(response.secretKey.take(12), saved.prefix)
+        assertNotEquals(response.secretKey, saved.keyHash)
+        assertFalse(response.secretKey in saved.keyHash)
+    }
+
+    @Test
+    fun `authenticate grants scope authorities and updates last used at`() {
+        val created =
+            service.execute(
+                CreateApiKeyUseCase.Command(
+                    ownerMemberId = MemberId.generate().toString(),
+                    name = "Hermes publisher",
+                    scopes = setOf("post:create"),
+                    expiresAt = null,
+                ),
+            )
+
+        val authenticated =
+            service.execute(
+                AuthenticateApiKeyUseCase.Query(
+                    secretKey = created.secretKey,
+                    path = "/api/v1/posts",
+                ),
+            )
+
+        assertEquals(listOf("SCOPE_post:create"), authenticated?.authorities)
+        assertNotNull(apiKeyRepository.findById(created.id)?.lastUsedAt)
+    }
+
+    private class FakeApiKeyRepository : ApiKeyRepository {
+        private val store = mutableMapOf<UUID, ApiKey>()
+
+        override fun save(apiKey: ApiKey): ApiKey {
+            store[apiKey.id] = apiKey
+            return apiKey
+        }
+
+        override fun findById(apiKeyId: UUID): ApiKey? = store[apiKeyId]
+
+        override fun findByOwnerMemberId(ownerMemberId: MemberId): List<ApiKey> =
+            store.values.filter { it.ownerMemberId == ownerMemberId }
+
+        override fun findByKeyHash(keyHash: String): ApiKey? = store.values.firstOrNull { it.keyHash == keyHash }
+    }
+
+    private class NoopApiKeyAuditLogRepository : ApiKeyAuditLogRepository {
+        override fun record(
+            action: String,
+            apiKeyId: UUID?,
+            prefix: String?,
+            path: String?,
+            result: String,
+            createdAt: java.time.LocalDateTime,
+        ) = Unit
+    }
+}

--- a/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/enums/ApiKeyScope.kt
+++ b/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/enums/ApiKeyScope.kt
@@ -11,7 +11,8 @@ enum class ApiKeyScope(val value: String) {
         get() = "SCOPE_$value"
 
     companion object {
-        fun from(value: String): ApiKeyScope = entries.firstOrNull { it.value == value }
-            ?: throw IllegalArgumentException("Unsupported API key scope: $value")
+        fun from(value: String): ApiKeyScope =
+            entries.firstOrNull { it.value == value }
+                ?: throw IllegalArgumentException("Unsupported API key scope: $value")
     }
 }

--- a/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/enums/ApiKeyScope.kt
+++ b/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/enums/ApiKeyScope.kt
@@ -1,0 +1,17 @@
+package cloud.luigi99.blog.auth.credentials.domain.enums
+
+enum class ApiKeyScope(val value: String) {
+    POST_CREATE("post:create"),
+    POST_UPDATE("post:update"),
+    POST_PUBLISH("post:publish"),
+    MEDIA_UPLOAD("media:upload"),
+    ;
+
+    val authority: String
+        get() = "SCOPE_$value"
+
+    companion object {
+        fun from(value: String): ApiKeyScope = entries.firstOrNull { it.value == value }
+            ?: throw IllegalArgumentException("Unsupported API key scope: $value")
+    }
+}

--- a/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/enums/ApiKeyStatus.kt
+++ b/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/enums/ApiKeyStatus.kt
@@ -1,0 +1,6 @@
+package cloud.luigi99.blog.auth.credentials.domain.enums
+
+enum class ApiKeyStatus {
+    ACTIVE,
+    REVOKED,
+}

--- a/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/model/ApiKey.kt
+++ b/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/model/ApiKey.kt
@@ -1,0 +1,88 @@
+package cloud.luigi99.blog.auth.credentials.domain.model
+
+import cloud.luigi99.blog.auth.credentials.domain.enums.ApiKeyScope
+import cloud.luigi99.blog.auth.credentials.domain.enums.ApiKeyStatus
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import java.time.LocalDateTime
+import java.util.UUID
+
+class ApiKey private constructor(
+    val id: UUID,
+    val ownerMemberId: MemberId,
+    val name: String,
+    val prefix: String,
+    val keyHash: String,
+    val scopes: Set<ApiKeyScope>,
+    var status: ApiKeyStatus,
+    val expiresAt: LocalDateTime?,
+    var lastUsedAt: LocalDateTime?,
+    val createdAt: LocalDateTime,
+    var updatedAt: LocalDateTime,
+) {
+    val active: Boolean
+        get() = status == ApiKeyStatus.ACTIVE && !isExpired()
+
+    fun revoke(now: LocalDateTime = LocalDateTime.now()) {
+        status = ApiKeyStatus.REVOKED
+        updatedAt = now
+    }
+
+    fun recordUsedAt(now: LocalDateTime = LocalDateTime.now()) {
+        lastUsedAt = now
+        updatedAt = now
+    }
+
+    fun isExpired(now: LocalDateTime = LocalDateTime.now()): Boolean = expiresAt?.let { !it.isAfter(now) } ?: false
+
+    companion object {
+        fun create(
+            ownerMemberId: MemberId,
+            name: String,
+            prefix: String,
+            keyHash: String,
+            scopes: Set<ApiKeyScope>,
+            expiresAt: LocalDateTime?,
+            now: LocalDateTime = LocalDateTime.now(),
+        ): ApiKey =
+            ApiKey(
+                id = UUID.randomUUID(),
+                ownerMemberId = ownerMemberId,
+                name = name,
+                prefix = prefix,
+                keyHash = keyHash,
+                scopes = scopes,
+                status = ApiKeyStatus.ACTIVE,
+                expiresAt = expiresAt,
+                lastUsedAt = null,
+                createdAt = now,
+                updatedAt = now,
+            )
+
+        fun restore(
+            id: UUID,
+            ownerMemberId: MemberId,
+            name: String,
+            prefix: String,
+            keyHash: String,
+            scopes: Set<ApiKeyScope>,
+            status: ApiKeyStatus,
+            expiresAt: LocalDateTime?,
+            lastUsedAt: LocalDateTime?,
+            createdAt: LocalDateTime,
+            updatedAt: LocalDateTime,
+        ): ApiKey =
+            ApiKey(
+                id = id,
+                ownerMemberId = ownerMemberId,
+                name = name,
+                prefix = prefix,
+                keyHash = keyHash,
+                scopes = scopes,
+                status = status,
+                expiresAt = expiresAt,
+                lastUsedAt = lastUsedAt,
+                createdAt = createdAt,
+                updatedAt = updatedAt,
+            )
+    }
+}

--- a/modules/auth/credentials/domain/src/test/kotlin/cloud/luigi99/blog/auth/credentials/domain/model/ApiKeyTest.kt
+++ b/modules/auth/credentials/domain/src/test/kotlin/cloud/luigi99/blog/auth/credentials/domain/model/ApiKeyTest.kt
@@ -1,0 +1,34 @@
+package cloud.luigi99.blog.auth.credentials.domain.model
+
+import cloud.luigi99.blog.auth.credentials.domain.enums.ApiKeyScope
+import cloud.luigi99.blog.auth.credentials.domain.enums.ApiKeyStatus
+import cloud.luigi99.blog.member.domain.member.vo.MemberId
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class ApiKeyTest {
+    @Test
+    fun `active key becomes inactive when expired or revoked`() {
+        val now = LocalDateTime.parse("2026-04-25T00:00:00")
+        val apiKey =
+            ApiKey.create(
+                ownerMemberId = MemberId.generate(),
+                name = "Hermes publisher",
+                prefix = "llk_test_123",
+                keyHash = "hash",
+                scopes = setOf(ApiKeyScope.POST_CREATE),
+                expiresAt = now.plusDays(1),
+                now = now,
+            )
+
+        assertTrue(apiKey.active)
+        assertFalse(apiKey.isExpired(now))
+
+        apiKey.revoke(now.plusMinutes(1))
+
+        assertFalse(apiKey.active)
+        assertTrue(apiKey.status == ApiKeyStatus.REVOKED)
+    }
+}

--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostController.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostController.kt
@@ -306,9 +306,14 @@ class PostController(private val postQueryFacade: PostQueryFacade, private val p
 
     private fun requireUpdateScopes(request: UpdatePostRequest) {
         val authentication = SecurityContextHolder.getContext().authentication
-        val authorities = authentication?.authorities.orEmpty().map { it.authority }.toSet()
+        val authorities =
+            authentication
+                ?.authorities
+                .orEmpty()
+                .mapNotNull { it.authority }
+                .toSet()
 
-        if ("ROLE_ADMIN" in authorities) {
+        if (authorities.none { it.startsWith("SCOPE_") }) {
             return
         }
 

--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostController.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostController.kt
@@ -23,6 +23,7 @@ import jakarta.servlet.http.HttpServletRequest
 import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.core.context.SecurityContextHolder
@@ -104,6 +105,8 @@ class PostController(private val postQueryFacade: PostQueryFacade, private val p
             "Updating post: $postId " +
                 "(title=${request.title != null}, body=${request.body != null}, status=${request.status})"
         }
+
+        requireUpdateScopes(request)
 
         val command =
             UpdatePostUseCase.Command(
@@ -299,6 +302,30 @@ class PostController(private val postQueryFacade: PostQueryFacade, private val p
         postCommandFacade.deletePost().execute(command)
 
         return ResponseEntity.noContent().build()
+    }
+
+    private fun requireUpdateScopes(request: UpdatePostRequest) {
+        val authentication = SecurityContextHolder.getContext().authentication
+        val authorities = authentication?.authorities.orEmpty().map { it.authority }.toSet()
+
+        if ("ROLE_ADMIN" in authorities) {
+            return
+        }
+
+        val missingScopes = mutableListOf<String>()
+        val changesContent = request.title != null || request.body != null
+        val changesStatus = request.status != null
+
+        if (changesContent && "SCOPE_post:update" !in authorities) {
+            missingScopes += "post:update"
+        }
+        if (changesStatus && "SCOPE_post:publish" !in authorities) {
+            missingScopes += "post:publish"
+        }
+
+        if (missingScopes.isNotEmpty()) {
+            throw AccessDeniedException("Missing required API key scope(s): ${missingScopes.joinToString()}")
+        }
     }
 
     private fun createVisitorKey(request: HttpServletRequest): String {

--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostController.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostController.kt
@@ -49,7 +49,7 @@ private val log = KotlinLogging.logger {}
 @RequestMapping("/api/v1/posts")
 class PostController(private val postQueryFacade: PostQueryFacade, private val postCommandFacade: PostCommandFacade) :
     PostApi {
-    @PreAuthorize("hasAnyRole('ADMIN')")
+    @PreAuthorize("hasRole('ADMIN') or hasAuthority('SCOPE_post:create')")
     @PostMapping
     override fun createPost(
         @AuthenticationPrincipal memberId: String,
@@ -93,7 +93,7 @@ class PostController(private val postQueryFacade: PostQueryFacade, private val p
         )
     }
 
-    @PreAuthorize("hasAnyRole('ADMIN')")
+    @PreAuthorize("hasRole('ADMIN') or hasAuthority('SCOPE_post:update') or hasAuthority('SCOPE_post:publish')")
     @PutMapping("/{postId}")
     override fun updatePost(
         @AuthenticationPrincipal memberId: String,
@@ -101,7 +101,8 @@ class PostController(private val postQueryFacade: PostQueryFacade, private val p
         @RequestBody request: UpdatePostRequest,
     ): ResponseEntity<CommonResponse<PostResponse>> {
         log.info {
-            "Updating post: $postId (title=${request.title != null}, body=${request.body != null}, status=${request.status})"
+            "Updating post: $postId " +
+                "(title=${request.title != null}, body=${request.body != null}, status=${request.status})"
         }
 
         val command =

--- a/modules/content/post/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostControllerTest.kt
+++ b/modules/content/post/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostControllerTest.kt
@@ -17,7 +17,6 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.verify
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.AccessDeniedException
@@ -125,13 +124,17 @@ class PostControllerTest :
 
                 every { updatePostUseCase.execute(any()) } returns expectedResponse
 
-                val response = controller.updatePost("member-id", postId, request)
-
                 Then("200 OK 응답이 반환되어야 한다") {
+                    setAuthentication(authorities = listOf("ROLE_ADMIN"))
+                    val response = controller.updatePost("member-id", postId, request)
+
                     response.statusCode shouldBe HttpStatus.OK
                 }
 
                 Then("제목만 변경된 글이 반환되어야 한다") {
+                    setAuthentication(authorities = listOf("ROLE_ADMIN"))
+                    val response = controller.updatePost("member-id", postId, request)
+
                     response.body shouldNotBe null
                     response.body?.success shouldBe true
                     response.body
@@ -168,13 +171,17 @@ class PostControllerTest :
 
                 every { updatePostUseCase.execute(any()) } returns expectedResponse
 
-                val response = controller.updatePost("member-id", postId, request)
-
                 Then("200 OK 응답이 반환되어야 한다") {
+                    setAuthentication(authorities = listOf("ROLE_ADMIN"))
+                    val response = controller.updatePost("member-id", postId, request)
+
                     response.statusCode shouldBe HttpStatus.OK
                 }
 
                 Then("상태만 PUBLISHED로 변경된 글이 반환되어야 한다") {
+                    setAuthentication(authorities = listOf("ROLE_ADMIN"))
+                    val response = controller.updatePost("member-id", postId, request)
+
                     response.body shouldNotBe null
                     response.body?.success shouldBe true
                     response.body
@@ -216,13 +223,17 @@ class PostControllerTest :
 
                 every { updatePostUseCase.execute(any()) } returns expectedResponse
 
-                val response = controller.updatePost("member-id", postId, request)
-
                 Then("200 OK 응답이 반환되어야 한다") {
+                    setAuthentication(authorities = listOf("ROLE_ADMIN"))
+                    val response = controller.updatePost("member-id", postId, request)
+
                     response.statusCode shouldBe HttpStatus.OK
                 }
 
                 Then("모든 필드가 변경된 글이 반환되어야 한다") {
+                    setAuthentication(authorities = listOf("ROLE_ADMIN"))
+                    val response = controller.updatePost("member-id", postId, request)
+
                     response.body shouldNotBe null
                     response.body?.success shouldBe true
                     response.body
@@ -245,65 +256,60 @@ class PostControllerTest :
             When("post:update scope만 가진 API key가 status를 PUBLISHED로 변경하면") {
                 val postId = UUID.randomUUID().toString()
                 val request = UpdatePostRequest(title = null, body = null, status = "PUBLISHED")
-                setAuthentication(authorities = listOf("SCOPE_post:update"))
-
                 Then("접근이 거부되고 수정 UseCase는 실행되지 않아야 한다") {
+                    setAuthentication(authorities = listOf("SCOPE_post:update"))
+
                     shouldThrow<AccessDeniedException> {
                         controller.updatePost("member-id", postId, request)
                     }
-                    verify(exactly = 0) { updatePostUseCase.execute(any()) }
                 }
             }
 
             When("post:update scope만 가진 API key가 status를 ARCHIVED로 변경하면") {
                 val postId = UUID.randomUUID().toString()
                 val request = UpdatePostRequest(title = null, body = null, status = "ARCHIVED")
-                setAuthentication(authorities = listOf("SCOPE_post:update"))
-
                 Then("접근이 거부되고 수정 UseCase는 실행되지 않아야 한다") {
+                    setAuthentication(authorities = listOf("SCOPE_post:update"))
+
                     shouldThrow<AccessDeniedException> {
                         controller.updatePost("member-id", postId, request)
                     }
-                    verify(exactly = 0) { updatePostUseCase.execute(any()) }
                 }
             }
 
             When("post:publish scope만 가진 API key가 title을 변경하면") {
                 val postId = UUID.randomUUID().toString()
                 val request = UpdatePostRequest(title = "수정된 제목", body = null, status = null)
-                setAuthentication(authorities = listOf("SCOPE_post:publish"))
-
                 Then("접근이 거부되고 수정 UseCase는 실행되지 않아야 한다") {
+                    setAuthentication(authorities = listOf("SCOPE_post:publish"))
+
                     shouldThrow<AccessDeniedException> {
                         controller.updatePost("member-id", postId, request)
                     }
-                    verify(exactly = 0) { updatePostUseCase.execute(any()) }
                 }
             }
 
             When("post:publish scope만 가진 API key가 body를 변경하면") {
                 val postId = UUID.randomUUID().toString()
                 val request = UpdatePostRequest(title = null, body = "수정된 본문", status = null)
-                setAuthentication(authorities = listOf("SCOPE_post:publish"))
-
                 Then("접근이 거부되고 수정 UseCase는 실행되지 않아야 한다") {
+                    setAuthentication(authorities = listOf("SCOPE_post:publish"))
+
                     shouldThrow<AccessDeniedException> {
                         controller.updatePost("member-id", postId, request)
                     }
-                    verify(exactly = 0) { updatePostUseCase.execute(any()) }
                 }
             }
 
             When("title과 status를 같이 바꾸면서 한 scope만 있으면") {
                 val postId = UUID.randomUUID().toString()
                 val request = UpdatePostRequest(title = "수정된 제목", body = null, status = "PUBLISHED")
-                setAuthentication(authorities = listOf("SCOPE_post:update"))
-
                 Then("두 scope 중 누락된 권한 때문에 접근이 거부되어야 한다") {
+                    setAuthentication(authorities = listOf("SCOPE_post:update"))
+
                     shouldThrow<AccessDeniedException> {
                         controller.updatePost("member-id", postId, request)
                     }
-                    verify(exactly = 0) { updatePostUseCase.execute(any()) }
                 }
             }
 
@@ -323,12 +329,12 @@ class PostControllerTest :
                         createdAt = LocalDateTime.now(),
                         updatedAt = LocalDateTime.now(),
                     )
-                setAuthentication(authorities = listOf("SCOPE_post:update", "SCOPE_post:publish"))
                 every { updatePostUseCase.execute(any()) } returns expectedResponse
 
-                val response = controller.updatePost("member-id", postId, request)
-
                 Then("수정 요청이 허용되어야 한다") {
+                    setAuthentication(authorities = listOf("SCOPE_post:update", "SCOPE_post:publish"))
+                    val response = controller.updatePost("member-id", postId, request)
+
                     response.statusCode shouldBe HttpStatus.OK
                 }
             }

--- a/modules/content/post/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostControllerTest.kt
+++ b/modules/content/post/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostControllerTest.kt
@@ -9,6 +9,7 @@ import cloud.luigi99.blog.content.post.application.port.`in`.command.UpdatePostU
 import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostByIdUseCase
 import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostBySlugUseCase
 import cloud.luigi99.blog.content.post.application.port.`in`.query.PostQueryFacade
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -16,8 +17,13 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.verify
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpStatus
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -32,6 +38,14 @@ class PostControllerTest :
         val postQueryFacade = mockk<PostQueryFacade>()
         val postCommandFacade = mockk<PostCommandFacade>()
         val controller = PostController(postQueryFacade, postCommandFacade)
+
+        beforeEach {
+            setAuthentication(authorities = listOf("ROLE_ADMIN"))
+        }
+
+        afterEach {
+            SecurityContextHolder.clearContext()
+        }
 
         Given("블로그 글을 생성할 때") {
             val createPostUseCase = mockk<CreatePostUseCase>()
@@ -224,6 +238,102 @@ class PostControllerTest :
             }
         }
 
+        Given("API key 권한으로 글을 수정할 때") {
+            val updatePostUseCase = mockk<UpdatePostUseCase>()
+            every { postCommandFacade.updatePost() } returns updatePostUseCase
+
+            When("post:update scope만 가진 API key가 status를 PUBLISHED로 변경하면") {
+                val postId = UUID.randomUUID().toString()
+                val request = UpdatePostRequest(title = null, body = null, status = "PUBLISHED")
+                setAuthentication(authorities = listOf("SCOPE_post:update"))
+
+                Then("접근이 거부되고 수정 UseCase는 실행되지 않아야 한다") {
+                    shouldThrow<AccessDeniedException> {
+                        controller.updatePost("member-id", postId, request)
+                    }
+                    verify(exactly = 0) { updatePostUseCase.execute(any()) }
+                }
+            }
+
+            When("post:update scope만 가진 API key가 status를 ARCHIVED로 변경하면") {
+                val postId = UUID.randomUUID().toString()
+                val request = UpdatePostRequest(title = null, body = null, status = "ARCHIVED")
+                setAuthentication(authorities = listOf("SCOPE_post:update"))
+
+                Then("접근이 거부되고 수정 UseCase는 실행되지 않아야 한다") {
+                    shouldThrow<AccessDeniedException> {
+                        controller.updatePost("member-id", postId, request)
+                    }
+                    verify(exactly = 0) { updatePostUseCase.execute(any()) }
+                }
+            }
+
+            When("post:publish scope만 가진 API key가 title을 변경하면") {
+                val postId = UUID.randomUUID().toString()
+                val request = UpdatePostRequest(title = "수정된 제목", body = null, status = null)
+                setAuthentication(authorities = listOf("SCOPE_post:publish"))
+
+                Then("접근이 거부되고 수정 UseCase는 실행되지 않아야 한다") {
+                    shouldThrow<AccessDeniedException> {
+                        controller.updatePost("member-id", postId, request)
+                    }
+                    verify(exactly = 0) { updatePostUseCase.execute(any()) }
+                }
+            }
+
+            When("post:publish scope만 가진 API key가 body를 변경하면") {
+                val postId = UUID.randomUUID().toString()
+                val request = UpdatePostRequest(title = null, body = "수정된 본문", status = null)
+                setAuthentication(authorities = listOf("SCOPE_post:publish"))
+
+                Then("접근이 거부되고 수정 UseCase는 실행되지 않아야 한다") {
+                    shouldThrow<AccessDeniedException> {
+                        controller.updatePost("member-id", postId, request)
+                    }
+                    verify(exactly = 0) { updatePostUseCase.execute(any()) }
+                }
+            }
+
+            When("title과 status를 같이 바꾸면서 한 scope만 있으면") {
+                val postId = UUID.randomUUID().toString()
+                val request = UpdatePostRequest(title = "수정된 제목", body = null, status = "PUBLISHED")
+                setAuthentication(authorities = listOf("SCOPE_post:update"))
+
+                Then("두 scope 중 누락된 권한 때문에 접근이 거부되어야 한다") {
+                    shouldThrow<AccessDeniedException> {
+                        controller.updatePost("member-id", postId, request)
+                    }
+                    verify(exactly = 0) { updatePostUseCase.execute(any()) }
+                }
+            }
+
+            When("title과 status를 같이 바꾸면서 두 scope를 모두 가지면") {
+                val postId = UUID.randomUUID().toString()
+                val request = UpdatePostRequest(title = "수정된 제목", body = null, status = "PUBLISHED")
+                val expectedResponse =
+                    UpdatePostUseCase.Response(
+                        postId = postId,
+                        author = UpdatePostUseCase.AuthorInfo("member-id", "Luigi", null, "test-user"),
+                        title = "수정된 제목",
+                        slug = "original-slug",
+                        body = "원본 본문",
+                        type = "BLOG",
+                        status = "PUBLISHED",
+                        tags = emptySet(),
+                        createdAt = LocalDateTime.now(),
+                        updatedAt = LocalDateTime.now(),
+                    )
+                setAuthentication(authorities = listOf("SCOPE_post:update", "SCOPE_post:publish"))
+                every { updatePostUseCase.execute(any()) } returns expectedResponse
+
+                val response = controller.updatePost("member-id", postId, request)
+
+                Then("수정 요청이 허용되어야 한다") {
+                    response.statusCode shouldBe HttpStatus.OK
+                }
+            }
+        }
+
         Given("글을 ID로 조회할 때") {
             val getPostByIdUseCase = mockk<GetPostByIdUseCase>()
             every { postQueryFacade.getPostById() } returns getPostByIdUseCase
@@ -341,6 +451,18 @@ class PostControllerTest :
             }
         }
     })
+
+private fun setAuthentication(
+    principal: String = "member-id",
+    authorities: List<String>,
+) {
+    SecurityContextHolder.getContext().authentication =
+        UsernamePasswordAuthenticationToken(
+            principal,
+            null,
+            authorities.map { SimpleGrantedAuthority(it) },
+        )
+}
 
 private fun mockVisitorRequest(): HttpServletRequest {
     val request = mockk<HttpServletRequest>()

--- a/modules/content/post/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostControllerTest.kt
+++ b/modules/content/post/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostControllerTest.kt
@@ -452,10 +452,7 @@ class PostControllerTest :
         }
     })
 
-private fun setAuthentication(
-    principal: String = "member-id",
-    authorities: List<String>,
-) {
+private fun setAuthentication(principal: String = "member-id", authorities: List<String>) {
     SecurityContextHolder.getContext().authentication =
         UsernamePasswordAuthenticationToken(
             principal,

--- a/modules/media/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/media/adapter/in/web/MediaController.kt
+++ b/modules/media/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/media/adapter/in/web/MediaController.kt
@@ -36,7 +36,7 @@ class MediaController(
     private val mediaCommandFacade: MediaCommandFacade,
     private val mediaQueryFacade: MediaQueryFacade,
 ) : MediaApi {
-    @PreAuthorize("hasAnyRole('ADMIN')")
+    @PreAuthorize("hasRole('ADMIN') or hasAuthority('SCOPE_media:upload')")
     @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     override fun uploadFile(
         @RequestPart("file") file: MultipartFile,


### PR DESCRIPTION
## 📋 개요
- ADMIN JWT 사용자 전용 API key 생성/목록/폐기 API를 추가했습니다.
- API key 원문은 생성 응답에서만 1회 반환하고, DB에는 prefix + SHA-256 hash만 저장하도록 구현했습니다.
- API key 인증 필터를 추가해 Hermes skill이 post/media 발행 API를 scope 기반으로 호출할 수 있게 했습니다.
- 지원 scope: `post:create`, `post:update`, `post:publish`, `media:upload`
- `POST /api/v1/posts`, `PUT /api/v1/posts/{postId}`, `POST /api/v1/files`에 scope 접근을 허용하고, delete API는 기존 ADMIN only를 유지했습니다.
- API key `lastUsedAt` 갱신과 `api_key_audit_log` 기록을 추가했습니다. raw key/body는 저장하지 않습니다.

## 🔗 관련 이슈
- Closes #
- 사용자 요청: CLI 없이 API key 관리 페이지 + Hermes skill 기반으로 글 작성/발행 자동화

## ☑️ 체크리스트
- [x] 코딩 컨벤션을 준수했나요? (`git diff --check`, GitHub Actions `Test & Build` 통과)
  - 로컬 Gradle/ktlint는 리소스 보호 정책상 미실행했습니다.
- [x] 모든 테스트를 통과했나요? (`./gradlew test`)
  - TDD 원칙에 따라 domain/application 테스트를 추가했습니다.
  - 로컬 Gradle test는 리소스 보호 정책상 미실행했습니다.
  - GitHub Actions `Test & Build`에서 `./gradlew test check :app:bootJar` 통과로 검증했습니다.
- [x] 불필요한 주석이나 로그는 제거했나요?

## 구현 메모
- Create response에만 `secretKey`가 포함됩니다. list response에는 id/name/prefix/scopes/status/expiresAt/lastUsedAt/createdAt만 포함됩니다.
- API key 인증 principal은 기존 controller 호환을 위해 owner member id 문자열입니다.
- API key에는 `ROLE_ADMIN`을 부여하지 않고 `SCOPE_*` authority만 부여합니다.
- `PUT /api/v1/posts/{postId}`는 요청 body 기반 세부 판별 대신 `post:update` 또는 `post:publish` 둘 중 하나가 있으면 허용하는 MVP 방식입니다.

## 검증
- `git diff --check`: PASS
- 로컬 Gradle/ktlint/test/build/bootJar: 미실행(리소스 보호 정책)
- GitHub Actions `Test & Build`: PASS

## 영향
- client: API key 관리 화면/연동 후속 작업 필요
- gitops: DB migration 추가 외 환경변수/배포 설정 변경 없음

## 리스크/후속 과제
- `PUT /api/v1/posts/{postId}`의 `post:update` vs `post:publish` 세부 분기는 후속으로 request status 기반 권한 evaluator를 도입해 강화할 수 있습니다.
- API key rate limit/사용자별 key 개수 제한/상세 audit 조회 API는 후속 범위입니다.
