### PR TITLE
fix(web): 접근 거부 예외 응답 처리 추가

### DIFF
--- a/libs/adapter/web/src/main/kotlin/cloud/luigi99/blog/adapter/web/GlobalExceptionHandler.kt
+++ b/libs/adapter/web/src/main/kotlin/cloud/luigi99/blog/adapter/web/GlobalExceptionHandler.kt
@@ -7,6 +7,7 @@ import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.authorization.AuthorizationDeniedException
 import org.springframework.web.bind.MissingRequestHeaderException
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -24,8 +25,8 @@ class GlobalExceptionHandler {
             .body(CommonResponse.error(e.errorCode.code, e.message))
     }
 
-    @ExceptionHandler(AuthorizationDeniedException::class)
-    fun handleAuthorizationDeniedException(e: AuthorizationDeniedException): ResponseEntity<CommonResponse<Unit>> {
+    @ExceptionHandler(AuthorizationDeniedException::class, AccessDeniedException::class)
+    fun handleAuthorizationDeniedException(e: Exception): ResponseEntity<CommonResponse<Unit>> {
         log.warn { "Access denied: ${e.message}" }
         return ResponseEntity
             .status(HttpStatus.FORBIDDEN)


### PR DESCRIPTION
## 📋 개요
- `AccessDeniedException`이 공통 예외 핸들러에서 generic 500으로 처리되던 문제를 수정했습니다.
- `AuthorizationDeniedException`과 동일하게 403 ACCESS_DENIED 응답으로 반환되도록 했습니다.
- 운영에서 인증 없이 `/api/v1/api-keys` 접근 시 500이 발생하던 회귀를 방지합니다.

## 🔗 관련 이슈
- Closes #
- 후속 수정: API key 관리 endpoint 운영 검증 중 unauthenticated request가 500으로 떨어지는 문제

## ☑️ 체크리스트
- [x] 코딩 컨벤션을 준수했나요? (`git diff --check` 통과)
- [ ] 모든 테스트를 통과했나요? (`./gradlew test`)
  - 로컬 Gradle/ktlint/test/build는 AGENTS.md 리소스 보호 정책에 따라 실행하지 않았습니다.
  - GitHub Actions `Test & Build`로 최종 검증합니다.
- [x] 불필요한 주석이나 로그는 제거했나요?

## 검증
- `git diff --check`: PASS
- 로컬 Gradle/ktlint/test/build/bootJar: 미실행(리소스 보호 정책)
- GitHub Actions: 확인 대기

## 영향
- client: 없음
- gitops: 서버 이미지 재배포 필요

## 리스크
- 공통 AccessDenied 응답이 500에서 403으로 바뀌는 정상화 변경입니다.
