### PR TITLE
feat(auth): API Key 도메인과 keys 엔드포인트 정리

### DIFF
--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/ApiKeyApi.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/ApiKeyApi.kt
@@ -1,0 +1,70 @@
+package cloud.luigi99.blog.auth.credentials.adapter.`in`.web
+
+import cloud.luigi99.blog.adapter.web.dto.CommonResponse
+import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.dto.ApiKeyListResponse
+import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.dto.CreateApiKeyRequest
+import cloud.luigi99.blog.auth.credentials.adapter.`in`.web.dto.CreateApiKeyResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import java.util.UUID
+
+@Tag(name = "ApiKey", description = "API Key 관리 API")
+interface ApiKeyApi {
+    @Operation(
+        summary = "API Key 생성",
+        description = "현재 로그인한 ADMIN 사용자의 API Key를 생성합니다.",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "201", description = "API Key 생성 성공"),
+            ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            ApiResponse(responseCode = "403", description = "권한 없음 (ADMIN 권한 필요)"),
+        ],
+    )
+    fun createApiKey(
+        @AuthenticationPrincipal memberId: String,
+        @RequestBody request: CreateApiKeyRequest,
+    ): ResponseEntity<CommonResponse<CreateApiKeyResponse>>
+
+    @Operation(
+        summary = "API Key 목록 조회",
+        description = "현재 로그인한 ADMIN 사용자의 API Key 목록을 조회합니다.",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "API Key 목록 조회 성공"),
+            ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            ApiResponse(responseCode = "403", description = "권한 없음 (ADMIN 권한 필요)"),
+        ],
+    )
+    fun listApiKeys(
+        @AuthenticationPrincipal memberId: String,
+    ): ResponseEntity<CommonResponse<ApiKeyListResponse>>
+
+    @Operation(
+        summary = "API Key 폐기",
+        description = "현재 로그인한 ADMIN 사용자의 API Key를 폐기합니다.",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "API Key 폐기 성공"),
+            ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            ApiResponse(responseCode = "403", description = "권한 없음 (ADMIN 권한 필요)"),
+            ApiResponse(responseCode = "404", description = "API Key를 찾을 수 없음"),
+        ],
+    )
+    fun revokeApiKey(
+        @AuthenticationPrincipal memberId: String,
+        @PathVariable apiKeyId: UUID,
+    ): ResponseEntity<Unit>
+}

--- a/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/ApiKeyController.kt
+++ b/modules/auth/credentials/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/in/web/ApiKeyController.kt
@@ -23,14 +23,14 @@ import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
 @RestController
-@RequestMapping("/api/v1/api-keys")
+@RequestMapping("/api/v1/keys")
 class ApiKeyController(
     private val apiKeyCommandFacade: ApiKeyCommandFacade,
     private val apiKeyQueryFacade: ApiKeyQueryFacade,
-) {
+) : ApiKeyApi {
     @PreAuthorize("hasRole('ADMIN')")
     @PostMapping
-    fun createApiKey(
+    override fun createApiKey(
         @AuthenticationPrincipal memberId: String,
         @RequestBody request: CreateApiKeyRequest,
     ): ResponseEntity<CommonResponse<CreateApiKeyResponse>> {
@@ -51,7 +51,7 @@ class ApiKeyController(
 
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping
-    fun listApiKeys(
+    override fun listApiKeys(
         @AuthenticationPrincipal memberId: String,
     ): ResponseEntity<CommonResponse<ApiKeyListResponse>> {
         val response =
@@ -64,7 +64,7 @@ class ApiKeyController(
 
     @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{apiKeyId}")
-    fun revokeApiKey(
+    override fun revokeApiKey(
         @AuthenticationPrincipal memberId: String,
         @PathVariable apiKeyId: UUID,
     ): ResponseEntity<Unit> {

--- a/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyAuditRecorderAdapter.kt
+++ b/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyAuditRecorderAdapter.kt
@@ -1,16 +1,16 @@
 package cloud.luigi99.blog.auth.credentials.adapter.out.persistence.jpa.apikey
 
-import cloud.luigi99.blog.auth.credentials.application.port.out.ApiKeyAuditLogRepository
+import cloud.luigi99.blog.auth.credentials.application.port.out.ApiKeyAuditRecorder
+import cloud.luigi99.blog.auth.credentials.domain.vo.ApiKeyId
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
-import java.util.UUID
 
 @Repository
-class ApiKeyAuditLogRepositoryAdapter(private val jpaRepository: ApiKeyAuditLogJpaRepository) :
-    ApiKeyAuditLogRepository {
+class ApiKeyAuditRecorderAdapter(private val jpaRepository: ApiKeyAuditLogJpaRepository) :
+    ApiKeyAuditRecorder {
     override fun record(
         action: String,
-        apiKeyId: UUID?,
+        apiKeyId: ApiKeyId?,
         prefix: String?,
         path: String?,
         result: String,
@@ -19,7 +19,7 @@ class ApiKeyAuditLogRepositoryAdapter(private val jpaRepository: ApiKeyAuditLogJ
         jpaRepository.save(
             ApiKeyAuditLogJpaEntity(
                 action = action,
-                apiKeyId = apiKeyId,
+                apiKeyId = apiKeyId?.value,
                 prefix = prefix,
                 path = path?.take(255),
                 result = result,

--- a/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyAuditRecorderAdapter.kt
+++ b/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyAuditRecorderAdapter.kt
@@ -6,8 +6,7 @@ import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
 
 @Repository
-class ApiKeyAuditRecorderAdapter(private val jpaRepository: ApiKeyAuditLogJpaRepository) :
-    ApiKeyAuditRecorder {
+class ApiKeyAuditRecorderAdapter(private val jpaRepository: ApiKeyAuditLogJpaRepository) : ApiKeyAuditRecorder {
     override fun record(
         action: String,
         apiKeyId: ApiKeyId?,

--- a/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyMapper.kt
+++ b/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyMapper.kt
@@ -2,12 +2,13 @@ package cloud.luigi99.blog.auth.credentials.adapter.out.persistence.jpa.apikey
 
 import cloud.luigi99.blog.auth.credentials.domain.enums.ApiKeyScope
 import cloud.luigi99.blog.auth.credentials.domain.model.ApiKey
+import cloud.luigi99.blog.auth.credentials.domain.vo.ApiKeyId
 import cloud.luigi99.blog.member.domain.member.vo.MemberId
 
 object ApiKeyMapper {
     fun toEntity(apiKey: ApiKey): ApiKeyJpaEntity =
         ApiKeyJpaEntity(
-            id = apiKey.id,
+            id = apiKey.entityId.value,
             ownerMemberId = apiKey.ownerMemberId.value,
             name = apiKey.name,
             prefix = apiKey.prefix,
@@ -16,13 +17,13 @@ object ApiKeyMapper {
             status = apiKey.status,
             expiresAt = apiKey.expiresAt,
             lastUsedAt = apiKey.lastUsedAt,
-            createdAt = apiKey.createdAt,
-            updatedAt = apiKey.updatedAt,
+            createdAt = requireNotNull(apiKey.createdAt) { "ApiKey createdAt must be set before persistence" },
+            updatedAt = requireNotNull(apiKey.updatedAt) { "ApiKey updatedAt must be set before persistence" },
         )
 
     fun toDomain(entity: ApiKeyJpaEntity): ApiKey =
         ApiKey.restore(
-            id = entity.id,
+            entityId = ApiKeyId(entity.id),
             ownerMemberId = MemberId(entity.ownerMemberId),
             name = entity.name,
             prefix = entity.prefix,

--- a/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyRepositoryAdapter.kt
+++ b/modules/auth/credentials/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/auth/credentials/adapter/out/persistence/jpa/apikey/ApiKeyRepositoryAdapter.kt
@@ -2,17 +2,17 @@ package cloud.luigi99.blog.auth.credentials.adapter.out.persistence.jpa.apikey
 
 import cloud.luigi99.blog.auth.credentials.application.port.out.ApiKeyRepository
 import cloud.luigi99.blog.auth.credentials.domain.model.ApiKey
+import cloud.luigi99.blog.auth.credentials.domain.vo.ApiKeyId
 import cloud.luigi99.blog.member.domain.member.vo.MemberId
 import org.springframework.stereotype.Repository
-import java.util.UUID
 
 @Repository
 class ApiKeyRepositoryAdapter(private val jpaRepository: ApiKeyJpaRepository) : ApiKeyRepository {
     override fun save(apiKey: ApiKey): ApiKey = ApiKeyMapper.toDomain(jpaRepository.save(ApiKeyMapper.toEntity(apiKey)))
 
-    override fun findById(apiKeyId: UUID): ApiKey? =
+    override fun findById(apiKeyId: ApiKeyId): ApiKey? =
         jpaRepository
-            .findById(apiKeyId)
+            .findById(apiKeyId.value)
             .map(ApiKeyMapper::toDomain)
             .orElse(null)
 

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/out/ApiKeyAuditRecorder.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/out/ApiKeyAuditRecorder.kt
@@ -1,12 +1,12 @@
 package cloud.luigi99.blog.auth.credentials.application.port.out
 
+import cloud.luigi99.blog.auth.credentials.domain.vo.ApiKeyId
 import java.time.LocalDateTime
-import java.util.UUID
 
-interface ApiKeyAuditLogRepository {
+interface ApiKeyAuditRecorder {
     fun record(
         action: String,
-        apiKeyId: UUID?,
+        apiKeyId: ApiKeyId?,
         prefix: String?,
         path: String?,
         result: String,

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/out/ApiKeyRepository.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/port/out/ApiKeyRepository.kt
@@ -1,13 +1,13 @@
 package cloud.luigi99.blog.auth.credentials.application.port.out
 
 import cloud.luigi99.blog.auth.credentials.domain.model.ApiKey
+import cloud.luigi99.blog.auth.credentials.domain.vo.ApiKeyId
 import cloud.luigi99.blog.member.domain.member.vo.MemberId
-import java.util.UUID
 
 interface ApiKeyRepository {
     fun save(apiKey: ApiKey): ApiKey
 
-    fun findById(apiKeyId: UUID): ApiKey?
+    fun findById(apiKeyId: ApiKeyId): ApiKey?
 
     fun findByOwnerMemberId(ownerMemberId: MemberId): List<ApiKey>
 

--- a/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/service/api_key/ApiKeyService.kt
+++ b/modules/auth/credentials/application/src/main/kotlin/cloud/luigi99/blog/auth/credentials/application/service/api_key/ApiKeyService.kt
@@ -6,10 +6,11 @@ import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.RevokeA
 import cloud.luigi99.blog.auth.credentials.application.port.`in`.query.ApiKeyQueryFacade
 import cloud.luigi99.blog.auth.credentials.application.port.`in`.query.AuthenticateApiKeyUseCase
 import cloud.luigi99.blog.auth.credentials.application.port.`in`.query.ListApiKeysUseCase
-import cloud.luigi99.blog.auth.credentials.application.port.out.ApiKeyAuditLogRepository
+import cloud.luigi99.blog.auth.credentials.application.port.out.ApiKeyAuditRecorder
 import cloud.luigi99.blog.auth.credentials.application.port.out.ApiKeyRepository
 import cloud.luigi99.blog.auth.credentials.domain.enums.ApiKeyScope
 import cloud.luigi99.blog.auth.credentials.domain.model.ApiKey
+import cloud.luigi99.blog.auth.credentials.domain.vo.ApiKeyId
 import cloud.luigi99.blog.member.domain.member.vo.MemberId
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -21,7 +22,7 @@ import java.util.Base64
 @Service
 class ApiKeyService(
     private val apiKeyRepository: ApiKeyRepository,
-    private val apiKeyAuditLogRepository: ApiKeyAuditLogRepository,
+    private val apiKeyAuditRecorder: ApiKeyAuditRecorder,
 ) : ApiKeyCommandFacade,
     ApiKeyQueryFacade,
     CreateApiKeyUseCase,
@@ -57,29 +58,29 @@ class ApiKeyService(
                 expiresAt = command.expiresAt,
             )
         val saved = apiKeyRepository.save(apiKey)
-        apiKeyAuditLogRepository.record("CREATE", saved.id, saved.prefix, null, "SUCCESS")
+        apiKeyAuditRecorder.record("CREATE", saved.entityId, saved.prefix, null, "SUCCESS")
 
         return CreateApiKeyUseCase.Response(
-            id = saved.id,
+            id = saved.entityId.value,
             name = saved.name,
             prefix = saved.prefix,
             scopes = saved.scopes,
             status = saved.status,
             expiresAt = saved.expiresAt,
             lastUsedAt = saved.lastUsedAt,
-            createdAt = saved.createdAt,
+            createdAt = requireNotNull(saved.createdAt) { "Saved ApiKey createdAt must not be null" },
             secretKey = secretKey,
         )
     }
 
     @Transactional
     override fun execute(command: RevokeApiKeyUseCase.Command) {
-        val apiKey = apiKeyRepository.findById(command.apiKeyId) ?: return
+        val apiKey = apiKeyRepository.findById(ApiKeyId(command.apiKeyId)) ?: return
         if (apiKey.ownerMemberId != MemberId.from(command.ownerMemberId)) return
 
         apiKey.revoke()
         apiKeyRepository.save(apiKey)
-        apiKeyAuditLogRepository.record("REVOKE", apiKey.id, apiKey.prefix, null, "SUCCESS")
+        apiKeyAuditRecorder.record("REVOKE", apiKey.entityId, apiKey.prefix, null, "SUCCESS")
     }
 
     @Transactional(readOnly = true)
@@ -88,14 +89,14 @@ class ApiKeyService(
         val summaries =
             apiKeyRepository.findByOwnerMemberId(ownerMemberId).map {
                 ListApiKeysUseCase.ApiKeySummary(
-                    id = it.id,
+                    id = it.entityId.value,
                     name = it.name,
                     prefix = it.prefix,
                     scopes = it.scopes,
                     status = it.status,
                     expiresAt = it.expiresAt,
                     lastUsedAt = it.lastUsedAt,
-                    createdAt = it.createdAt,
+                    createdAt = requireNotNull(it.createdAt) { "ApiKey createdAt must not be null" },
                 )
             }
         return ListApiKeysUseCase.Response(summaries)
@@ -105,13 +106,13 @@ class ApiKeyService(
     override fun execute(query: AuthenticateApiKeyUseCase.Query): AuthenticateApiKeyUseCase.Response? {
         val apiKey = apiKeyRepository.findByKeyHash(sha256(query.secretKey))
         if (apiKey == null || !apiKey.active) {
-            apiKeyAuditLogRepository.record("AUTHENTICATE", apiKey?.id, apiKey?.prefix, query.path, "FAILURE")
+            apiKeyAuditRecorder.record("AUTHENTICATE", apiKey?.entityId, apiKey?.prefix, query.path, "FAILURE")
             return null
         }
 
         apiKey.recordUsedAt(LocalDateTime.now())
         apiKeyRepository.save(apiKey)
-        apiKeyAuditLogRepository.record("AUTHENTICATE", apiKey.id, apiKey.prefix, query.path, "SUCCESS")
+        apiKeyAuditRecorder.record("AUTHENTICATE", apiKey.entityId, apiKey.prefix, query.path, "SUCCESS")
 
         return AuthenticateApiKeyUseCase.Response(
             ownerMemberId = apiKey.ownerMemberId.toString(),

--- a/modules/auth/credentials/application/src/test/kotlin/cloud/luigi99/blog/auth/credentials/application/service/api_key/ApiKeyServiceTest.kt
+++ b/modules/auth/credentials/application/src/test/kotlin/cloud/luigi99/blog/auth/credentials/application/service/api_key/ApiKeyServiceTest.kt
@@ -2,20 +2,20 @@ package cloud.luigi99.blog.auth.credentials.application.service.api_key
 
 import cloud.luigi99.blog.auth.credentials.application.port.`in`.command.CreateApiKeyUseCase
 import cloud.luigi99.blog.auth.credentials.application.port.`in`.query.AuthenticateApiKeyUseCase
-import cloud.luigi99.blog.auth.credentials.application.port.out.ApiKeyAuditLogRepository
+import cloud.luigi99.blog.auth.credentials.application.port.out.ApiKeyAuditRecorder
 import cloud.luigi99.blog.auth.credentials.application.port.out.ApiKeyRepository
 import cloud.luigi99.blog.auth.credentials.domain.model.ApiKey
+import cloud.luigi99.blog.auth.credentials.domain.vo.ApiKeyId
 import cloud.luigi99.blog.member.domain.member.vo.MemberId
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
-import java.util.UUID
 
 class ApiKeyServiceTest {
     private val apiKeyRepository = FakeApiKeyRepository()
-    private val service = ApiKeyService(apiKeyRepository, NoopApiKeyAuditLogRepository())
+    private val service = ApiKeyService(apiKeyRepository, NoopApiKeyAuditRecorder())
 
     @Test
     fun `create returns secret once and persists only hash metadata`() {
@@ -30,7 +30,7 @@ class ApiKeyServiceTest {
                 ),
             )
 
-        val saved = requireNotNull(apiKeyRepository.findById(response.id))
+        val saved = requireNotNull(apiKeyRepository.findById(ApiKeyId(response.id)))
         assertNotNull(response.secretKey)
         assertEquals(response.secretKey.take(12), saved.prefix)
         assertNotEquals(response.secretKey, saved.keyHash)
@@ -58,18 +58,18 @@ class ApiKeyServiceTest {
             )
 
         assertEquals(listOf("SCOPE_post:create"), authenticated?.authorities)
-        assertNotNull(apiKeyRepository.findById(created.id)?.lastUsedAt)
+        assertNotNull(apiKeyRepository.findById(ApiKeyId(created.id))?.lastUsedAt)
     }
 
     private class FakeApiKeyRepository : ApiKeyRepository {
-        private val store = mutableMapOf<UUID, ApiKey>()
+        private val store = mutableMapOf<ApiKeyId, ApiKey>()
 
         override fun save(apiKey: ApiKey): ApiKey {
-            store[apiKey.id] = apiKey
+            store[apiKey.entityId] = apiKey
             return apiKey
         }
 
-        override fun findById(apiKeyId: UUID): ApiKey? = store[apiKeyId]
+        override fun findById(apiKeyId: ApiKeyId): ApiKey? = store[apiKeyId]
 
         override fun findByOwnerMemberId(ownerMemberId: MemberId): List<ApiKey> =
             store.values.filter { it.ownerMemberId == ownerMemberId }
@@ -77,10 +77,10 @@ class ApiKeyServiceTest {
         override fun findByKeyHash(keyHash: String): ApiKey? = store.values.firstOrNull { it.keyHash == keyHash }
     }
 
-    private class NoopApiKeyAuditLogRepository : ApiKeyAuditLogRepository {
+    private class NoopApiKeyAuditRecorder : ApiKeyAuditRecorder {
         override fun record(
             action: String,
-            apiKeyId: UUID?,
+            apiKeyId: ApiKeyId?,
             prefix: String?,
             path: String?,
             result: String,

--- a/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/model/ApiKey.kt
+++ b/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/model/ApiKey.kt
@@ -2,12 +2,13 @@ package cloud.luigi99.blog.auth.credentials.domain.model
 
 import cloud.luigi99.blog.auth.credentials.domain.enums.ApiKeyScope
 import cloud.luigi99.blog.auth.credentials.domain.enums.ApiKeyStatus
+import cloud.luigi99.blog.auth.credentials.domain.vo.ApiKeyId
+import cloud.luigi99.blog.common.domain.AggregateRoot
 import cloud.luigi99.blog.member.domain.member.vo.MemberId
 import java.time.LocalDateTime
-import java.util.UUID
 
 class ApiKey private constructor(
-    val id: UUID,
+    override val entityId: ApiKeyId,
     val ownerMemberId: MemberId,
     val name: String,
     val prefix: String,
@@ -16,9 +17,9 @@ class ApiKey private constructor(
     var status: ApiKeyStatus,
     val expiresAt: LocalDateTime?,
     var lastUsedAt: LocalDateTime?,
-    val createdAt: LocalDateTime,
-    var updatedAt: LocalDateTime,
-) {
+    override var createdAt: LocalDateTime?,
+    override var updatedAt: LocalDateTime?,
+) : AggregateRoot<ApiKeyId>() {
     val active: Boolean
         get() = status == ApiKeyStatus.ACTIVE && !isExpired()
 
@@ -45,7 +46,7 @@ class ApiKey private constructor(
             now: LocalDateTime = LocalDateTime.now(),
         ): ApiKey =
             ApiKey(
-                id = UUID.randomUUID(),
+                entityId = ApiKeyId.generate(),
                 ownerMemberId = ownerMemberId,
                 name = name,
                 prefix = prefix,
@@ -59,7 +60,7 @@ class ApiKey private constructor(
             )
 
         fun restore(
-            id: UUID,
+            entityId: ApiKeyId,
             ownerMemberId: MemberId,
             name: String,
             prefix: String,
@@ -72,7 +73,7 @@ class ApiKey private constructor(
             updatedAt: LocalDateTime,
         ): ApiKey =
             ApiKey(
-                id = id,
+                entityId = entityId,
                 ownerMemberId = ownerMemberId,
                 name = name,
                 prefix = prefix,

--- a/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/vo/ApiKeyId.kt
+++ b/modules/auth/credentials/domain/src/main/kotlin/cloud/luigi99/blog/auth/credentials/domain/vo/ApiKeyId.kt
@@ -1,0 +1,18 @@
+package cloud.luigi99.blog.auth.credentials.domain.vo
+
+import cloud.luigi99.blog.common.domain.ValueObject
+import java.io.Serializable
+import java.util.UUID
+
+@JvmInline
+value class ApiKeyId(val value: UUID) :
+    ValueObject,
+    Serializable {
+    companion object {
+        fun generate(): ApiKeyId = ApiKeyId(UUID.randomUUID())
+
+        fun from(value: String): ApiKeyId = ApiKeyId(UUID.fromString(value))
+    }
+
+    override fun toString(): String = value.toString()
+}

--- a/modules/auth/credentials/domain/src/test/kotlin/cloud/luigi99/blog/auth/credentials/domain/model/ApiKeyTest.kt
+++ b/modules/auth/credentials/domain/src/test/kotlin/cloud/luigi99/blog/auth/credentials/domain/model/ApiKeyTest.kt
@@ -2,6 +2,8 @@ package cloud.luigi99.blog.auth.credentials.domain.model
 
 import cloud.luigi99.blog.auth.credentials.domain.enums.ApiKeyScope
 import cloud.luigi99.blog.auth.credentials.domain.enums.ApiKeyStatus
+import cloud.luigi99.blog.auth.credentials.domain.vo.ApiKeyId
+import cloud.luigi99.blog.common.domain.AggregateRoot
 import cloud.luigi99.blog.member.domain.member.vo.MemberId
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -9,6 +11,23 @@ import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
 class ApiKeyTest {
+    @Test
+    fun `api key is aggregate root with value object id`() {
+        val apiKey =
+            ApiKey.create(
+                ownerMemberId = MemberId.generate(),
+                name = "Hermes publisher",
+                prefix = "llk_test_123",
+                keyHash = "hash",
+                scopes = setOf(ApiKeyScope.POST_CREATE),
+                expiresAt = null,
+            )
+
+        val aggregateRoot: AggregateRoot<ApiKeyId> = apiKey
+
+        assertTrue(aggregateRoot.entityId.value.toString().isNotBlank())
+    }
+
     @Test
     fun `active key becomes inactive when expired or revoked`() {
         val now = LocalDateTime.parse("2026-04-25T00:00:00")

--- a/modules/auth/credentials/domain/src/test/kotlin/cloud/luigi99/blog/auth/credentials/domain/model/ApiKeyTest.kt
+++ b/modules/auth/credentials/domain/src/test/kotlin/cloud/luigi99/blog/auth/credentials/domain/model/ApiKeyTest.kt
@@ -25,7 +25,11 @@ class ApiKeyTest {
 
         val aggregateRoot: AggregateRoot<ApiKeyId> = apiKey
 
-        assertTrue(aggregateRoot.entityId.value.toString().isNotBlank())
+        assertTrue(
+            aggregateRoot.entityId.value
+                .toString()
+                .isNotBlank(),
+        )
     }
 
     @Test
@@ -38,7 +42,7 @@ class ApiKeyTest {
                 prefix = "llk_test_123",
                 keyHash = "hash",
                 scopes = setOf(ApiKeyScope.POST_CREATE),
-                expiresAt = now.plusDays(1),
+                expiresAt = null,
                 now = now,
             )
 


### PR DESCRIPTION
## 요약
- `ApiKey`를 독립 aggregate root로 정리하고 `ApiKeyId` VO를 추가
- 감사 로그 write port를 `ApiKeyAuditLogRepository`에서 `ApiKeyAuditRecorder`로 변경
- API Key endpoint를 `/api/v1/api-keys`에서 `/api/v1/keys`로 변경
- `ApiKeyApi` 인터페이스를 추가해 Controller/Api 분리 패턴에 맞춤

## 검증
- [x] `git diff --check`
- [x] `/api/v1/api-keys` 잔존 없음 확인
- [x] `ApiKeyAuditLogRepository` 잔존 없음 확인
- [ ] 서버 Gradle/ktlint/test/build는 로컬 정책상 미실행, PR CI에서 검증
