### PR TITLE
feat(media): 이미지 업로드 5MB 정책 적용

### DIFF
--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -23,8 +23,8 @@ spring:
   servlet:
     multipart:
       enabled: true
-      max-file-size: 50MB
-      max-request-size: 50MB
+      max-file-size: 6MB
+      max-request-size: 6MB
 
 cloudflare:
   r2:

--- a/libs/adapter/web/src/main/kotlin/cloud/luigi99/blog/adapter/web/GlobalExceptionHandler.kt
+++ b/libs/adapter/web/src/main/kotlin/cloud/luigi99/blog/adapter/web/GlobalExceptionHandler.kt
@@ -12,6 +12,7 @@ import org.springframework.security.authorization.AuthorizationDeniedException
 import org.springframework.web.bind.MissingRequestHeaderException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.multipart.MaxUploadSizeExceededException
 
 private val log = KotlinLogging.logger {}
 
@@ -49,6 +50,14 @@ class GlobalExceptionHandler {
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(CommonResponse.error(ErrorCode.INVALID_INPUT.code, ErrorCode.INVALID_INPUT.message))
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException::class)
+    fun handleMaxUploadSizeExceededException(e: MaxUploadSizeExceededException): ResponseEntity<CommonResponse<Unit>> {
+        log.warn { "Max upload size exceeded: ${e.message}" }
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(CommonResponse.error(ErrorCode.FILE_SIZE_EXCEEDED.code, ErrorCode.FILE_SIZE_EXCEEDED.message))
     }
 
     @ExceptionHandler(Exception::class)

--- a/libs/common/src/main/kotlin/cloud/luigi99/blog/common/exception/BusinessException.kt
+++ b/libs/common/src/main/kotlin/cloud/luigi99/blog/common/exception/BusinessException.kt
@@ -33,6 +33,7 @@ enum class ErrorCode(val code: String, val message: String, val status: Int) {
     // Media
     FILE_UPLOAD_FAILED("MEDIA_001", "파일 업로드에 실패했습니다.", 500),
     INVALID_FILE_TYPE("MEDIA_002", "지원하지 않는 파일 형식입니다.", 400),
+    FILE_SIZE_EXCEEDED("MEDIA_003", "파일 크기가 제한을 초과했습니다.", 400),
 
     // Guestbook
     GUESTBOOK_NOT_FOUND("GUESTBOOK_001", "방명록을 찾을 수 없습니다.", 404),

--- a/modules/media/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/media/adapter/in/web/MediaApi.kt
+++ b/modules/media/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/media/adapter/in/web/MediaApi.kt
@@ -20,7 +20,7 @@ import org.springframework.web.multipart.MultipartFile
 interface MediaApi {
     @Operation(
         summary = "파일 업로드",
-        description = "이미지 등 파일을 업로드합니다. 최대 10MB까지 업로드 가능합니다.",
+        description = "이미지 파일을 업로드합니다. 파일 1개당 최대 5MB까지 업로드 가능합니다.",
     )
     @ApiResponses(
         value = [

--- a/modules/media/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/media/adapter/in/web/MediaController.kt
+++ b/modules/media/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/media/adapter/in/web/MediaController.kt
@@ -9,6 +9,8 @@ import cloud.luigi99.blog.media.application.media.port.`in`.command.UploadFileUs
 import cloud.luigi99.blog.media.application.media.port.`in`.query.GetFileListUseCase
 import cloud.luigi99.blog.media.application.media.port.`in`.query.GetFileUseCase
 import cloud.luigi99.blog.media.application.media.port.`in`.query.MediaQueryFacade
+import cloud.luigi99.blog.media.domain.media.exception.FileSizeExceededException
+import cloud.luigi99.blog.media.domain.media.vo.FileSize
 import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -42,6 +44,9 @@ class MediaController(
         @RequestPart("file") file: MultipartFile,
     ): ResponseEntity<CommonResponse<FileResponse>> {
         log.info { "Uploading file: ${file.originalFilename}" }
+        if (file.size > FileSize.MAX_BYTES) {
+            throw FileSizeExceededException()
+        }
 
         val response =
             mediaCommandFacade.uploadFile().execute(

--- a/modules/media/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/media/adapter/in/web/MediaControllerTest.kt
+++ b/modules/media/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/media/adapter/in/web/MediaControllerTest.kt
@@ -1,11 +1,15 @@
 package cloud.luigi99.blog.media.adapter.`in`.web
 
+import cloud.luigi99.blog.adapter.web.GlobalExceptionHandler
+import cloud.luigi99.blog.common.exception.ErrorCode
 import cloud.luigi99.blog.media.application.media.port.`in`.command.DeleteFileUseCase
 import cloud.luigi99.blog.media.application.media.port.`in`.command.MediaCommandFacade
 import cloud.luigi99.blog.media.application.media.port.`in`.command.UploadFileUseCase
 import cloud.luigi99.blog.media.application.media.port.`in`.query.GetFileListUseCase
 import cloud.luigi99.blog.media.application.media.port.`in`.query.GetFileUseCase
 import cloud.luigi99.blog.media.application.media.port.`in`.query.MediaQueryFacade
+import cloud.luigi99.blog.media.domain.media.exception.FileSizeExceededException
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -13,6 +17,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.springframework.http.HttpStatus
 import org.springframework.mock.web.MockMultipartFile
+import org.springframework.web.multipart.MaxUploadSizeExceededException
 import java.time.LocalDateTime
 
 /**
@@ -70,6 +75,49 @@ class MediaControllerTest :
                             },
                         )
                     }
+                }
+            }
+        }
+
+        Given("5MB를 초과하는 파일 업로드 요청이 주어졌을 때") {
+            val oversizedCommandFacade = mockk<MediaCommandFacade>()
+            val oversizedController = MediaController(oversizedCommandFacade, mediaQueryFacade)
+            val file =
+                MockMultipartFile(
+                    "file",
+                    "large.png",
+                    "image/png",
+                    ByteArray((5L * 1024L * 1024L + 1L).toInt()),
+                )
+
+            When("파일을 업로드하면") {
+                Then("controller에서 file.bytes 접근 전에 크기 초과 예외가 발생하고 UseCase는 호출되지 않는다") {
+                    shouldThrow<FileSizeExceededException> {
+                        oversizedController.uploadFile(file)
+                    }
+                    verify(exactly = 0) { oversizedCommandFacade.uploadFile() }
+                }
+            }
+        }
+
+        Given("Spring multipart resolver에서 업로드 크기 초과 예외가 발생했을 때") {
+            val exceptionHandler = GlobalExceptionHandler()
+
+            When("MaxUploadSizeExceededException을 처리하면") {
+                val result =
+                    exceptionHandler.handleMaxUploadSizeExceededException(
+                        MaxUploadSizeExceededException(6L * 1024L * 1024L),
+                    )
+
+                Then("MEDIA_003 400 응답이 반환되어야 한다") {
+                    result.statusCode shouldBe HttpStatus.BAD_REQUEST
+                    result.body?.success shouldBe false
+                    result.body
+                        ?.error
+                        ?.code shouldBe ErrorCode.FILE_SIZE_EXCEEDED.code
+                    result.body
+                        ?.error
+                        ?.message shouldBe ErrorCode.FILE_SIZE_EXCEEDED.message
                 }
             }
         }

--- a/modules/media/application/src/main/kotlin/cloud/luigi99/blog/media/application/media/service/command/UploadFileService.kt
+++ b/modules/media/application/src/main/kotlin/cloud/luigi99/blog/media/application/media/service/command/UploadFileService.kt
@@ -3,6 +3,7 @@ package cloud.luigi99.blog.media.application.media.service.command
 import cloud.luigi99.blog.media.application.media.port.`in`.command.UploadFileUseCase
 import cloud.luigi99.blog.media.application.media.port.out.MediaFileRepository
 import cloud.luigi99.blog.media.application.media.port.out.StoragePort
+import cloud.luigi99.blog.media.domain.media.exception.InvalidFileTypeException
 import cloud.luigi99.blog.media.domain.media.model.MediaFile
 import cloud.luigi99.blog.media.domain.media.vo.FileSize
 import cloud.luigi99.blog.media.domain.media.vo.MimeType
@@ -30,6 +31,9 @@ class UploadFileService(private val mediaFileRepository: MediaFileRepository, pr
         val originalFileName = OriginalFileName(command.originalFileName)
         val mimeType = MimeType(command.mimeType)
         val fileSize = FileSize(command.fileSize)
+        if (!MimeType.matchesMagicBytes(mimeType.value, command.fileData)) {
+            throw InvalidFileTypeException()
+        }
         val storageKey = StorageKey.generate(originalFileName.value)
 
         // Storage에 업로드

--- a/modules/media/application/src/test/kotlin/cloud/luigi99/blog/media/application/media/service/command/UploadFileServiceTest.kt
+++ b/modules/media/application/src/test/kotlin/cloud/luigi99/blog/media/application/media/service/command/UploadFileServiceTest.kt
@@ -4,6 +4,8 @@ import cloud.luigi99.blog.common.domain.event.EventManager
 import cloud.luigi99.blog.media.application.media.port.`in`.command.UploadFileUseCase
 import cloud.luigi99.blog.media.application.media.port.out.MediaFileRepository
 import cloud.luigi99.blog.media.application.media.port.out.StoragePort
+import cloud.luigi99.blog.media.domain.media.exception.FileSizeExceededException
+import cloud.luigi99.blog.media.domain.media.exception.InvalidFileTypeException
 import cloud.luigi99.blog.media.domain.media.model.MediaFile
 import cloud.luigi99.blog.media.domain.media.vo.FileSize
 import cloud.luigi99.blog.media.domain.media.vo.MediaFileId
@@ -33,12 +35,13 @@ class UploadFileServiceTest :
             val storagePort = mockk<StoragePort>()
             val service = UploadFileService(mediaFileRepository, storagePort)
 
+            val pngBytes = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
             val command =
                 UploadFileUseCase.Command(
                     originalFileName = "test.png",
                     mimeType = "image/png",
                     fileSize = 1024L,
-                    fileData = ByteArray(1024),
+                    fileData = pngBytes,
                 )
 
             When("파일을 업로드하면") {
@@ -62,7 +65,7 @@ class UploadFileServiceTest :
                 val response = service.execute(command)
 
                 Then("Storage에 업로드가 호출된다") {
-                    verify(exactly = 1) { storagePort.upload(any(), any(), "image/png") }
+                    verify(exactly = 1) { storagePort.upload(any(), pngBytes, "image/png") }
                 }
 
                 Then("Repository의 save가 호출된다") {
@@ -123,6 +126,52 @@ class UploadFileServiceTest :
                             service.execute(command)
                         }
                     exception.message shouldContain "File size must be positive"
+                }
+            }
+        }
+
+        Given("파일 크기가 5MB를 초과하는 이미지가 주어졌을 때") {
+            val mediaFileRepository = mockk<MediaFileRepository>()
+            val storagePort = mockk<StoragePort>()
+            val service = UploadFileService(mediaFileRepository, storagePort)
+
+            val command =
+                UploadFileUseCase.Command(
+                    originalFileName = "large.png",
+                    mimeType = "image/png",
+                    fileSize = 5L * 1024L * 1024L + 1L,
+                    fileData = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A),
+                )
+
+            When("파일을 업로드하려고 하면") {
+                Then("파일 크기 초과 예외가 발생하고 Storage는 호출되지 않는다") {
+                    shouldThrow<FileSizeExceededException> {
+                        service.execute(command)
+                    }
+                    verify(exactly = 0) { storagePort.upload(any(), any(), any()) }
+                }
+            }
+        }
+
+        Given("선언 MIME 타입과 실제 파일 시그니처가 다른 이미지가 주어졌을 때") {
+            val mediaFileRepository = mockk<MediaFileRepository>()
+            val storagePort = mockk<StoragePort>()
+            val service = UploadFileService(mediaFileRepository, storagePort)
+
+            val command =
+                UploadFileUseCase.Command(
+                    originalFileName = "spoofed.png",
+                    mimeType = "image/png",
+                    fileSize = 6L,
+                    fileData = "GIF89a".toByteArray(),
+                )
+
+            When("파일을 업로드하려고 하면") {
+                Then("지원하지 않는 파일 형식 예외가 발생하고 Storage는 호출되지 않는다") {
+                    shouldThrow<InvalidFileTypeException> {
+                        service.execute(command)
+                    }
+                    verify(exactly = 0) { storagePort.upload(any(), any(), any()) }
                 }
             }
         }

--- a/modules/media/domain/src/main/kotlin/cloud/luigi99/blog/media/domain/media/exception/FileSizeExceededException.kt
+++ b/modules/media/domain/src/main/kotlin/cloud/luigi99/blog/media/domain/media/exception/FileSizeExceededException.kt
@@ -1,0 +1,7 @@
+package cloud.luigi99.blog.media.domain.media.exception
+
+import cloud.luigi99.blog.common.exception.BusinessException
+import cloud.luigi99.blog.common.exception.ErrorCode
+
+class FileSizeExceededException(message: String = ErrorCode.FILE_SIZE_EXCEEDED.message) :
+    BusinessException(ErrorCode.FILE_SIZE_EXCEEDED, message)

--- a/modules/media/domain/src/main/kotlin/cloud/luigi99/blog/media/domain/media/exception/InvalidFileTypeException.kt
+++ b/modules/media/domain/src/main/kotlin/cloud/luigi99/blog/media/domain/media/exception/InvalidFileTypeException.kt
@@ -1,0 +1,7 @@
+package cloud.luigi99.blog.media.domain.media.exception
+
+import cloud.luigi99.blog.common.exception.BusinessException
+import cloud.luigi99.blog.common.exception.ErrorCode
+
+class InvalidFileTypeException(message: String = ErrorCode.INVALID_FILE_TYPE.message) :
+    BusinessException(ErrorCode.INVALID_FILE_TYPE, message)

--- a/modules/media/domain/src/main/kotlin/cloud/luigi99/blog/media/domain/media/vo/FileSize.kt
+++ b/modules/media/domain/src/main/kotlin/cloud/luigi99/blog/media/domain/media/vo/FileSize.kt
@@ -1,6 +1,7 @@
 package cloud.luigi99.blog.media.domain.media.vo
 
 import cloud.luigi99.blog.common.domain.ValueObject
+import cloud.luigi99.blog.media.domain.media.exception.FileSizeExceededException
 
 /**
  * 파일 크기 Value Object
@@ -10,6 +11,9 @@ import cloud.luigi99.blog.common.domain.ValueObject
 value class FileSize(val bytes: Long) : ValueObject {
     init {
         require(bytes > 0) { "File size must be positive" }
+        if (bytes > MAX_BYTES) {
+            throw FileSizeExceededException()
+        }
     }
 
     /**
@@ -18,4 +22,8 @@ value class FileSize(val bytes: Long) : ValueObject {
      * @return 메가바이트 단위의 파일 크기
      */
     fun toMegaBytes(): Double = bytes.toDouble() / 1024 / 1024
+
+    companion object {
+        const val MAX_BYTES: Long = 5L * 1024L * 1024L
+    }
 }

--- a/modules/media/domain/src/main/kotlin/cloud/luigi99/blog/media/domain/media/vo/MimeType.kt
+++ b/modules/media/domain/src/main/kotlin/cloud/luigi99/blog/media/domain/media/vo/MimeType.kt
@@ -26,6 +26,8 @@ value class MimeType(val value: String) : ValueObject {
                 "image/webp",
             )
 
+        private val PNG_SIGNATURE = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+
         /**
          * 주어진 MIME 타입이 허용되는지 확인합니다.
          *
@@ -33,5 +35,37 @@ value class MimeType(val value: String) : ValueObject {
          * @return 허용 여부
          */
         fun isAllowed(value: String): Boolean = value in ALLOWED_TYPES
+
+        /**
+         * 선언된 MIME 타입과 파일 시그니처(magic bytes)가 일치하는지 확인합니다.
+         */
+        fun matchesMagicBytes(value: String, bytes: ByteArray): Boolean =
+            when (value) {
+                "image/jpeg" -> {
+                    bytes.startsWithBytes(byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte()))
+                }
+
+                "image/png" -> {
+                    bytes.startsWithBytes(PNG_SIGNATURE)
+                }
+
+                "image/gif" -> {
+                    bytes.startsWithBytes("GIF87a".toByteArray()) ||
+                        bytes.startsWithBytes("GIF89a".toByteArray())
+                }
+
+                "image/webp" -> {
+                    bytes.size >= 12 &&
+                        bytes.startsWithBytes("RIFF".toByteArray()) &&
+                        bytes.sliceArray(8 until 12).contentEquals("WEBP".toByteArray())
+                }
+
+                else -> {
+                    false
+                }
+            }
+
+        private fun ByteArray.startsWithBytes(prefix: ByteArray): Boolean =
+            size >= prefix.size && prefix.indices.all { this[it] == prefix[it] }
     }
 }

--- a/modules/media/domain/src/test/kotlin/cloud/luigi99/blog/media/domain/media/vo/FileSizeTest.kt
+++ b/modules/media/domain/src/test/kotlin/cloud/luigi99/blog/media/domain/media/vo/FileSizeTest.kt
@@ -1,5 +1,6 @@
 package cloud.luigi99.blog.media.domain.media.vo
 
+import cloud.luigi99.blog.media.domain.media.exception.FileSizeExceededException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -18,6 +19,32 @@ class FileSizeTest :
 
                 Then("정상적으로 값이 저장된다") {
                     fileSize.bytes shouldBe validSize
+                }
+            }
+        }
+
+        Given("파일 크기가 정확히 5MB인 경우") {
+            val maxSize = 5L * 1024L * 1024L
+
+            When("파일 크기 객체를 생성하면") {
+                val fileSize = FileSize(maxSize)
+
+                Then("정상적으로 값이 저장된다") {
+                    fileSize.bytes shouldBe maxSize
+                }
+            }
+        }
+
+        Given("파일 크기가 5MB를 초과한 경우") {
+            val oversized = 5L * 1024L * 1024L + 1L
+
+            When("객체 생성을 시도하면") {
+                Then("파일 크기 초과 오류가 발생한다") {
+                    val exception =
+                        shouldThrow<FileSizeExceededException> {
+                            FileSize(oversized)
+                        }
+                    exception.message shouldContain "파일 크기가 제한을 초과했습니다."
                 }
             }
         }

--- a/modules/media/domain/src/test/kotlin/cloud/luigi99/blog/media/domain/media/vo/MimeTypeTest.kt
+++ b/modules/media/domain/src/test/kotlin/cloud/luigi99/blog/media/domain/media/vo/MimeTypeTest.kt
@@ -54,4 +54,30 @@ class MimeTypeTest :
                 }
             }
         }
+
+        Given("MIME 타입과 파일 시그니처가 일치하는 경우") {
+            val samples =
+                mapOf(
+                    "image/jpeg" to byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0x00),
+                    "image/png" to byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A),
+                    "image/gif" to "GIF89a".toByteArray(),
+                    "image/webp" to "RIFFxxxxWEBP".toByteArray(),
+                )
+
+            samples.forEach { (type, bytes) ->
+                When("$type 파일 시그니처를 검증하면") {
+                    Then("검증을 통과한다") {
+                        MimeType.matchesMagicBytes(type, bytes) shouldBe true
+                    }
+                }
+            }
+        }
+
+        Given("MIME 타입과 파일 시그니처가 일치하지 않는 경우") {
+            When("PNG로 선언된 GIF 바이트를 검증하면") {
+                Then("검증에 실패한다") {
+                    MimeType.matchesMagicBytes("image/png", "GIF89a".toByteArray()) shouldBe false
+                }
+            }
+        }
     })


### PR DESCRIPTION
## Summary
- Enforce 5MB max image upload policy across domain/application/web paths
- Add controller precheck before reading multipart bytes
- Add JPEG/PNG/GIF/WebP magic-byte validation to reduce MIME spoofing
- Map oversized multipart requests to MEDIA_003 / HTTP 400
- Update API docs and multipart limits while preserving POST /api/v1/files contract

## Test Plan
- git diff --check
- Added/updated domain/application/web tests for 5MB policy, MIME spoofing, and multipart size handler
- Local Gradle tests intentionally not run; backend verification is expected via CI per project policy.