### PR TITLE
fix(media): 잘못된 파일 형식 에러 계약 수정

### DIFF
--- a/modules/media/application/src/test/kotlin/cloud/luigi99/blog/media/application/media/service/command/UploadFileServiceTest.kt
+++ b/modules/media/application/src/test/kotlin/cloud/luigi99/blog/media/application/media/service/command/UploadFileServiceTest.kt
@@ -96,12 +96,11 @@ class UploadFileServiceTest :
                 )
 
             When("파일을 업로드하려고 하면") {
-                Then("IllegalArgumentException이 발생한다") {
-                    val exception =
-                        shouldThrow<IllegalArgumentException> {
-                            service.execute(command)
-                        }
-                    exception.message shouldContain "Unsupported MIME type"
+                Then("지원하지 않는 파일 형식 예외가 발생하고 Storage는 호출되지 않는다") {
+                    shouldThrow<InvalidFileTypeException> {
+                        service.execute(command)
+                    }
+                    verify(exactly = 0) { storagePort.upload(any(), any(), any()) }
                 }
             }
         }

--- a/modules/media/domain/src/main/kotlin/cloud/luigi99/blog/media/domain/media/vo/MimeType.kt
+++ b/modules/media/domain/src/main/kotlin/cloud/luigi99/blog/media/domain/media/vo/MimeType.kt
@@ -1,6 +1,7 @@
 package cloud.luigi99.blog.media.domain.media.vo
 
 import cloud.luigi99.blog.common.domain.ValueObject
+import cloud.luigi99.blog.media.domain.media.exception.InvalidFileTypeException
 
 /**
  * MIME 타입 Value Object
@@ -9,8 +10,8 @@ import cloud.luigi99.blog.common.domain.ValueObject
 @JvmInline
 value class MimeType(val value: String) : ValueObject {
     init {
-        require(value in ALLOWED_TYPES) {
-            "Unsupported MIME type: $value. Allowed types: ${ALLOWED_TYPES.joinToString()}"
+        if (value !in ALLOWED_TYPES) {
+            throw InvalidFileTypeException()
         }
     }
 

--- a/modules/media/domain/src/test/kotlin/cloud/luigi99/blog/media/domain/media/vo/MimeTypeTest.kt
+++ b/modules/media/domain/src/test/kotlin/cloud/luigi99/blog/media/domain/media/vo/MimeTypeTest.kt
@@ -1,9 +1,10 @@
 package cloud.luigi99.blog.media.domain.media.vo
 
+import cloud.luigi99.blog.common.exception.ErrorCode
+import cloud.luigi99.blog.media.domain.media.exception.InvalidFileTypeException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldContain
 
 /**
  * MimeType Value Object 테스트
@@ -31,10 +32,10 @@ class MimeTypeTest :
                 When("$type 형식으로 객체 생성을 시도하면") {
                     Then("지원하지 않는 미디어 타입 오류가 발생한다") {
                         val exception =
-                            shouldThrow<IllegalArgumentException> {
+                            shouldThrow<InvalidFileTypeException> {
                                 MimeType(type)
                             }
-                        exception.message shouldContain "Unsupported MIME type"
+                        exception.errorCode shouldBe ErrorCode.INVALID_FILE_TYPE
                     }
                 }
             }


### PR DESCRIPTION
## 📋 개요
- 지원하지 않는 MIME type 업로드가 500 COMMON_002로 떨어지는 문제를 수정합니다.
- MimeType VO에서 기존 InvalidFileTypeException을 사용하도록 변경해 MEDIA_002/4xx 에러 계약을 타게 합니다.
- 관련 domain/application 테스트 기대값을 갱신했습니다.

## 🔗 관련 이슈
- Closes #

## ☑️ 체크리스트
- [ ] 코딩 컨벤션을 준수했나요? (`./gradlew ktlintCheck`)
  - 로컬 Gradle/ktlint는 리소스 보호 정책상 미실행, PR CI로 확인합니다.
- [ ] 모든 테스트를 통과했나요? (`./gradlew test`)
  - 로컬 Gradle/test는 리소스 보호 정책상 미실행, PR CI로 확인합니다.
- [x] 불필요한 주석이나 로그는 제거했나요?

## 운영 QA 근거
- 테스트 API key로 운영 `/api/v1/files` 업로드 smoke 확인
- valid GIF 업로드: 201 성공
- non-image 업로드: 500 COMMON_002 재현 → blocker로 수정
- API key/token 값은 PR/로그에 남기지 않았습니다.
