### PR TITLE
feat(posts): 태그 정확 필터 추가

### DIFF
--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostApi.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostApi.kt
@@ -409,7 +409,7 @@ interface PostApi {
 
     @Operation(
         summary = "블로그 글 목록 조회",
-        description = "블로그 글 목록을 조회합니다. 상태 및 타입 필터링이 가능합니다.",
+        description = "블로그 글 목록을 조회합니다. 상태, 타입, 검색어, exact 태그 필터링이 가능합니다.",
     )
     @ApiResponses(
         value = [
@@ -460,6 +460,9 @@ interface PostApi {
         @Parameter(description = "상태 필터 (DRAFT, PUBLISHED, ARCHIVED)") @RequestParam(required = false) status: String?,
         @Parameter(description = "타입 필터 (BLOG, PORTFOLIO)") @RequestParam(required = false) type: String?,
         @Parameter(description = "검색어 (title/body/tags)") @RequestParam(required = false) q: String?,
+        @Parameter(description = "태그 exact match 필터 (q의 LIKE 검색과 별도, 함께 지정하면 AND 적용)")
+        @RequestParam(required = false)
+        tag: String?,
         @Parameter(description = "페이지 크기 (기본 20, 최대 50)") @RequestParam(required = false) limit: Int?,
         @Parameter(description = "커서") @RequestParam(required = false) cursor: String?,
     ): ResponseEntity<CommonResponse<PostListResponse>>

--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostController.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostController.kt
@@ -221,12 +221,13 @@ class PostController(private val postQueryFacade: PostQueryFacade, private val p
         @RequestParam(required = false) status: String?,
         @RequestParam(required = false) type: String?,
         @RequestParam(required = false) q: String?,
+        @RequestParam(required = false) tag: String?,
         @RequestParam(required = false) limit: Int?,
         @RequestParam(required = false) cursor: String?,
     ): ResponseEntity<CommonResponse<PostListResponse>> {
-        log.info { "Listing posts with filters - status: $status, type: $type" }
+        log.info { "Listing posts with filters - status: $status, type: $type, tag: $tag" }
 
-        val query = GetPostsUseCase.Query(status = status, type = type, q = q, limit = limit, cursor = cursor)
+        val query = GetPostsUseCase.Query(status = status, type = type, q = q, tag = tag, limit = limit, cursor = cursor)
         val response = postQueryFacade.getPosts().execute(query)
 
         val summaries =

--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostController.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostController.kt
@@ -227,7 +227,15 @@ class PostController(private val postQueryFacade: PostQueryFacade, private val p
     ): ResponseEntity<CommonResponse<PostListResponse>> {
         log.info { "Listing posts with filters - status: $status, type: $type, tag: $tag" }
 
-        val query = GetPostsUseCase.Query(status = status, type = type, q = q, tag = tag, limit = limit, cursor = cursor)
+        val query =
+            GetPostsUseCase.Query(
+                status = status,
+                type = type,
+                q = q,
+                tag = tag,
+                limit = limit,
+                cursor = cursor,
+            )
         val response = postQueryFacade.getPosts().execute(query)
 
         val summaries =

--- a/modules/content/post/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostControllerTest.kt
+++ b/modules/content/post/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostControllerTest.kt
@@ -8,6 +8,7 @@ import cloud.luigi99.blog.content.post.application.port.`in`.command.PostCommand
 import cloud.luigi99.blog.content.post.application.port.`in`.command.UpdatePostUseCase
 import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostByIdUseCase
 import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostBySlugUseCase
+import cloud.luigi99.blog.content.post.application.port.`in`.query.GetPostsUseCase
 import cloud.luigi99.blog.content.post.application.port.`in`.query.PostQueryFacade
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -17,6 +18,7 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.verify
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.AccessDeniedException
@@ -431,6 +433,43 @@ class PostControllerTest :
                     response.body
                         ?.data
                         ?.title shouldBe "테스트 글"
+                }
+            }
+        }
+
+        Given("글 목록을 태그로 조회할 때") {
+            val getPostsUseCase = mockk<GetPostsUseCase>()
+            every { postQueryFacade.getPosts() } returns getPostsUseCase
+
+            When("q와 tag query parameter가 함께 전달되면") {
+                every { getPostsUseCase.execute(any()) } returns
+                    GetPostsUseCase.Response(
+                        posts = emptyList(),
+                        pageInfo = GetPostsUseCase.PageInfo(limit = 20, hasNext = false, nextCursor = null),
+                    )
+
+                val response =
+                    controller.getPosts(
+                        status = "PUBLISHED",
+                        type = "BLOG",
+                        q = "kotlin",
+                        tag = "Spring Boot",
+                        limit = null,
+                        cursor = null,
+                    )
+
+                Then("tag를 q와 별도 필터로 UseCase에 전달해야 한다") {
+                    response.statusCode shouldBe HttpStatus.OK
+                    verify(exactly = 1) {
+                        getPostsUseCase.execute(
+                            match {
+                                it.status == "PUBLISHED" &&
+                                    it.type == "BLOG" &&
+                                    it.q == "kotlin" &&
+                                    it.tag == "Spring Boot"
+                            },
+                        )
+                    }
                 }
             }
         }

--- a/modules/content/post/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostJpaRepository.kt
+++ b/modules/content/post/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostJpaRepository.kt
@@ -93,6 +93,11 @@ interface PostJpaRepository : JpaRepository<PostJpaEntity, UUID> {
                 WHERE pt.post_id = p.id
                   AND lower(pt.tag_name) LIKE lower(concat('%', CAST(:q AS varchar), '%'))
             ))
+          AND (:tagFilterEnabled = false OR EXISTS (
+                SELECT 1 FROM post_tag pt
+                WHERE pt.post_id = p.id
+                  AND pt.tag_name = CAST(:tag AS varchar)
+            ))
           AND (
             :cursorFilterEnabled = false
             OR p.created_at < :cursorCreatedAt
@@ -107,11 +112,13 @@ interface PostJpaRepository : JpaRepository<PostJpaEntity, UUID> {
         @Param("status") status: String?,
         @Param("type") type: String?,
         @Param("q") q: String?,
+        @Param("tag") tag: String?,
         @Param("cursorCreatedAt") cursorCreatedAt: LocalDateTime?,
         @Param("cursorPostId") cursorPostId: UUID?,
         @Param("statusFilterEnabled") statusFilterEnabled: Boolean,
         @Param("typeFilterEnabled") typeFilterEnabled: Boolean,
         @Param("qFilterEnabled") qFilterEnabled: Boolean,
+        @Param("tagFilterEnabled") tagFilterEnabled: Boolean,
         @Param("cursorFilterEnabled") cursorFilterEnabled: Boolean,
         @Param("limit") limit: Int,
     ): List<PostJpaEntity>

--- a/modules/content/post/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostRepositoryAdapter.kt
+++ b/modules/content/post/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostRepositoryAdapter.kt
@@ -130,20 +130,24 @@ class PostRepositoryAdapter(
         status: PostStatus?,
         type: ContentType?,
         q: String?,
+        tag: String?,
         limit: Int,
         cursor: PostRepository.PostCursor?,
     ): PostRepository.PostListResult {
         val trimmedQuery = q?.trim()?.takeIf { it.isNotEmpty() }
+        val trimmedTag = tag?.trim()?.takeIf { it.isNotEmpty() }
         val rows =
             jpaRepository.search(
                 status = status?.name,
                 type = type?.name,
                 q = trimmedQuery,
+                tag = trimmedTag,
                 cursorCreatedAt = cursor?.createdAt,
                 cursorPostId = cursor?.postId?.value,
                 statusFilterEnabled = status != null,
                 typeFilterEnabled = type != null,
                 qFilterEnabled = trimmedQuery != null,
+                tagFilterEnabled = trimmedTag != null,
                 cursorFilterEnabled = cursor != null,
                 limit = limit + 1,
             )

--- a/modules/content/post/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostRepositoryAdapterTest.kt
+++ b/modules/content/post/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostRepositoryAdapterTest.kt
@@ -221,17 +221,19 @@ class PostRepositoryAdapterTest :
                         status = null,
                         type = null,
                         q = null,
+                        tag = null,
                         cursorCreatedAt = null,
                         cursorPostId = null,
                         statusFilterEnabled = false,
                         typeFilterEnabled = false,
                         qFilterEnabled = false,
+                        tagFilterEnabled = false,
                         cursorFilterEnabled = false,
                         limit = 7,
                     )
                 } returns emptyList()
 
-                val result = adapter.search(null, null, null, 6, null)
+                val result = adapter.search(null, null, null, null, 6, null)
 
                 Then("nullable 파라미터 IS NULL 조건 대신 명시적 필터 플래그를 비활성화한다") {
                     result.posts shouldBe emptyList()
@@ -241,11 +243,13 @@ class PostRepositoryAdapterTest :
                             status = null,
                             type = null,
                             q = null,
+                            tag = null,
                             cursorCreatedAt = null,
                             cursorPostId = null,
                             statusFilterEnabled = false,
                             typeFilterEnabled = false,
                             qFilterEnabled = false,
+                            tagFilterEnabled = false,
                             cursorFilterEnabled = false,
                             limit = 7,
                         )
@@ -259,17 +263,19 @@ class PostRepositoryAdapterTest :
                         status = PostStatus.PUBLISHED.name,
                         type = null,
                         q = null,
+                        tag = null,
                         cursorCreatedAt = null,
                         cursorPostId = null,
                         statusFilterEnabled = true,
                         typeFilterEnabled = false,
                         qFilterEnabled = false,
+                        tagFilterEnabled = false,
                         cursorFilterEnabled = false,
                         limit = 2,
                     )
                 } returns emptyList()
 
-                adapter.search(PostStatus.PUBLISHED, null, null, 1, null)
+                adapter.search(PostStatus.PUBLISHED, null, null, null, 1, null)
 
                 Then("상태 필터만 활성화하고 나머지 nullable 필터는 비활성화한다") {
                     verify(exactly = 1) {
@@ -277,11 +283,53 @@ class PostRepositoryAdapterTest :
                             status = PostStatus.PUBLISHED.name,
                             type = null,
                             q = null,
+                            tag = null,
                             cursorCreatedAt = null,
                             cursorPostId = null,
                             statusFilterEnabled = true,
                             typeFilterEnabled = false,
                             qFilterEnabled = false,
+                            tagFilterEnabled = false,
+                            cursorFilterEnabled = false,
+                            limit = 2,
+                        )
+                    }
+                }
+            }
+
+            When("태그 필터가 있으면") {
+                every {
+                    jpaRepository.search(
+                        status = null,
+                        type = null,
+                        q = null,
+                        tag = "Kotlin",
+                        cursorCreatedAt = null,
+                        cursorPostId = null,
+                        statusFilterEnabled = false,
+                        typeFilterEnabled = false,
+                        qFilterEnabled = false,
+                        tagFilterEnabled = true,
+                        cursorFilterEnabled = false,
+                        limit = 2,
+                    )
+                } returns emptyList()
+
+                adapter.search(null, null, null, " Kotlin ", 1, null)
+
+                Then("태그 필터를 trim한 exact match 조건으로 활성화한다") {
+                    verify(exactly = 1) {
+                        jpaRepository.search(
+                            status = null,
+                            type = null,
+                            q = null,
+                            tag = "Kotlin",
+                            cursorCreatedAt = null,
+                            cursorPostId = null,
+                            statusFilterEnabled = false,
+                            typeFilterEnabled = false,
+                            qFilterEnabled = false,
+                            tagFilterEnabled = true,
                             cursorFilterEnabled = false,
                             limit = 2,
                         )

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/in/query/GetPostsUseCase.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/in/query/GetPostsUseCase.kt
@@ -21,11 +21,13 @@ interface GetPostsUseCase {
      *
      * @property status 상태 필터 (null이면 전체)
      * @property type 컨텐츠 타입 필터 (null이면 전체)
+     * @property tag 태그 exact match 필터 (null이면 전체)
      */
     data class Query(
         val status: String? = null,
         val type: String? = null,
         val q: String? = null,
+        val tag: String? = null,
         val limit: Int? = null,
         val cursor: String? = null,
     )

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/out/PostRepository.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/out/PostRepository.kt
@@ -86,6 +86,7 @@ interface PostRepository : Repository<Post, PostId> {
         status: PostStatus?,
         type: ContentType?,
         q: String?,
+        tag: String?,
         limit: Int,
         cursor: PostCursor?,
     ): PostListResult

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostsService.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostsService.kt
@@ -29,10 +29,11 @@ class GetPostsService(private val postRepository: PostRepository, private val me
         val cursor = query.cursor?.let { decodeCursor(it) }
 
         log.info {
-            "Listing posts with filters - status: ${query.status}, type: ${query.type}, q: ${query.q}, limit: $limit"
+            "Listing posts with filters - status: ${query.status}, type: ${query.type}, " +
+                "q: ${query.q}, tag: ${query.tag}, limit: $limit"
         }
 
-        val result = postRepository.search(status, type, query.q, limit, cursor)
+        val result = postRepository.search(status, type, query.q, query.tag, limit, cursor)
         val posts = result.posts
         val commentCounts = postRepository.countCommentsByPostIds(posts.map { it.entityId })
         val memberIds =

--- a/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostsServiceTest.kt
+++ b/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostsServiceTest.kt
@@ -19,6 +19,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.verify
 
 /**
  * GetPostsService 테스트
@@ -58,7 +59,7 @@ class GetPostsServiceTest :
                     )
 
                 every { postRepository.findAll() } returns posts
-                every { postRepository.search(null, null, null, 20, null) } returns
+                every { postRepository.search(null, null, null, null, 20, null) } returns
                     PostRepository.PostListResult(posts, false)
                 every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
                 every { memberClient.getAuthors(any()) } returns emptyMap()
@@ -98,7 +99,7 @@ class GetPostsServiceTest :
                     )
 
                 every { postRepository.findAllByStatus(PostStatus.PUBLISHED) } returns publishedPosts
-                every { postRepository.search(PostStatus.PUBLISHED, null, null, 20, null) } returns
+                every { postRepository.search(PostStatus.PUBLISHED, null, null, null, 20, null) } returns
                     PostRepository.PostListResult(publishedPosts, false)
                 every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
                 every { memberClient.getAuthors(any()) } returns emptyMap()
@@ -131,7 +132,7 @@ class GetPostsServiceTest :
                     )
 
                 every { postRepository.findAllByContentType(ContentType.PORTFOLIO) } returns portfolioPosts
-                every { postRepository.search(null, ContentType.PORTFOLIO, null, 20, null) } returns
+                every { postRepository.search(null, ContentType.PORTFOLIO, null, null, 20, null) } returns
                     PostRepository.PostListResult(portfolioPosts, false)
                 every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
                 every { memberClient.getAuthors(any()) } returns emptyMap()
@@ -140,6 +141,29 @@ class GetPostsServiceTest :
 
                 Then("PORTFOLIO 글만 반환된다") {
                     response.posts.size shouldBe 1
+                }
+            }
+        }
+        Given("태그 exact match 필터로 글 목록을 조회할 때") {
+            val postRepository = mockk<PostRepository>()
+            val memberClient = mockk<MemberClient>()
+            val service = GetPostsService(postRepository, memberClient)
+
+            When("q와 tag가 함께 있으면") {
+                val query = GetPostsUseCase.Query(q = "kotlin", tag = "Spring Boot")
+
+                every { postRepository.search(null, null, "kotlin", "Spring Boot", 20, null) } returns
+                    PostRepository.PostListResult(emptyList(), false)
+                every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
+                every { memberClient.getAuthors(any()) } returns emptyMap()
+
+                val response = service.execute(query)
+
+                Then("q와 tag를 모두 repository 검색 조건으로 전달한다") {
+                    response.posts shouldBe emptyList()
+                    verify(exactly = 1) {
+                        postRepository.search(null, null, "kotlin", "Spring Boot", 20, null)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## 📋 개요
- 게시글 목록 API에 `tag` query parameter를 추가했습니다.
- 기존 `q` 검색은 title/body/tags broad search로 유지하고, 신규 `tag`는 exact tag filter로 동작합니다.
- `q`와 `tag`가 같이 전달되면 AND 조건으로 적용됩니다.

## 🔗 관련 이슈
- Closes #

## ☑️ 체크리스트
- [x] 코딩 컨벤션을 준수했나요? (`./gradlew ktlintCheck`)
  - 로컬 Gradle 미실행(리소스 보호 정책), `git diff --check`로 whitespace 검증 완료
- [ ] 모든 테스트를 통과했나요? (`./gradlew test`)
  - 로컬 Gradle 미실행(리소스 보호 정책), PR CI로 확인 예정
- [x] 불필요한 주석이나 로그는 제거했나요?
