### PR TITLE
fix(posts): 수정 API에서 태그 교체 지원

### DIFF
--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostApi.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostApi.kt
@@ -159,7 +159,8 @@ interface PostApi {
 
     @Operation(
         summary = "블로그 글 수정",
-        description = "기존 블로그 글의 제목, 본문, 상태를 선택적으로 수정합니다. null인 필드는 변경되지 않습니다.",
+        description = "기존 블로그 글의 제목, 본문, 태그, 상태를 선택적으로 수정합니다. " +
+            "null인 필드는 변경되지 않습니다. tags는 null이면 변경하지 않고, []이면 전체 제거하며, 값이 있으면 요청 태그로 교체합니다.",
         security = [SecurityRequirement(name = "Bearer Authentication")],
     )
     @ApiResponses(
@@ -167,7 +168,40 @@ interface PostApi {
             ApiResponse(
                 responseCode = "200",
                 description = "글 수정 성공",
-                content = [Content(schema = Schema(implementation = CommonResponse::class))],
+                content = [
+                    Content(
+                        schema = Schema(implementation = CommonResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "UpdatePostTagsSuccess",
+                                value = """
+                                {
+                                  "success": true,
+                                  "data": {
+                                    "postId": "550e8400-e29b-41d4-a716-446655440000",
+                                    "author": {
+                                      "memberId": "987e6543-e21b-98d7-a654-426614174111",
+                                      "nickname": "Luigi99",
+                                      "profileImageUrl": null,
+                                      "username": "luigi99"
+                                    },
+                                    "title": "Kotlin으로 DDD 구현하기",
+                                    "slug": "kotlin-ddd-implementation",
+                                    "body": "# 시작하기\n\nKotlin과 DDD를 결합하면...",
+                                    "type": "BLOG",
+                                    "status": "DRAFT",
+                                    "tags": ["Kotlin", "Spring"],
+                                    "createdAt": "2025-12-31T12:00:00",
+                                    "updatedAt": "2025-12-31T12:30:00"
+                                  },
+                                  "error": null,
+                                  "timestamp": "2025-12-31T12:30:00"
+                                }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
             ),
             ApiResponse(
                 responseCode = "401",

--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostApi.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostApi.kt
@@ -159,8 +159,9 @@ interface PostApi {
 
     @Operation(
         summary = "블로그 글 수정",
-        description = "기존 블로그 글의 제목, 본문, 태그, 상태를 선택적으로 수정합니다. " +
-            "null인 필드는 변경되지 않습니다. tags는 null이면 변경하지 않고, []이면 전체 제거하며, 값이 있으면 요청 태그로 교체합니다.",
+        description =
+            "기존 블로그 글의 제목, 본문, 태그, 상태를 선택적으로 수정합니다. " +
+                "null인 필드는 변경되지 않습니다. tags는 null이면 변경하지 않고, []이면 전체 제거하며, 값이 있으면 요청 태그로 교체합니다.",
         security = [SecurityRequirement(name = "Bearer Authentication")],
     )
     @ApiResponses(

--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostController.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostController.kt
@@ -103,7 +103,8 @@ class PostController(private val postQueryFacade: PostQueryFacade, private val p
     ): ResponseEntity<CommonResponse<PostResponse>> {
         log.info {
             "Updating post: $postId " +
-                "(title=${request.title != null}, body=${request.body != null}, status=${request.status})"
+                "(title=${request.title != null}, body=${request.body != null}, " +
+                "tags=${request.tags != null}, status=${request.status})"
         }
 
         requireUpdateScopes(request)
@@ -115,6 +116,7 @@ class PostController(private val postQueryFacade: PostQueryFacade, private val p
                 title = request.title,
                 body = request.body,
                 status = request.status,
+                tags = request.tags,
             )
 
         val response = postCommandFacade.updatePost().execute(command)
@@ -327,7 +329,7 @@ class PostController(private val postQueryFacade: PostQueryFacade, private val p
         }
 
         val missingScopes = mutableListOf<String>()
-        val changesContent = request.title != null || request.body != null
+        val changesContent = request.title != null || request.body != null || request.tags != null
         val changesStatus = request.status != null
 
         if (changesContent && "SCOPE_post:update" !in authorities) {

--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/dto/UpdatePostRequest.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/dto/UpdatePostRequest.kt
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  * 블로그 글 수정 요청 DTO
  *
  * 모든 필드가 선택적입니다. null인 필드는 변경되지 않습니다.
+ * tags는 null이면 변경하지 않고, 빈 배열이면 전체 제거하며, 값이 있으면 요청 태그로 교체합니다.
  */
 data class UpdatePostRequest(
     @field:Schema(description = "제목 (null이면 변경하지 않음)", example = "수정된 제목")
@@ -18,4 +19,6 @@ data class UpdatePostRequest(
         allowableValues = ["DRAFT", "PUBLISHED", "ARCHIVED"],
     )
     val status: String? = null,
+    @field:Schema(description = "태그 목록 (null이면 변경하지 않음, []이면 전체 제거)", example = "[\"Kotlin\", \"DDD\"]")
+    val tags: List<String>? = null,
 )

--- a/modules/content/post/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostControllerTest.kt
+++ b/modules/content/post/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostControllerTest.kt
@@ -18,6 +18,7 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpStatus
@@ -254,6 +255,49 @@ class PostControllerTest :
         Given("API key 권한으로 글을 수정할 때") {
             val updatePostUseCase = mockk<UpdatePostUseCase>()
             every { postCommandFacade.updatePost() } returns updatePostUseCase
+
+            When("post:update scope만 가진 API key가 tags를 변경하면") {
+                val postId = UUID.randomUUID().toString()
+                val request = UpdatePostRequest(tags = listOf("Kotlin", "Spring"))
+                val commandSlot = slot<UpdatePostUseCase.Command>()
+                val expectedResponse =
+                    UpdatePostUseCase.Response(
+                        postId = postId,
+                        author = UpdatePostUseCase.AuthorInfo("member-id", "Luigi", null, "test-user"),
+                        title = "원본 제목",
+                        slug = "original-slug",
+                        body = "원본 본문",
+                        type = "BLOG",
+                        status = "DRAFT",
+                        tags = setOf("Kotlin", "Spring"),
+                        createdAt = LocalDateTime.now(),
+                        updatedAt = LocalDateTime.now(),
+                    )
+                every { updatePostUseCase.execute(capture(commandSlot)) } returns expectedResponse
+
+                Then("수정 요청이 허용되고 tags가 Command로 전달되어야 한다") {
+                    setAuthentication(authorities = listOf("SCOPE_post:update"))
+                    val response = controller.updatePost("member-id", postId, request)
+
+                    response.statusCode shouldBe HttpStatus.OK
+                    commandSlot.captured.tags shouldBe listOf("Kotlin", "Spring")
+                    response.body
+                        ?.data
+                        ?.tags shouldBe setOf("Kotlin", "Spring")
+                }
+            }
+
+            When("post:publish scope만 가진 API key가 tags를 변경하면") {
+                val postId = UUID.randomUUID().toString()
+                val request = UpdatePostRequest(tags = emptyList())
+                Then("접근이 거부되고 수정 UseCase는 실행되지 않아야 한다") {
+                    setAuthentication(authorities = listOf("SCOPE_post:publish"))
+
+                    shouldThrow<AccessDeniedException> {
+                        controller.updatePost("member-id", postId, request)
+                    }
+                }
+            }
 
             When("post:update scope만 가진 API key가 status를 PUBLISHED로 변경하면") {
                 val postId = UUID.randomUUID().toString()

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/in/command/UpdatePostUseCase.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/in/command/UpdatePostUseCase.kt
@@ -5,7 +5,7 @@ import java.time.LocalDateTime
 /**
  * Post 수정 UseCase
  *
- * Post의 제목, 본문, 상태를 수정합니다.
+ * Post의 제목, 본문, 태그, 상태를 수정합니다.
  */
 interface UpdatePostUseCase {
     /**
@@ -24,6 +24,7 @@ interface UpdatePostUseCase {
      * @property title 새로운 제목 (null이면 변경하지 않음)
      * @property body 새로운 본문 (null이면 변경하지 않음)
      * @property status 새로운 상태 (null이면 변경하지 않음, "PUBLISHED", "ARCHIVED", "DRAFT")
+     * @property tags 새로운 태그 목록 (null이면 변경하지 않음, 빈 목록이면 전체 제거)
      */
     data class Command(
         val memberId: String,
@@ -31,6 +32,7 @@ interface UpdatePostUseCase {
         val title: String?,
         val body: String?,
         val status: String? = null,
+        val tags: List<String>? = null,
     )
 
     /**

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/command/UpdatePostService.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/command/UpdatePostService.kt
@@ -19,7 +19,7 @@ private val log = KotlinLogging.logger {}
 /**
  * Post 수정 유스케이스 구현체
  *
- * Post의 제목, 본문, 상태를 선택적으로 수정합니다.
+ * Post의 제목, 본문, 태그, 상태를 선택적으로 수정합니다.
  */
 @Service
 class UpdatePostService(private val postRepository: PostRepository, private val memberClient: MemberClient) :
@@ -27,7 +27,9 @@ class UpdatePostService(private val postRepository: PostRepository, private val 
     @Transactional
     override fun execute(command: UpdatePostUseCase.Command): UpdatePostUseCase.Response {
         log.info {
-            "Updating post: ${command.postId} by member: ${command.memberId} (title=${command.title != null}, body=${command.body != null}, status=${command.status})"
+            "Updating post: ${command.postId} by member: ${command.memberId} " +
+                "(title=${command.title != null}, body=${command.body != null}, " +
+                "tags=${command.tags != null}, status=${command.status})"
         }
 
         val memberId = MemberId.from(command.memberId)
@@ -48,7 +50,12 @@ class UpdatePostService(private val postRepository: PostRepository, private val 
             post = post.update(newTitle, newBody)
         }
 
-        // 2. 상태 변경 (status가 있으면)
+        // 2. 태그 교체 (tags가 null이 아니면)
+        if (command.tags != null) {
+            post = post.replaceTags(command.tags)
+        }
+
+        // 3. 상태 변경 (status가 있으면)
         if (command.status != null) {
             post =
                 when (command.status.uppercase()) {

--- a/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/command/UpdatePostServiceTest.kt
+++ b/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/command/UpdatePostServiceTest.kt
@@ -249,6 +249,132 @@ class UpdatePostServiceTest :
             }
         }
 
+        Given("글의 태그를 수정할 때") {
+            val postRepository = mockk<PostRepository>()
+            val memberClient = mockk<MemberClient>()
+            val service = UpdatePostService(postRepository, memberClient)
+            val memberId = MemberId.generate()
+
+            When("작성자가 tags를 새 목록으로 보내면") {
+                val postId = PostId.generate()
+                val command =
+                    UpdatePostUseCase.Command(
+                        memberId = memberId.value.toString(),
+                        postId = postId.value.toString(),
+                        title = null,
+                        body = null,
+                        tags = listOf("Kotlin", "Spring"),
+                    )
+
+                val originalPost =
+                    Post
+                        .create(
+                            memberId = memberId,
+                            title = Title("원본 제목"),
+                            slug = Slug("original-post"),
+                            body = Body("원본 본문"),
+                            type = ContentType.BLOG,
+                        ).addTag("Old")
+
+                every { postRepository.findById(postId) } returns originalPost
+                every { postRepository.save(any()) } answers { firstArg() }
+                every { memberClient.getAuthor(memberId.value.toString()) } returns
+                    MemberClient.Author(
+                        memberId = memberId.value.toString(),
+                        nickname = "TestUser",
+                        profileImageUrl = null,
+                        username = "test_user",
+                    )
+
+                val response = service.execute(command)
+
+                Then("태그가 요청 태그로 교체된다") {
+                    response.tags shouldBe setOf("Kotlin", "Spring")
+                }
+
+                Then("제목과 본문은 유지된다") {
+                    response.title shouldBe "원본 제목"
+                    response.body shouldBe "원본 본문"
+                }
+            }
+
+            When("작성자가 tags를 null로 보내면") {
+                val postId = PostId.generate()
+                val command =
+                    UpdatePostUseCase.Command(
+                        memberId = memberId.value.toString(),
+                        postId = postId.value.toString(),
+                        title = null,
+                        body = null,
+                        tags = null,
+                    )
+
+                val originalPost =
+                    Post
+                        .create(
+                            memberId = memberId,
+                            title = Title("원본 제목"),
+                            slug = Slug("original-post"),
+                            body = Body("원본 본문"),
+                            type = ContentType.BLOG,
+                        ).addTag("Kotlin")
+
+                every { postRepository.findById(postId) } returns originalPost
+                every { postRepository.save(any()) } answers { firstArg() }
+                every { memberClient.getAuthor(memberId.value.toString()) } returns
+                    MemberClient.Author(
+                        memberId = memberId.value.toString(),
+                        nickname = "TestUser",
+                        profileImageUrl = null,
+                        username = "test_user",
+                    )
+
+                val response = service.execute(command)
+
+                Then("기존 태그가 유지된다") {
+                    response.tags shouldBe setOf("Kotlin")
+                }
+            }
+
+            When("작성자가 tags를 빈 목록으로 보내면") {
+                val postId = PostId.generate()
+                val command =
+                    UpdatePostUseCase.Command(
+                        memberId = memberId.value.toString(),
+                        postId = postId.value.toString(),
+                        title = null,
+                        body = null,
+                        tags = emptyList(),
+                    )
+
+                val originalPost =
+                    Post
+                        .create(
+                            memberId = memberId,
+                            title = Title("원본 제목"),
+                            slug = Slug("original-post"),
+                            body = Body("원본 본문"),
+                            type = ContentType.BLOG,
+                        ).addTag("Kotlin")
+
+                every { postRepository.findById(postId) } returns originalPost
+                every { postRepository.save(any()) } answers { firstArg() }
+                every { memberClient.getAuthor(memberId.value.toString()) } returns
+                    MemberClient.Author(
+                        memberId = memberId.value.toString(),
+                        nickname = "TestUser",
+                        profileImageUrl = null,
+                        username = "test_user",
+                    )
+
+                val response = service.execute(command)
+
+                Then("태그가 모두 제거된다") {
+                    response.tags shouldBe emptySet()
+                }
+            }
+        }
+
         Given("존재하지 않는 글을 수정하려고 할 때") {
             val postRepository = mockk<PostRepository>()
             val memberClient = mockk<MemberClient>()

--- a/modules/content/post/domain/src/main/kotlin/cloud/luigi99/blog/content/post/domain/model/Post.kt
+++ b/modules/content/post/domain/src/main/kotlin/cloud/luigi99/blog/content/post/domain/model/Post.kt
@@ -225,4 +225,22 @@ class Post private constructor(
         this.tags = tags - tagName
         return this
     }
+
+    /**
+     * 태그를 요청 태그 목록으로 교체합니다.
+     *
+     * 빈 목록이면 모든 태그가 제거됩니다.
+     *
+     * @param tagNames 교체할 태그 이름 목록
+     * @return 태그가 교체된 Post
+     */
+    fun replaceTags(tagNames: Iterable<String>): Post {
+        tagNames.forEach { tagName ->
+            require(tagName.isNotBlank()) { "Tag name cannot be blank" }
+            require(tagName.length <= 50) { "Tag name must not exceed 50 characters" }
+        }
+
+        this.tags = tagNames.toSet()
+        return this
+    }
 }

--- a/modules/content/post/domain/src/test/kotlin/cloud/luigi99/blog/content/post/domain/model/PostTest.kt
+++ b/modules/content/post/domain/src/test/kotlin/cloud/luigi99/blog/content/post/domain/model/PostTest.kt
@@ -295,6 +295,39 @@ class PostTest :
             }
         }
 
+        Given("태그를 교체할 때") {
+            val post =
+                Post
+                    .create(
+                        MemberId.generate(),
+                        Title("태그 교체 테스트"),
+                        Slug("replace-tags-test"),
+                        Body("내용"),
+                        ContentType.BLOG,
+                    ).addTag("kotlin")
+                    .addTag("spring")
+
+            When("새 태그 목록으로 교체하면") {
+                val replaced = post.replaceTags(listOf("java", "spring-boot"))
+
+                Then("기존 태그가 요청 태그로 교체된다") {
+                    replaced.tags shouldBe setOf("java", "spring-boot")
+                }
+
+                Then("현재 인스턴스가 변경되어 반환된다") {
+                    replaced shouldBeSameInstanceAs post
+                }
+            }
+
+            When("빈 목록으로 교체하면") {
+                val cleared = post.replaceTags(emptyList())
+
+                Then("모든 태그가 제거된다") {
+                    cleared.tags.shouldBeEmpty()
+                }
+            }
+        }
+
         Given("영속성에서 로드된 데이터가 주어졌을 때") {
             val entityId = PostId.generate()
             val memberId = MemberId.generate()


### PR DESCRIPTION
## 📋 개요
- 게시글 수정 API에서 `tags` 변경을 지원합니다.
- `tags=null` 또는 미전달 시 기존 태그를 유지하고, `tags=[]`는 전체 삭제, `tags=[...]`는 요청 태그로 교체합니다.
- API key 기반 수정에서 태그 변경은 `post:update` scope를 요구합니다.

## 🔗 관련 이슈
- Closes #

## ☑️ 체크리스트
- [x] 코딩 컨벤션을 준수했나요? (`./gradlew ktlintCheck`)
  - 로컬 Gradle 미실행(리소스 보호 정책), `git diff --check`로 whitespace 검증 완료
- [ ] 모든 테스트를 통과했나요? (`./gradlew test`)
  - 로컬 Gradle 미실행(리소스 보호 정책), PR CI로 확인 예정
- [x] 불필요한 주석이나 로그는 제거했나요?
