### PR TITLE
feat(posts): 상세 응답에 이전 다음 글을 추가

### DIFF
--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostApi.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostApi.kt
@@ -366,7 +366,10 @@ interface PostApi {
 
     @Operation(
         summary = "사용자의 특정 Slug 블로그 글 조회",
-        description = "사용자 이름과 URL Slug로 단일 블로그 글을 조회합니다.",
+        description =
+            "사용자 이름과 URL Slug로 단일 블로그 글을 조회합니다. " +
+                "응답의 previousPost는 현재 글보다 더 오래된 인접 글, " +
+                "nextPost는 현재 글보다 더 최신인 인접 글입니다.",
     )
     @ApiResponses(
         value = [
@@ -396,6 +399,18 @@ interface PostApi {
                                     "type": "BLOG",
                                     "status": "PUBLISHED",
                                     "tags": ["Kotlin", "DDD"],
+                                    "previousPost": {
+                                      "postId": "660e8400-e29b-41d4-a716-446655440000",
+                                      "title": "이전 블로그 글",
+                                      "slug": "previous-blog-post",
+                                      "createdAt": "2025-12-30T12:00:00"
+                                    },
+                                    "nextPost": {
+                                      "postId": "770e8400-e29b-41d4-a716-446655440000",
+                                      "title": "다음 블로그 글",
+                                      "slug": "next-blog-post",
+                                      "createdAt": "2026-01-01T12:00:00"
+                                    },
                                     "createdAt": "2025-12-31T12:00:00",
                                     "updatedAt": "2025-12-31T12:00:00"
                                   },

--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostController.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostController.kt
@@ -1,6 +1,7 @@
 ﻿package cloud.luigi99.blog.content.post.adapter.`in`.web
 
 import cloud.luigi99.blog.adapter.web.dto.CommonResponse
+import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.AdjacentPostResponse
 import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.AuthorResponse
 import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.CreatePostRequest
 import cloud.luigi99.blog.content.post.adapter.`in`.web.dto.PageInfoResponse
@@ -211,6 +212,8 @@ class PostController(private val postQueryFacade: PostQueryFacade, private val p
                     tags = response.tags,
                     viewCount = response.viewCount,
                     commentCount = response.commentCount,
+                    previousPost = response.previousPost?.toAdjacentPostResponse(),
+                    nextPost = response.nextPost?.toAdjacentPostResponse(),
                     createdAt = response.createdAt,
                     updatedAt = response.updatedAt,
                 ),
@@ -314,6 +317,14 @@ class PostController(private val postQueryFacade: PostQueryFacade, private val p
 
         return ResponseEntity.noContent().build()
     }
+
+    private fun GetPostBySlugUseCase.AdjacentPostInfo.toAdjacentPostResponse(): AdjacentPostResponse =
+        AdjacentPostResponse(
+            postId = postId,
+            title = title,
+            slug = slug,
+            createdAt = createdAt,
+        )
 
     private fun requireUpdateScopes(request: UpdatePostRequest) {
         val authentication = SecurityContextHolder.getContext().authentication

--- a/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/dto/PostResponse.kt
+++ b/modules/content/post/adapter/in/web/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/dto/PostResponse.kt
@@ -27,8 +27,26 @@ data class PostResponse(
     val viewCount: Long = 0,
     @field:Schema(description = "댓글 수", example = "3")
     val commentCount: Long = 0,
+    @field:Schema(description = "이전 글 정보 (현재 글보다 더 오래된 인접 글, 없으면 null)")
+    val previousPost: AdjacentPostResponse? = null,
+    @field:Schema(description = "다음 글 정보 (현재 글보다 더 최신인 인접 글, 없으면 null)")
+    val nextPost: AdjacentPostResponse? = null,
     @field:Schema(description = "생성 시간", example = "2025-01-01T12:00:00")
     val createdAt: LocalDateTime?,
     @field:Schema(description = "수정 시간", example = "2025-01-01T13:00:00")
     val updatedAt: LocalDateTime?,
+)
+
+/**
+ * 상세 글의 인접 글 응답 DTO
+ */
+data class AdjacentPostResponse(
+    @field:Schema(description = "Post ID", example = "123e4567-e89b-12d3-a456-426614174000")
+    val postId: String,
+    @field:Schema(description = "제목", example = "이전 블로그 글")
+    val title: String,
+    @field:Schema(description = "URL slug", example = "previous-blog-post")
+    val slug: String,
+    @field:Schema(description = "생성 시간", example = "2025-01-01T11:00:00")
+    val createdAt: LocalDateTime?,
 )

--- a/modules/content/post/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostControllerTest.kt
+++ b/modules/content/post/adapter/in/web/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/in/web/PostControllerTest.kt
@@ -443,6 +443,8 @@ class PostControllerTest :
                 val username = "testuser"
                 val slug = "test-post"
 
+                val previousCreatedAt = LocalDateTime.now().minusDays(1)
+                val nextCreatedAt = LocalDateTime.now().plusDays(1)
                 val expectedResponse =
                     GetPostBySlugUseCase.Response(
                         postId = UUID.randomUUID().toString(),
@@ -457,6 +459,20 @@ class PostControllerTest :
                         commentCount = 0,
                         createdAt = LocalDateTime.now(),
                         updatedAt = LocalDateTime.now(),
+                        previousPost =
+                            GetPostBySlugUseCase.AdjacentPostInfo(
+                                postId = UUID.randomUUID().toString(),
+                                title = "이전 글",
+                                slug = "previous-post",
+                                createdAt = previousCreatedAt,
+                            ),
+                        nextPost =
+                            GetPostBySlugUseCase.AdjacentPostInfo(
+                                postId = UUID.randomUUID().toString(),
+                                title = "다음 글",
+                                slug = "next-post",
+                                createdAt = nextCreatedAt,
+                            ),
                     )
 
                 every { getPostBySlugUseCase.execute(any()) } returns expectedResponse
@@ -477,6 +493,22 @@ class PostControllerTest :
                     response.body
                         ?.data
                         ?.title shouldBe "테스트 글"
+                    response.body
+                        ?.data
+                        ?.previousPost
+                        ?.slug shouldBe "previous-post"
+                    response.body
+                        ?.data
+                        ?.previousPost
+                        ?.createdAt shouldBe previousCreatedAt
+                    response.body
+                        ?.data
+                        ?.nextPost
+                        ?.slug shouldBe "next-post"
+                    response.body
+                        ?.data
+                        ?.nextPost
+                        ?.createdAt shouldBe nextCreatedAt
                 }
             }
         }

--- a/modules/content/post/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostJpaRepository.kt
+++ b/modules/content/post/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostJpaRepository.kt
@@ -83,6 +83,50 @@ interface PostJpaRepository : JpaRepository<PostJpaEntity, UUID> {
 
     @Query(
         """
+        SELECT p.* FROM post p
+        WHERE p.member_id = :memberId
+          AND p.type = CAST(:type AS varchar)
+          AND p.status = 'PUBLISHED'
+          AND (
+            p.created_at < :currentCreatedAt
+            OR (p.created_at = :currentCreatedAt AND p.id < :currentPostId)
+          )
+        ORDER BY p.created_at DESC, p.id DESC
+        LIMIT 1
+        """,
+        nativeQuery = true,
+    )
+    fun findPreviousPublishedPost(
+        @Param("memberId") memberId: UUID,
+        @Param("type") type: String,
+        @Param("currentCreatedAt") currentCreatedAt: LocalDateTime,
+        @Param("currentPostId") currentPostId: UUID,
+    ): PostJpaEntity?
+
+    @Query(
+        """
+        SELECT p.* FROM post p
+        WHERE p.member_id = :memberId
+          AND p.type = CAST(:type AS varchar)
+          AND p.status = 'PUBLISHED'
+          AND (
+            p.created_at > :currentCreatedAt
+            OR (p.created_at = :currentCreatedAt AND p.id > :currentPostId)
+          )
+        ORDER BY p.created_at ASC, p.id ASC
+        LIMIT 1
+        """,
+        nativeQuery = true,
+    )
+    fun findNextPublishedPost(
+        @Param("memberId") memberId: UUID,
+        @Param("type") type: String,
+        @Param("currentCreatedAt") currentCreatedAt: LocalDateTime,
+        @Param("currentPostId") currentPostId: UUID,
+    ): PostJpaEntity?
+
+    @Query(
+        """
         SELECT DISTINCT p.* FROM post p
         WHERE (:statusFilterEnabled = false OR p.status = CAST(:status AS varchar))
           AND (:typeFilterEnabled = false OR p.type = CAST(:type AS varchar))

--- a/modules/content/post/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostRepositoryAdapter.kt
+++ b/modules/content/post/adapter/out/persistence/jpa/src/main/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostRepositoryAdapter.kt
@@ -94,6 +94,30 @@ class PostRepositoryAdapter(
             ?.let { PostMapper.toDomain(it) }
     }
 
+    override fun findPreviousPublishedPost(currentPost: Post): Post? {
+        val currentCreatedAt = currentPost.createdAt ?: return null
+        log.debug { "Finding previous published post for post: ${currentPost.entityId}" }
+        return jpaRepository
+            .findPreviousPublishedPost(
+                memberId = currentPost.memberId.value,
+                type = currentPost.type.name,
+                currentCreatedAt = currentCreatedAt,
+                currentPostId = currentPost.entityId.value,
+            )?.let { PostMapper.toDomain(it) }
+    }
+
+    override fun findNextPublishedPost(currentPost: Post): Post? {
+        val currentCreatedAt = currentPost.createdAt ?: return null
+        log.debug { "Finding next published post for post: ${currentPost.entityId}" }
+        return jpaRepository
+            .findNextPublishedPost(
+                memberId = currentPost.memberId.value,
+                type = currentPost.type.name,
+                currentCreatedAt = currentCreatedAt,
+                currentPostId = currentPost.entityId.value,
+            )?.let { PostMapper.toDomain(it) }
+    }
+
     /**
      * 특정 사용자가 해당 Slug를 사용 중인지 확인합니다.
      */

--- a/modules/content/post/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostRepositoryAdapterTest.kt
+++ b/modules/content/post/adapter/out/persistence/jpa/src/test/kotlin/cloud/luigi99/blog/content/post/adapter/out/persistence/jpa/PostRepositoryAdapterTest.kt
@@ -21,6 +21,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.verify
+import java.time.LocalDateTime
 import java.util.Optional
 import java.util.UUID
 
@@ -473,6 +474,122 @@ class PostRepositoryAdapterTest :
                 Then("해당 게시글이 반환된다") {
                     found shouldNotBe null
                     found?.slug shouldBe slug
+                }
+            }
+        }
+
+        Given("현재 글의 이전 발행 글을 조회할 때") {
+            val jpaRepository = mockk<PostJpaRepository>()
+            val eventContextManager = mockk<EventContextManager>()
+            val domainEventPublisher = mockk<DomainEventPublisher>()
+            val adapter = PostRepositoryAdapter(jpaRepository, eventContextManager, domainEventPublisher)
+            val memberId = MemberId.generate()
+            val currentCreatedAt = LocalDateTime.of(2025, 1, 2, 12, 0)
+            val currentPost =
+                Post.from(
+                    entityId = PostId.generate(),
+                    memberId = memberId,
+                    title = Title("현재 글"),
+                    slug = Slug("current-post"),
+                    body = Body("본문"),
+                    type = ContentType.BLOG,
+                    status = PostStatus.PUBLISHED,
+                    tags = emptySet(),
+                    createdAt = currentCreatedAt,
+                    updatedAt = currentCreatedAt,
+                )
+            val previousEntity =
+                PostJpaEntity
+                    .from(
+                        entityId = UUID.randomUUID(),
+                        memberId = memberId.value,
+                        title = "이전 글",
+                        slug = "previous-post",
+                        body = "본문",
+                        type = ContentType.BLOG,
+                        status = PostStatus.PUBLISHED,
+                    ).apply { createdAt = currentCreatedAt.minusDays(1) }
+
+            When("createdAt DESC, id DESC 기준으로 더 오래된 글이 존재하면") {
+                every {
+                    jpaRepository.findPreviousPublishedPost(
+                        memberId = memberId.value,
+                        type = ContentType.BLOG.name,
+                        currentCreatedAt = currentCreatedAt,
+                        currentPostId = currentPost.entityId.value,
+                    )
+                } returns previousEntity
+
+                val found = adapter.findPreviousPublishedPost(currentPost)
+
+                Then("same author/type PUBLISHED 조건의 이전 글이 반환된다") {
+                    found?.slug shouldBe Slug("previous-post")
+                    verify(exactly = 1) {
+                        jpaRepository.findPreviousPublishedPost(
+                            memberId = memberId.value,
+                            type = ContentType.BLOG.name,
+                            currentCreatedAt = currentCreatedAt,
+                            currentPostId = currentPost.entityId.value,
+                        )
+                    }
+                }
+            }
+        }
+
+        Given("현재 글의 다음 발행 글을 조회할 때") {
+            val jpaRepository = mockk<PostJpaRepository>()
+            val eventContextManager = mockk<EventContextManager>()
+            val domainEventPublisher = mockk<DomainEventPublisher>()
+            val adapter = PostRepositoryAdapter(jpaRepository, eventContextManager, domainEventPublisher)
+            val memberId = MemberId.generate()
+            val currentCreatedAt = LocalDateTime.of(2025, 1, 2, 12, 0)
+            val currentPost =
+                Post.from(
+                    entityId = PostId.generate(),
+                    memberId = memberId,
+                    title = Title("현재 글"),
+                    slug = Slug("current-post"),
+                    body = Body("본문"),
+                    type = ContentType.BLOG,
+                    status = PostStatus.PUBLISHED,
+                    tags = emptySet(),
+                    createdAt = currentCreatedAt,
+                    updatedAt = currentCreatedAt,
+                )
+            val nextEntity =
+                PostJpaEntity
+                    .from(
+                        entityId = UUID.randomUUID(),
+                        memberId = memberId.value,
+                        title = "다음 글",
+                        slug = "next-post",
+                        body = "본문",
+                        type = ContentType.BLOG,
+                        status = PostStatus.PUBLISHED,
+                    ).apply { createdAt = currentCreatedAt.plusDays(1) }
+
+            When("createdAt DESC, id DESC 기준으로 더 최신인 글이 존재하면") {
+                every {
+                    jpaRepository.findNextPublishedPost(
+                        memberId = memberId.value,
+                        type = ContentType.BLOG.name,
+                        currentCreatedAt = currentCreatedAt,
+                        currentPostId = currentPost.entityId.value,
+                    )
+                } returns nextEntity
+
+                val found = adapter.findNextPublishedPost(currentPost)
+
+                Then("same author/type PUBLISHED 조건의 다음 글이 반환된다") {
+                    found?.slug shouldBe Slug("next-post")
+                    verify(exactly = 1) {
+                        jpaRepository.findNextPublishedPost(
+                            memberId = memberId.value,
+                            type = ContentType.BLOG.name,
+                            currentCreatedAt = currentCreatedAt,
+                            currentPostId = currentPost.entityId.value,
+                        )
+                    }
                 }
             }
         }

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/in/query/GetPostBySlugUseCase.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/in/query/GetPostBySlugUseCase.kt
@@ -37,6 +37,8 @@ interface GetPostBySlugUseCase {
      * @property tags 태그 목록
      * @property createdAt 생성 시간
      * @property updatedAt 수정 시간
+     * @property previousPost 현재 글보다 더 오래된 인접 글
+     * @property nextPost 현재 글보다 더 최신인 인접 글
      */
     data class Response(
         val postId: String,
@@ -51,6 +53,15 @@ interface GetPostBySlugUseCase {
         val commentCount: Long,
         val createdAt: LocalDateTime?,
         val updatedAt: LocalDateTime?,
+        val previousPost: AdjacentPostInfo? = null,
+        val nextPost: AdjacentPostInfo? = null,
+    )
+
+    data class AdjacentPostInfo(
+        val postId: String,
+        val title: String,
+        val slug: String,
+        val createdAt: LocalDateTime?,
     )
 
     data class AuthorInfo(

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/out/PostRepository.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/port/out/PostRepository.kt
@@ -51,6 +51,28 @@ interface PostRepository : Repository<Post, PostId> {
     fun findByUsernameAndSlug(username: String, slug: Slug): Post?
 
     /**
+     * 현재 글보다 더 오래된 같은 작성자/타입의 발행된 인접 Post를 조회합니다.
+     *
+     * canonical ordering: createdAt DESC, id DESC
+     * previous condition: createdAt < current.createdAt OR same createdAt and id < current.id
+     *
+     * @param currentPost 기준이 되는 현재 Post
+     * @return 이전 Post 또는 null (존재하지 않을 경우)
+     */
+    fun findPreviousPublishedPost(currentPost: Post): Post?
+
+    /**
+     * 현재 글보다 더 최신인 같은 작성자/타입의 발행된 인접 Post를 조회합니다.
+     *
+     * canonical ordering: createdAt DESC, id DESC
+     * next condition: createdAt > current.createdAt OR same createdAt and id > current.id
+     *
+     * @param currentPost 기준이 되는 현재 Post
+     * @return 다음 Post 또는 null (존재하지 않을 경우)
+     */
+    fun findNextPublishedPost(currentPost: Post): Post?
+
+    /**
      * 특정 사용자가 해당 slug를 이미 사용 중인지 확인합니다.
      *
      * @param memberId 회원 ID

--- a/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugService.kt
+++ b/modules/content/post/application/src/main/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugService.kt
@@ -5,6 +5,7 @@ import cloud.luigi99.blog.content.post.application.port.out.MemberClient
 import cloud.luigi99.blog.content.post.application.port.out.PostRepository
 import cloud.luigi99.blog.content.post.application.port.out.PostViewCountDeduplicationPort
 import cloud.luigi99.blog.content.post.domain.exception.PostNotFoundException
+import cloud.luigi99.blog.content.post.domain.model.Post
 import cloud.luigi99.blog.content.post.domain.vo.PostId
 import cloud.luigi99.blog.content.post.domain.vo.PostStatus
 import cloud.luigi99.blog.content.post.domain.vo.Slug
@@ -42,6 +43,18 @@ class GetPostBySlugService(
             }
         }
         val commentCount = postRepository.countCommentsByPostIds(listOf(post.entityId))[post.entityId] ?: 0
+        val previousPost =
+            if (post.status == PostStatus.PUBLISHED) {
+                postRepository.findPreviousPublishedPost(post)?.toAdjacentPostInfo()
+            } else {
+                null
+            }
+        val nextPost =
+            if (post.status == PostStatus.PUBLISHED) {
+                postRepository.findNextPublishedPost(post)?.toAdjacentPostInfo()
+            } else {
+                null
+            }
 
         val author =
             memberClient.getAuthor(
@@ -70,8 +83,20 @@ class GetPostBySlugService(
             commentCount = commentCount,
             createdAt = post.createdAt,
             updatedAt = post.updatedAt,
+            previousPost = previousPost,
+            nextPost = nextPost,
         )
     }
+
+    private fun Post.toAdjacentPostInfo(): GetPostBySlugUseCase.AdjacentPostInfo =
+        GetPostBySlugUseCase.AdjacentPostInfo(
+            postId =
+                entityId.value
+                    .toString(),
+            title = title.value,
+            slug = slug.value,
+            createdAt = createdAt,
+        )
 
     private fun isUniqueView(postId: PostId, visitorKey: String): Boolean =
         runCatching { postViewCountDeduplicationPort.isUniqueView(postId, visitorKey) }

--- a/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugServiceTest.kt
+++ b/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugServiceTest.kt
@@ -317,8 +317,7 @@ private fun publishedSlugPost(memberId: MemberId): Post =
             slug = Slug("test-post"),
             body = Body("테스트 내용"),
             type = ContentType.BLOG,
-        )
-        .publish()
+        ).publish()
 
 private fun draftSlugPost(memberId: MemberId): Post =
     Post.create(

--- a/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugServiceTest.kt
+++ b/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugServiceTest.kt
@@ -9,6 +9,8 @@ import cloud.luigi99.blog.content.post.domain.exception.PostNotFoundException
 import cloud.luigi99.blog.content.post.domain.model.Post
 import cloud.luigi99.blog.content.post.domain.vo.Body
 import cloud.luigi99.blog.content.post.domain.vo.ContentType
+import cloud.luigi99.blog.content.post.domain.vo.PostId
+import cloud.luigi99.blog.content.post.domain.vo.PostStatus
 import cloud.luigi99.blog.content.post.domain.vo.Slug
 import cloud.luigi99.blog.content.post.domain.vo.Title
 import cloud.luigi99.blog.member.domain.member.vo.MemberId
@@ -19,6 +21,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.verify
+import java.time.LocalDateTime
 
 /**
  * GetPostBySlugService 테스트
@@ -46,6 +49,8 @@ class GetPostBySlugServiceTest :
 
             every { postRepository.findByUsernameAndSlug("testuser", Slug("test-post")) } returns post
             every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
+            every { postRepository.findPreviousPublishedPost(post) } returns null
+            every { postRepository.findNextPublishedPost(post) } returns null
             every { memberClient.getAuthor(any()) } returns authorOfSlugPost(post)
 
             When("Redis dedupe가 최초 조회로 판단하면") {
@@ -80,6 +85,8 @@ class GetPostBySlugServiceTest :
             every { postRepository.findByUsernameAndSlug("testuser", Slug("test-post")) } returns post
             every { deduplicationPort.isUniqueView(post.entityId, "visitor-key") } returns false
             every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
+            every { postRepository.findPreviousPublishedPost(post) } returns null
+            every { postRepository.findNextPublishedPost(post) } returns null
             every { memberClient.getAuthor(any()) } returns authorOfSlugPost(post)
 
             When("Redis dedupe가 중복 조회로 판단하면") {
@@ -110,6 +117,8 @@ class GetPostBySlugServiceTest :
                 deduplicationPort.isUniqueView(post.entityId, "visitor-key")
             } throws IllegalStateException("redis down")
             every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
+            every { postRepository.findPreviousPublishedPost(post) } returns null
+            every { postRepository.findNextPublishedPost(post) } returns null
             every { memberClient.getAuthor(any()) } returns authorOfSlugPost(post)
 
             When("상세 글을 조회하면") {
@@ -119,6 +128,128 @@ class GetPostBySlugServiceTest :
                     response.body shouldBe "테스트 내용"
                     response.viewCount shouldBe 0
                     verify(exactly = 0) { postRepository.incrementViewCount(any()) }
+                }
+            }
+        }
+
+        Given("Username과 Slug로 발행 글의 인접 글을 조회할 때") {
+            val postRepository = mockk<PostRepository>()
+            val memberClient = mockk<MemberClient>()
+            val deduplicationPort = mockk<PostViewCountDeduplicationPort>()
+            val service = GetPostBySlugService(postRepository, memberClient, deduplicationPort)
+            val memberId = MemberId.generate()
+            val post = publishedSlugPost(memberId)
+            val previous =
+                postFromPersistence(
+                    memberId = memberId,
+                    title = "이전 글",
+                    slug = "older-post",
+                    createdAt = LocalDateTime.of(2026, 4, 27, 12, 0),
+                )
+            val next =
+                postFromPersistence(
+                    memberId = memberId,
+                    title = "다음 글",
+                    slug = "newer-post",
+                    createdAt = LocalDateTime.of(2026, 4, 29, 12, 0),
+                )
+            val query =
+                GetPostBySlugUseCase.Query(
+                    username = "testuser",
+                    slug = "test-post",
+                    visitorKey = "visitor-key",
+                )
+
+            every { postRepository.findByUsernameAndSlug("testuser", Slug("test-post")) } returns post
+            every { deduplicationPort.isUniqueView(post.entityId, "visitor-key") } returns false
+            every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
+            every { postRepository.findPreviousPublishedPost(post) } returns previous
+            every { postRepository.findNextPublishedPost(post) } returns next
+            every { memberClient.getAuthor(any()) } returns authorOfSlugPost(post)
+
+            When("현재 글이 목록 중간에 있으면") {
+                val response = service.execute(query)
+
+                Then("previousPost와 nextPost를 모두 매핑한다") {
+                    response.previousPost?.postId shouldBe previous.entityId.value.toString()
+                    response.previousPost?.title shouldBe "이전 글"
+                    response.previousPost?.slug shouldBe "older-post"
+                    response.previousPost?.createdAt shouldBe previous.createdAt
+                    response.nextPost?.postId shouldBe next.entityId.value.toString()
+                    response.nextPost?.title shouldBe "다음 글"
+                    response.nextPost?.slug shouldBe "newer-post"
+                    response.nextPost?.createdAt shouldBe next.createdAt
+                }
+            }
+        }
+
+        Given("Username과 Slug로 발행 글의 가장자리 인접 글을 조회할 때") {
+            val postRepository = mockk<PostRepository>()
+            val memberClient = mockk<MemberClient>()
+            val deduplicationPort = mockk<PostViewCountDeduplicationPort>()
+            val service = GetPostBySlugService(postRepository, memberClient, deduplicationPort)
+            val memberId = MemberId.generate()
+            val post = publishedSlugPost(memberId)
+            val next =
+                postFromPersistence(
+                    memberId = memberId,
+                    title = "최신 글",
+                    slug = "newest-post",
+                    createdAt = LocalDateTime.of(2026, 4, 30, 12, 0),
+                )
+            val query =
+                GetPostBySlugUseCase.Query(
+                    username = "testuser",
+                    slug = "test-post",
+                    visitorKey = "visitor-key",
+                )
+
+            every { postRepository.findByUsernameAndSlug("testuser", Slug("test-post")) } returns post
+            every { deduplicationPort.isUniqueView(post.entityId, "visitor-key") } returns false
+            every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
+            every { postRepository.findPreviousPublishedPost(post) } returns null
+            every { postRepository.findNextPublishedPost(post) } returns next
+            every { memberClient.getAuthor(any()) } returns authorOfSlugPost(post)
+
+            When("더 오래된 글이 없으면") {
+                val response = service.execute(query)
+
+                Then("previousPost는 null이고 nextPost만 매핑한다") {
+                    response.previousPost shouldBe null
+                    response.nextPost?.postId shouldBe next.entityId.value.toString()
+                    response.nextPost?.title shouldBe "최신 글"
+                    response.nextPost?.slug shouldBe "newest-post"
+                    response.nextPost?.createdAt shouldBe next.createdAt
+                }
+            }
+        }
+
+        Given("Username과 Slug로 미발행 글을 조회할 때") {
+            val postRepository = mockk<PostRepository>()
+            val memberClient = mockk<MemberClient>()
+            val deduplicationPort = mockk<PostViewCountDeduplicationPort>()
+            val service = GetPostBySlugService(postRepository, memberClient, deduplicationPort)
+            val post = draftSlugPost(MemberId.generate())
+            val query =
+                GetPostBySlugUseCase.Query(
+                    username = "testuser",
+                    slug = "test-post",
+                    visitorKey = "visitor-key",
+                )
+
+            every { postRepository.findByUsernameAndSlug("testuser", Slug("test-post")) } returns post
+            every { postRepository.countCommentsByPostIds(any()) } returns emptyMap()
+            every { memberClient.getAuthor(any()) } returns authorOfSlugPost(post)
+
+            When("현재 글이 DRAFT이면") {
+                val response = service.execute(query)
+
+                Then("인접 글을 조회하지 않고 null로 응답한다") {
+                    response.previousPost shouldBe null
+                    response.nextPost shouldBe null
+                    verify(exactly = 0) { postRepository.findPreviousPublishedPost(any()) }
+                    verify(exactly = 0) { postRepository.findNextPublishedPost(any()) }
+                    verify(exactly = 0) { deduplicationPort.isUniqueView(any(), any()) }
                 }
             }
         }
@@ -173,14 +304,41 @@ class GetPostBySlugServiceTest :
     })
 
 private fun publishedSlugPost(memberId: MemberId): Post =
-    Post
-        .create(
-            memberId = memberId,
-            title = Title("테스트 글"),
-            slug = Slug("test-post"),
-            body = Body("테스트 내용"),
-            type = ContentType.BLOG,
-        ).publish()
+    Post.create(
+        memberId = memberId,
+        title = Title("테스트 글"),
+        slug = Slug("test-post"),
+        body = Body("테스트 내용"),
+        type = ContentType.BLOG,
+    ).publish()
+
+private fun draftSlugPost(memberId: MemberId): Post =
+    Post.create(
+        memberId = memberId,
+        title = Title("테스트 글"),
+        slug = Slug("test-post"),
+        body = Body("테스트 내용"),
+        type = ContentType.BLOG,
+    )
+
+private fun postFromPersistence(
+    memberId: MemberId,
+    title: String,
+    slug: String,
+    createdAt: LocalDateTime,
+): Post =
+    Post.from(
+        entityId = PostId.generate(),
+        memberId = memberId,
+        title = Title(title),
+        slug = Slug(slug),
+        body = Body("인접 글 내용"),
+        type = ContentType.BLOG,
+        status = PostStatus.PUBLISHED,
+        tags = emptySet(),
+        createdAt = createdAt,
+        updatedAt = createdAt,
+    )
 
 private fun authorOfSlugPost(post: Post): MemberClient.Author =
     MemberClient.Author(

--- a/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugServiceTest.kt
+++ b/modules/content/post/application/src/test/kotlin/cloud/luigi99/blog/content/post/application/service/query/GetPostBySlugServiceTest.kt
@@ -171,11 +171,15 @@ class GetPostBySlugServiceTest :
                 val response = service.execute(query)
 
                 Then("previousPost와 nextPost를 모두 매핑한다") {
-                    response.previousPost?.postId shouldBe previous.entityId.value.toString()
+                    response.previousPost?.postId shouldBe
+                        previous.entityId.value
+                            .toString()
                     response.previousPost?.title shouldBe "이전 글"
                     response.previousPost?.slug shouldBe "older-post"
                     response.previousPost?.createdAt shouldBe previous.createdAt
-                    response.nextPost?.postId shouldBe next.entityId.value.toString()
+                    response.nextPost?.postId shouldBe
+                        next.entityId.value
+                            .toString()
                     response.nextPost?.title shouldBe "다음 글"
                     response.nextPost?.slug shouldBe "newer-post"
                     response.nextPost?.createdAt shouldBe next.createdAt
@@ -216,7 +220,9 @@ class GetPostBySlugServiceTest :
 
                 Then("previousPost는 null이고 nextPost만 매핑한다") {
                     response.previousPost shouldBe null
-                    response.nextPost?.postId shouldBe next.entityId.value.toString()
+                    response.nextPost?.postId shouldBe
+                        next.entityId.value
+                            .toString()
                     response.nextPost?.title shouldBe "최신 글"
                     response.nextPost?.slug shouldBe "newest-post"
                     response.nextPost?.createdAt shouldBe next.createdAt
@@ -304,13 +310,15 @@ class GetPostBySlugServiceTest :
     })
 
 private fun publishedSlugPost(memberId: MemberId): Post =
-    Post.create(
-        memberId = memberId,
-        title = Title("테스트 글"),
-        slug = Slug("test-post"),
-        body = Body("테스트 내용"),
-        type = ContentType.BLOG,
-    ).publish()
+    Post
+        .create(
+            memberId = memberId,
+            title = Title("테스트 글"),
+            slug = Slug("test-post"),
+            body = Body("테스트 내용"),
+            type = ContentType.BLOG,
+        )
+        .publish()
 
 private fun draftSlugPost(memberId: MemberId): Post =
     Post.create(


### PR DESCRIPTION
## Summary
- Add nullable previousPost/nextPost to post detail response
- Wire adjacent post lookup through repository, service, and controller
- Add repository/service/controller tests for adjacent navigation

## Verification
- QA/review PASS provided by requester
- Local Gradle/test/build not run per server policy